### PR TITLE
feat: prevent theme flash and add smooth theme transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,28 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Callora — Programmable API Access</title>
+    <script>
+      // Pre-paint theme resolution to prevent flash of incorrect theme
+      (function() {
+        try {
+          const savedTheme = localStorage.getItem('callora-theme');
+          let theme = 'dark'; // default
+          
+          if (savedTheme === 'light' || savedTheme === 'dark') {
+            theme = savedTheme;
+          } else if (savedTheme === 'system' || !savedTheme) {
+            // Check system preference
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            theme = prefersDark ? 'dark' : 'light';
+          }
+          
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {
+          // Fallback to dark if localStorage is not available (e.g., in private browsing)
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -16,7 +16,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return (saved as Theme) || 'dark';
   });
 
-  const [actualTheme, setActualTheme] = useState<'light' | 'dark'>('dark');
+  const [actualTheme, setActualTheme] = useState<'light' | 'dark'>(() => {
+    // Initialize from the pre-paint resolved value to prevent flash
+    const resolvedTheme = document.documentElement.getAttribute('data-theme');
+    return (resolvedTheme === 'light' || resolvedTheme === 'dark') ? resolvedTheme : 'dark';
+  });
 
   useEffect(() => {
     localStorage.setItem('callora-theme', theme);

--- a/src/index.css
+++ b/src/index.css
@@ -134,8 +134,6 @@ body,
 html {
   font-family: var(--font-family);
   background: var(--page-bg);
-  /* Smooth theme transition */
-  transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease;
 }
 
 body {
@@ -144,11 +142,20 @@ body {
   background: var(--page-bg);
   color: var(--text);
   overflow-x: hidden;
-  /* Ensure all components transition smoothly */
-  transition: background-color var(--transition-speed) ease, 
-              color var(--transition-speed) ease,
-              border-color var(--transition-speed) ease,
-              box-shadow var(--transition-speed) ease;
+}
+
+/* Smooth theme transition - only for users who prefer motion */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease;
+  }
+
+  body {
+    transition: background-color var(--transition-speed) ease,
+                color var(--transition-speed) ease,
+                border-color var(--transition-speed) ease,
+                box-shadow var(--transition-speed) ease;
+  }
 }
 
 button,


### PR DESCRIPTION
closes #113

Changes Made
1. index.html - Added pre-paint theme resolution script

Inline script runs before React loads
Reads from localStorage (callora-theme)
Resolves 'system' preference using matchMedia('(prefers-color-scheme: dark)')
Sets data-theme attribute on <html> element
Includes try-catch for private browsing scenarios
2. src/ThemeContext.tsx - Initialize from resolved value

actualTheme now initializes from the data-theme attribute set by the inline script
Prevents flash by using the pre-resolved theme instead of defaulting to 'dark'
3. src/index.css - Added reduced-motion-aware transitions

Wrapped color transitions in @media (prefers-reduced-motion: no-preference)
Users with reduced motion preferences will see instant theme changes
All other users get smooth 240ms transitions