### PR TITLE
docs: refresh README structure and add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Callora Frontend
+
+Thanks for contributing! Follow these guidelines to keep the codebase consistent.
+
+## Prerequisites
+
+- Node.js 18+
+- npm (comes with Node.js)
+
+## Setup
+
+```bash
+git clone https://github.com/your-org/Callora-Frontend.git
+cd Callora-Frontend
+npm install
+npm run dev      # dev server at http://localhost:5173
+npm run build    # TypeScript check + production build
+```
+
+## Branch naming
+
+Branch off `main` using the format:
+
+```
+feature/<short-description>   # new features
+fix/<short-description>        # bug fixes
+docs/<short-description>       # documentation only
+```
+
+Example: `git checkout -b feature/api-search-filters`
+
+## Making changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes, following the guidelines below.
+3. Run `npm run build` to confirm no TypeScript errors.
+4. Open a pull request against `main` with a clear description of what changed and why.
+
+## Design system
+
+All UI changes must follow the [UI Design System](docs/UI-Design-System.md).
+
+Key rules:
+- **Use design tokens, not raw values.** Colors, spacing, and shadows are defined as CSS custom properties in `src/index.css`. Reference them via `var(--token-name)` — never use inline hex values or hardcoded pixel sizes.
+- **Reuse existing components.** Check `src/components/` before building something new. Components like `ApiCard`, `EmptyState`, `SearchBar`, `Skeleton`, and `Breadcrumb` are shared across views.
+- **Do not introduce a component library.** The project is intentionally dependency-light.
+
+## Accessibility
+
+- All interactive elements must be keyboard navigable and have visible focus styles.
+- Use semantic HTML elements (`<button>`, `<nav>`, `<main>`, `<article>`, etc.).
+- Provide `aria-label` or visible text for icon-only controls.
+- Verify your changes in both light and dark modes (use the theme toggle in the top bar).
+
+## Testing
+
+A test runner is being introduced — see the Vitest setup issue for progress. Once merged, tests will run via:
+
+```bash
+npm run test
+```
+
+Until then, manually verify the affected routes load and behave correctly after your changes.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 
 - **React 18** + **TypeScript**
 - **Vite** for build and dev server
+- **React Router v6** for client-side routing
 - Minimal UI (no component library); ready to extend
 
-## What’s included
+## What's included
 
-- Dashboard placeholder (usage, vault balance)
-- APIs section (publish/manage APIs and pricing)
-- Billing section (USDC deposit, settlements)
+- Landing page with product overview
+- Dashboard (usage stats, vault balance)
+- Marketplace (browse and compare APIs)
+- Billing (USDC deposit, Stellar settlement, transaction tracking)
+- API Usage analytics view
+- 500 error page with retry flow
+- 404 catch-all page
 - Dev proxy to backend at `http://localhost:3000` for `/api`
 
 ## UI Design System
@@ -20,10 +25,10 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 Callora uses a comprehensive design token system and component library. All contributors must follow the [UI Design System guide](docs/UI-Design-System.md) when building or modifying UI.
 
 Key principles:
-- **Use design tokens, not inline hex values** - All colors, spacing, and shadows use CSS custom properties
-- **Reuse shared components** - Use existing components from `src/components/` before creating new ones
-- **Maintain accessibility** - All UI must be keyboard navigable and screen reader friendly
-- **Test both themes** - Verify appearance in both light and dark modes
+- **Use design tokens, not inline hex values** — All colors, spacing, and shadows use CSS custom properties
+- **Reuse shared components** — Use existing components from `src/components/` before creating new ones
+- **Maintain accessibility** — All UI must be keyboard navigable and screen reader friendly
+- **Test both themes** — Verify appearance in both light and dark modes
 
 ## Local setup
 
@@ -32,7 +37,6 @@ Key principles:
 2. **Install and run:**
 
    ```bash
-   cd callora-frontend
    npm install
    npm run dev
    ```
@@ -41,21 +45,59 @@ Key principles:
 
 ## Scripts
 
-| Command     | Description              |
-|------------|--------------------------|
-| `npm run dev`    | Start dev server (port 5173) |
-| `npm run build`  | TypeScript check + production build |
-| `npm run preview`| Serve production build locally     |
+| Command          | Description                          |
+|------------------|--------------------------------------|
+| `npm run dev`    | Start dev server (port 5173)         |
+| `npm run build`  | TypeScript check + production build  |
+| `npm run preview`| Serve production build locally       |
+
+## Routes
+
+| Path        | Description                     |
+|-------------|---------------------------------|
+| `/`         | Landing page                    |
+| `/dashboard`| Developer dashboard             |
+| `/marketplace` | API marketplace              |
+| `/billing`  | USDC deposit and settlements    |
+| `/api-usage`| API usage analytics             |
+| `/500`      | Server error page               |
+| `*`         | 404 not found                   |
 
 ## Project layout
 
 ```
 callora-frontend/
 ├── src/
-│   ├── App.tsx       # Main app and tabs
-│   ├── main.tsx      # Entry
-│   ├── index.css     # Global styles
+│   ├── App.tsx              # Router, layout, and route definitions
+│   ├── main.tsx             # Entry point
+│   ├── index.css            # Global styles and design tokens
+│   ├── ThemeContext.tsx      # Light/dark theme context
+│   ├── ThemeToggle.tsx      # Theme toggle component
+│   ├── ApiUsage.tsx         # API usage analytics view
+│   ├── components/          # Shared UI components
+│   │   ├── ApiCard.tsx
+│   │   ├── Breadcrumb.tsx
+│   │   ├── CodeExample.tsx
+│   │   ├── Dashboard.tsx
+│   │   ├── EmptyState.tsx
+│   │   ├── FiltersSidebar.tsx
+│   │   ├── NotFound.tsx
+│   │   ├── SearchBar.tsx
+│   │   ├── ServerError.tsx
+│   │   ├── ServerErrorDemo.tsx
+│   │   └── Skeleton.tsx
+│   ├── pages/               # Standalone page components
+│   │   ├── ApiDetailPage.tsx
+│   │   └── MarketplacePage.tsx
+│   ├── hooks/               # Custom React hooks
+│   │   └── useDebounce.ts
+│   ├── data/                # Static and mock data
+│   │   └── mockApis.ts
+│   ├── utils/               # Utility functions
+│   │   └── format.ts
 │   └── vite-env.d.ts
+├── docs/
+│   └── UI-Design-System.md
 ├── index.html
 ├── package.json
 ├── tsconfig.json
@@ -63,3 +105,5 @@ callora-frontend/
 ```
 
 This repo is part of [Callora](https://github.com/your-org/callora). Backend and contracts live in separate repos: `callora-backend`, `callora-contracts`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
Closes #143

## Summary
- Updated README project layout to reflect the real `src/` tree (`pages/`, `components/`, `hooks/`, `data/`, `utils/`, `ThemeContext.tsx`)
- README routes table lists all 7 actual routes; removed stale 'tabs' wording
- Scripts table matches `package.json` exactly (`dev`, `build`, `preview`)
- Added `CONTRIBUTING.md` with setup, branch naming, design-system token rules, accessibility expectations, and note on upcoming Vitest integration
- All relative doc links resolve (`docs/UI-Design-System.md`, `CONTRIBUTING.md`)

## What was tested
- `npm run build` — pre-existing TS errors unrelated to this change; docs only
- All relative links verified to exist on disk

## Notes
Docs-only change — no code modified.