### PR TITLE
feat: add theme generator playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - API Usage analytics view
 - 500 error page with retry flow
 - 404 catch-all page
+- Theme playground for previewing primary/accent/surface tokens live
 - Dev proxy to backend at `http://localhost:3000` for `/api`
 
 ## UI Design System
@@ -25,6 +26,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 Callora uses a comprehensive design token system and component library. All contributors must follow the [UI Design System guide](docs/UI-Design-System.md) when building or modifying UI.
 
 Key principles:
+
 - **Use design tokens, not inline hex values** — All colors, spacing, and shadows use CSS custom properties
 - **Reuse shared components** — Use existing components from `src/components/` before creating new ones
 - **Maintain accessibility** — All UI must be keyboard navigable and screen reader friendly
@@ -45,23 +47,24 @@ Key principles:
 
 ## Scripts
 
-| Command          | Description                          |
-|------------------|--------------------------------------|
-| `npm run dev`    | Start dev server (port 5173)         |
-| `npm run build`  | TypeScript check + production build  |
-| `npm run preview`| Serve production build locally       |
+| Command           | Description                         |
+| ----------------- | ----------------------------------- |
+| `npm run dev`     | Start dev server (port 5173)        |
+| `npm run build`   | TypeScript check + production build |
+| `npm run preview` | Serve production build locally      |
 
 ## Routes
 
-| Path        | Description                     |
-|-------------|---------------------------------|
-| `/`         | Landing page                    |
-| `/dashboard`| Developer dashboard             |
-| `/marketplace` | API marketplace              |
-| `/billing`  | USDC deposit and settlements    |
-| `/api-usage`| API usage analytics             |
-| `/500`      | Server error page               |
-| `*`         | 404 not found                   |
+| Path                | Description                               |
+| ------------------- | ----------------------------------------- |
+| `/`                 | Landing page                              |
+| `/dashboard`        | Developer dashboard                       |
+| `/marketplace`      | API marketplace                           |
+| `/billing`          | USDC deposit and settlements              |
+| `/api-usage`        | API usage analytics                       |
+| `/theme-playground` | Live theme token playground for designers |
+| `/500`              | Server error page                         |
+| `*`                 | 404 not found                             |
 
 ## Project layout
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,29 @@
-import { useEffect, useRef, useState } from 'react';
-import { Routes, Route, NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { ThemeToggle } from './ThemeToggle';
-import ApiUsage from './ApiUsage';
-import Dashboard from './components/Dashboard';
-import RouteProgressBar from './components/RouteProgressBar';
-import ServerError from './components/ServerError';
-import NotFound from './components/NotFound';
-import { startRouteLoading, stopRouteLoading } from './hooks/useRouteLoading';
-import { formatUsdc, formatUsdShortcut } from './utils/format';
+import { useEffect, useRef, useState } from "react";
+import {
+  Routes,
+  Route,
+  NavLink,
+  useNavigate,
+  useLocation,
+} from "react-router-dom";
+import { ThemeToggle } from "./ThemeToggle";
+import ApiUsage from "./ApiUsage";
+import Dashboard from "./components/Dashboard";
+import RouteProgressBar from "./components/RouteProgressBar";
+import ServerError from "./components/ServerError";
+import NotFound from "./components/NotFound";
+import ThemePlayground from "./pages/ThemePlayground";
+import { startRouteLoading, stopRouteLoading } from "./hooks/useRouteLoading";
+import { formatUsdc, formatUsdShortcut } from "./utils/format";
 import {
   EXPLORER_BASE_URL,
   MIN_DEPOSIT,
   NETWORK_FEE,
   PRESET_AMOUNTS,
-} from './config/constants';
+} from "./config/constants";
 
-type DepositStage = 'input' | 'approving' | 'pending' | 'confirmed' | 'failed';
-type DemoOutcome = 'confirmed' | 'failed';
+type DepositStage = "input" | "approving" | "pending" | "confirmed" | "failed";
+type DemoOutcome = "confirmed" | "failed";
 
 type Feature = {
   icon: string;
@@ -79,8 +86,7 @@ const consumerSteps: Step[] = [
 const developerSteps: Step[] = [
   {
     title: "Register as developer",
-    description:
-      "Set up your publisher profile and prepare your API listing.",
+    description: "Set up your publisher profile and prepare your API listing.",
   },
   {
     title: "Publish your API",
@@ -99,8 +105,6 @@ const developerSteps: Step[] = [
   },
 ];
 
-
-
 const APP_ROUTES = {
   landing: "/",
   dashboard: "/dashboard",
@@ -110,10 +114,9 @@ const APP_ROUTES = {
   billing: "/billing",
   documentation: "/documentation",
   status: "/status",
+  themePlayground: "/theme-playground",
   serverError: "/500",
 } as const;
-
-
 
 function createMockHash() {
   const seed = `${Date.now().toString(16)}${Math.random()
@@ -157,7 +160,10 @@ function LandingPage({
           </p>
 
           <div className="lp-cta-row">
-            <button className="lp-btn lp-btn-primary" onClick={onStartUsingApis}>
+            <button
+              className="lp-btn lp-btn-primary"
+              onClick={onStartUsingApis}
+            >
               Start Using APIs
             </button>
             <button className="lp-btn lp-btn-secondary" onClick={onPublishApi}>
@@ -273,23 +279,29 @@ function LandingPage({
 function App() {
   const location = useLocation();
   const routeTitleMap: Record<string, string> = {
-    [APP_ROUTES.marketplace]: 'Marketplace – Callora',
-    [APP_ROUTES.dashboard]: 'Dashboard – Callora',
-    [APP_ROUTES.billing]: 'Billing – Callora',
-    '/api-usage': 'API Usage – Callora',
-    [APP_ROUTES.landing]: 'Callora',
+    [APP_ROUTES.marketplace]: "Marketplace – Callora",
+    [APP_ROUTES.dashboard]: "Dashboard – Callora",
+    [APP_ROUTES.billing]: "Billing – Callora",
+    [APP_ROUTES.themePlayground]: "Theme Playground – Callora",
+    "/api-usage": "API Usage – Callora",
+    [APP_ROUTES.landing]: "Callora",
   };
   const routeDescriptionMap: Record<string, string> = {
-    [APP_ROUTES.marketplace]: 'Explore APIs on the Callora marketplace, discover and integrate APIs for your applications.',
-    [APP_ROUTES.dashboard]: 'Your Callora dashboard showing balances, recent activity and quick actions.',
-    [APP_ROUTES.billing]: 'Manage your USDC vault, deposit funds, and view transaction status.',
-    '/api-usage': 'Monitor API usage, request stats, and view call history.',
-    [APP_ROUTES.landing]: 'Callora - Programmable API Access, pay-per-call billing, and on-chain settlement.',
+    [APP_ROUTES.marketplace]:
+      "Explore APIs on the Callora marketplace, discover and integrate APIs for your applications.",
+    [APP_ROUTES.dashboard]:
+      "Your Callora dashboard showing balances, recent activity and quick actions.",
+    [APP_ROUTES.billing]:
+      "Manage your USDC vault, deposit funds, and view transaction status.",
+    [APP_ROUTES.themePlayground]:
+      "Preview and tune primary, accent, and surface colors with the Callora theme playground.",
+    "/api-usage": "Monitor API usage, request stats, and view call history.",
+    [APP_ROUTES.landing]:
+      "Callora - Programmable API Access, pay-per-call billing, and on-chain settlement.",
   };
-  const currentTitle = routeTitleMap[location.pathname] ?? 'Callora';
+  const currentTitle = routeTitleMap[location.pathname] ?? "Callora";
   const currentDescription = routeDescriptionMap[location.pathname];
   useDocumentTitle(currentTitle, currentDescription);
-
 
   const [isDepositOpen, setIsDepositOpen] = useState(false);
   const [vaultBalance, setVaultBalance] = useState(284.62);
@@ -443,7 +455,9 @@ function App() {
       window.setTimeout(() => {
         if (demoOutcome === "confirmed") {
           setDepositStage("confirmed");
-          setVaultBalance(Number((startingBalance + approvedAmount).toFixed(2)));
+          setVaultBalance(
+            Number((startingBalance + approvedAmount).toFixed(2)),
+          );
           setStatusMessage(
             `${formatUsdShortcut(
               approvedAmount,
@@ -497,6 +511,7 @@ function App() {
             <NavLink to={APP_ROUTES.dashboard}>Dashboard</NavLink>
             <NavLink to={APP_ROUTES.marketplace}>Marketplace</NavLink>
             <NavLink to={APP_ROUTES.billing}>Billing</NavLink>
+            <NavLink to={APP_ROUTES.themePlayground}>Theme Playground</NavLink>
           </nav>
           <ThemeToggle />
         </div>
@@ -510,8 +525,8 @@ function App() {
               <LandingPage
                 onStartUsingApis={() => navigate(APP_ROUTES.marketplace)}
                 onPublishApi={() => {
-                  window.history.pushState({}, '', APP_ROUTES.publish);
-                  window.dispatchEvent(new PopStateEvent('popstate'));
+                  window.history.pushState({}, "", APP_ROUTES.publish);
+                  window.dispatchEvent(new PopStateEvent("popstate"));
                 }}
               />
             }
@@ -520,7 +535,11 @@ function App() {
           <Route
             path={APP_ROUTES.dashboard}
             element={
-              <Dashboard vaultBalance={vaultBalance} walletBalance={walletBalance} openDeposit={openDeposit} />
+              <Dashboard
+                vaultBalance={vaultBalance}
+                walletBalance={walletBalance}
+                openDeposit={openDeposit}
+              />
             }
           />
           <Route
@@ -536,6 +555,11 @@ function App() {
                 </p>
               </section>
             }
+          />
+
+          <Route
+            path={APP_ROUTES.themePlayground}
+            element={<ThemePlayground />}
           />
 
           <Route
@@ -648,17 +672,14 @@ function App() {
                 <h1>System status updates in one place.</h1>
                 <p>
                   All core services are operational. If you are still seeing
-                  issues, please contact support and include what action you were
-                  trying to complete.
+                  issues, please contact support and include what action you
+                  were trying to complete.
                 </p>
               </section>
             }
           />
 
-          <Route
-            path="/api-usage"
-            element={<ApiUsage />}
-          />
+          <Route path="/api-usage" element={<ApiUsage />} />
 
           <Route
             path={APP_ROUTES.serverError}
@@ -672,7 +693,9 @@ function App() {
 
           <Route
             path="*"
-            element={<NotFound onGoHome={() => navigate(APP_ROUTES.dashboard)} />}
+            element={
+              <NotFound onGoHome={() => navigate(APP_ROUTES.dashboard)} />
+            }
           />
         </Routes>
       </main>
@@ -689,6 +712,7 @@ function App() {
           <NavLink to={APP_ROUTES.dashboard}>Dashboard</NavLink>
           <NavLink to={APP_ROUTES.marketplace}>Marketplace</NavLink>
           <NavLink to={APP_ROUTES.billing}>Billing</NavLink>
+          <NavLink to={APP_ROUTES.themePlayground}>Theme Playground</NavLink>
           <NavLink to={APP_ROUTES.status}>Status</NavLink>
           <NavLink to={APP_ROUTES.documentation}>Documentation</NavLink>
         </nav>
@@ -759,183 +783,185 @@ function App() {
 
               <div className="modal-grid">
                 <div className="form-panel">
-                <div className="balance-row">
-                  <article className="balance-tile">
-                    <span>Vault balance</span>
-                    <strong>{formatUsdc(vaultBalance)} USDC</strong>
-                  </article>
-                  <article className="balance-tile">
-                    <span>Wallet available</span>
-                    <strong>{formatUsdc(walletBalance)} USDC</strong>
-                  </article>
-                </div>
+                  <div className="balance-row">
+                    <article className="balance-tile">
+                      <span>Vault balance</span>
+                      <strong>{formatUsdc(vaultBalance)} USDC</strong>
+                    </article>
+                    <article className="balance-tile">
+                      <span>Wallet available</span>
+                      <strong>{formatUsdc(walletBalance)} USDC</strong>
+                    </article>
+                  </div>
 
-                <label className="field-label" htmlFor="deposit-amount">
-                  Amount
-                </label>
+                  <label className="field-label" htmlFor="deposit-amount">
+                    Amount
+                  </label>
 
-                <div
-                  className={`input-shell ${
-                    validationMessage && depositStage === "input"
-                      ? "invalid"
-                      : ""
-                  }`}
-                >
-                  <input
-                    id="deposit-amount"
-                    type="text"
-                    inputMode="decimal"
-                    value={amountInput}
-                    onChange={(event) => handleAmountChange(event.target.value)}
-                    disabled={isBusy}
-                    placeholder="0.00"
-                    aria-describedby="deposit-help"
-                  />
-                  <span>USDC</span>
-                  <button
-                    type="button"
-                    className="ghost-button"
-                    onClick={handleMax}
-                    disabled={isBusy}
+                  <div
+                    className={`input-shell ${
+                      validationMessage && depositStage === "input"
+                        ? "invalid"
+                        : ""
+                    }`}
                   >
-                    Max
-                  </button>
-                </div>
-
-                <p id="deposit-help" className="helper-text">
-                  Minimum deposit is {formatUsdShortcut(MIN_DEPOSIT)}. Custom
-                  deposits settle into your vault after wallet approval.
-                </p>
-
-                {validationMessage && depositStage === "input" && (
-                  <p className="error-text">{validationMessage}</p>
-                )}
-
-                <div className="preset-row">
-                  {PRESET_AMOUNTS.map((preset) => (
+                    <input
+                      id="deposit-amount"
+                      type="text"
+                      inputMode="decimal"
+                      value={amountInput}
+                      onChange={(event) =>
+                        handleAmountChange(event.target.value)
+                      }
+                      disabled={isBusy}
+                      placeholder="0.00"
+                      aria-describedby="deposit-help"
+                    />
+                    <span>USDC</span>
                     <button
-                      key={preset}
-                      className={selectedPreset === preset ? "active" : ""}
-                      onClick={() => handlePresetClick(preset)}
+                      type="button"
+                      className="ghost-button"
+                      onClick={handleMax}
                       disabled={isBusy}
                     >
-                      ${preset}
+                      Max
                     </button>
-                  ))}
-                  <button
-                    className={selectedPreset === "custom" ? "active" : ""}
-                    onClick={() => setSelectedPreset("custom")}
-                    disabled={isBusy}
-                  >
-                    Custom
-                  </button>
-                </div>
+                  </div>
 
-                <div className="security-note">
-                  <strong>What you are approving</strong>
-                  <p>
-                    Your wallet signs a USDC deposit into the Callora vault. The
-                    preview shows the exact vault credit, network fee, and
-                    post-deposit balance before submission.
+                  <p id="deposit-help" className="helper-text">
+                    Minimum deposit is {formatUsdShortcut(MIN_DEPOSIT)}. Custom
+                    deposits settle into your vault after wallet approval.
                   </p>
+
+                  {validationMessage && depositStage === "input" && (
+                    <p className="error-text">{validationMessage}</p>
+                  )}
+
+                  <div className="preset-row">
+                    {PRESET_AMOUNTS.map((preset) => (
+                      <button
+                        key={preset}
+                        className={selectedPreset === preset ? "active" : ""}
+                        onClick={() => handlePresetClick(preset)}
+                        disabled={isBusy}
+                      >
+                        ${preset}
+                      </button>
+                    ))}
+                    <button
+                      className={selectedPreset === "custom" ? "active" : ""}
+                      onClick={() => setSelectedPreset("custom")}
+                      disabled={isBusy}
+                    >
+                      Custom
+                    </button>
+                  </div>
+
+                  <div className="security-note">
+                    <strong>What you are approving</strong>
+                    <p>
+                      Your wallet signs a USDC deposit into the Callora vault.
+                      The preview shows the exact vault credit, network fee, and
+                      post-deposit balance before submission.
+                    </p>
+                  </div>
                 </div>
-              </div>
 
-              <div className="preview-panel">
-                <article className="preview-card">
-                  <div className="preview-header">
-                    <div>
-                      <span className="eyebrow">Transaction preview</span>
-                      <h3>Review before wallet approval</h3>
-                    </div>
-                    <span className="preview-highlight">Secure preview</span>
-                  </div>
-
-                  <div className="preview-row">
-                    <span>Deposit amount</span>
-                    <strong>
-                      {hasAmount || submittedAmount
-                        ? `${balanceDelta} USDC`
-                        : "--"}
-                    </strong>
-                  </div>
-
-                  <div className="preview-row">
-                    <span>Current balance</span>
-                    <strong>{formatUsdc(previewCurrentBalance)} USDC</strong>
-                  </div>
-
-                  <div className="preview-row emphasis">
-                    <span>New balance</span>
-                    <strong>
-                      {hasAmount || submittedAmount
-                        ? `${formatUsdc(projectedBalance)} USDC`
-                        : "--"}
-                    </strong>
-                  </div>
-
-                  <div className="preview-row">
-                    <span>Network fee</span>
-                    <strong>{NETWORK_FEE}</strong>
-                  </div>
-
-                  <div className="preview-row total">
-                    <span>Total cost</span>
-                    <strong>
-                      {hasAmount || submittedAmount
-                        ? `${balanceDelta} USDC + ${NETWORK_FEE}`
-                        : `0.00 USDC + ${NETWORK_FEE}`}
-                    </strong>
-                  </div>
-                </article>
-
-                {(depositStage === "pending" ||
-                  depositStage === "confirmed" ||
-                  depositStage === "failed") &&
-                  txHash && (
-                    <article className="hash-card">
+                <div className="preview-panel">
+                  <article className="preview-card">
+                    <div className="preview-header">
                       <div>
-                        <span className="eyebrow">Transaction hash</span>
-                        <strong>{pendingHashLabel}</strong>
+                        <span className="eyebrow">Transaction preview</span>
+                        <h3>Review before wallet approval</h3>
                       </div>
+                      <span className="preview-highlight">Secure preview</span>
+                    </div>
 
-                      <div className="hash-actions">
-                        <a
-                          href={buildExplorerLink(txHash)}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          View on Stellar Explorer
-                        </a>
-                        <button onClick={handleCopyHash}>
-                          {copied ? "Copied" : "Copy hash"}
-                        </button>
-                      </div>
+                    <div className="preview-row">
+                      <span>Deposit amount</span>
+                      <strong>
+                        {hasAmount || submittedAmount
+                          ? `${balanceDelta} USDC`
+                          : "--"}
+                      </strong>
+                    </div>
+
+                    <div className="preview-row">
+                      <span>Current balance</span>
+                      <strong>{formatUsdc(previewCurrentBalance)} USDC</strong>
+                    </div>
+
+                    <div className="preview-row emphasis">
+                      <span>New balance</span>
+                      <strong>
+                        {hasAmount || submittedAmount
+                          ? `${formatUsdc(projectedBalance)} USDC`
+                          : "--"}
+                      </strong>
+                    </div>
+
+                    <div className="preview-row">
+                      <span>Network fee</span>
+                      <strong>{NETWORK_FEE}</strong>
+                    </div>
+
+                    <div className="preview-row total">
+                      <span>Total cost</span>
+                      <strong>
+                        {hasAmount || submittedAmount
+                          ? `${balanceDelta} USDC + ${NETWORK_FEE}`
+                          : `0.00 USDC + ${NETWORK_FEE}`}
+                      </strong>
+                    </div>
+                  </article>
+
+                  {(depositStage === "pending" ||
+                    depositStage === "confirmed" ||
+                    depositStage === "failed") &&
+                    txHash && (
+                      <article className="hash-card">
+                        <div>
+                          <span className="eyebrow">Transaction hash</span>
+                          <strong>{pendingHashLabel}</strong>
+                        </div>
+
+                        <div className="hash-actions">
+                          <a
+                            href={buildExplorerLink(txHash)}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            View on Stellar Explorer
+                          </a>
+                          <button onClick={handleCopyHash}>
+                            {copied ? "Copied" : "Copy hash"}
+                          </button>
+                        </div>
+                      </article>
+                    )}
+
+                  {depositStage === "failed" && (
+                    <article className="error-card">
+                      <strong>Approval not confirmed</strong>
+                      <p>
+                        No funds were added to the vault. Retry after confirming
+                        the wallet prompt or checking your network status.
+                      </p>
                     </article>
                   )}
 
-                {depositStage === "failed" && (
-                  <article className="error-card">
-                    <strong>Approval not confirmed</strong>
-                    <p>
-                      No funds were added to the vault. Retry after confirming
-                      the wallet prompt or checking your network status.
-                    </p>
-                  </article>
-                )}
-
-                {depositStage === "confirmed" && (
-                  <article className="success-card">
-                    <strong>Deposit successful</strong>
-                    <p>
-                      Your updated vault balance is {formatUsdc(vaultBalance)}{" "}
-                      USDC and ready for usage.
-                    </p>
-                  </article>
-                )}
+                  {depositStage === "confirmed" && (
+                    <article className="success-card">
+                      <strong>Deposit successful</strong>
+                      <p>
+                        Your updated vault balance is {formatUsdc(vaultBalance)}{" "}
+                        USDC and ready for usage.
+                      </p>
+                    </article>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
 
             <div className="modal-actions">
               {depositStage === "failed" ? (

--- a/src/components/TokenEditor.tsx
+++ b/src/components/TokenEditor.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+interface TokenEditorProps {
+  label: string;
+  tokenKey: string;
+  value: string;
+  onChange: (nextValue: string) => void;
+}
+
+function normalizeHexColor(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const withHash = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+  return /^#[0-9a-fA-F]{3,8}$/.test(withHash) ? withHash : trimmed;
+}
+
+export default function TokenEditor({
+  label,
+  tokenKey,
+  value,
+  onChange,
+}: TokenEditorProps) {
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = normalizeHexColor(event.target.value);
+    onChange(nextValue || event.target.value);
+  };
+
+  return (
+    <div className="token-editor">
+      <div className="token-editor__header">
+        <label className="token-editor__label" htmlFor={tokenKey}>
+          {label}
+        </label>
+        <input
+          id={tokenKey}
+          aria-label={`${label} token`}
+          className="token-editor__swatch"
+          type="color"
+          value={value.startsWith("#") ? value : "#4e85ff"}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </div>
+      <input
+        className="token-editor__input"
+        type="text"
+        value={value}
+        onChange={handleTextChange}
+        aria-describedby={`${tokenKey}-hint`}
+      />
+      <p id={`${tokenKey}-hint`} className="token-editor__hint">
+        Enter a hex color such as #4E85FF.
+      </p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -245,6 +245,186 @@ input {
   font: inherit;
 }
 
+.theme-playground {
+  display: grid;
+  gap: 24px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--theme-surface) 70%, transparent), var(--page-bg));
+  box-shadow: var(--shadow);
+}
+
+.theme-playground__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.theme-playground__copy {
+  max-width: 640px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.theme-playground__actions,
+.theme-playground__actions-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.theme-playground__layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 24px;
+}
+
+.theme-playground__editor,
+.theme-playground__preview {
+  display: grid;
+  gap: 16px;
+}
+
+.theme-playground__editor {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--theme-surface) 80%, var(--page-bg));
+}
+
+.theme-playground__card {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--theme-surface) 80%, var(--page-bg));
+  color: var(--text);
+}
+
+.theme-playground__card--compact {
+  background: color-mix(in srgb, var(--theme-surface) 70%, var(--page-bg));
+}
+
+.theme-playground__card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.theme-playground__pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: var(--theme-primary);
+  color: white;
+}
+
+.theme-playground__pill--muted {
+  background: var(--theme-accent);
+  color: var(--page-bg);
+}
+
+.token-editor {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--theme-surface) 65%, transparent);
+  border: 1px solid var(--line);
+}
+
+.token-editor__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.token-editor__label {
+  font-weight: 600;
+}
+
+.token-editor__swatch {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.token-editor__input {
+  width: 100%;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.token-editor__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.theme-playground__css-preview {
+  margin: 0;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  color: var(--text);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.9rem;
+  overflow-x: auto;
+}
+
+.theme-playground .primary-button {
+  background: var(--theme-primary);
+  color: #ffffff;
+}
+
+.theme-playground .secondary-button {
+  border: 1px solid var(--theme-accent);
+  color: var(--theme-accent);
+  background: transparent;
+}
+
+.theme-playground__link {
+  color: var(--theme-accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .theme-playground__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .theme-playground {
+    padding: 18px;
+  }
+
+  .theme-playground__actions,
+  .theme-playground__actions-inline {
+    width: 100%;
+  }
+
+  .theme-playground__actions > *,
+  .theme-playground__actions-inline > * {
+    flex: 1;
+  }
+}
+
 button {
   border: 0;
 }

--- a/src/pages/ThemePlayground.test.tsx
+++ b/src/pages/ThemePlayground.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "../ThemeContext";
+import ThemePlayground from "./ThemePlayground";
+
+describe("ThemePlayground", () => {
+  it("updates preview tokens live and resets to defaults", () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <ThemePlayground />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /theme playground/i }),
+    ).toBeInTheDocument();
+
+    const primaryInput = screen.getByLabelText(/primary token/i);
+    fireEvent.input(primaryInput, { target: { value: "#ff6600" } });
+
+    const previewButton = screen.getByRole("button", {
+      name: /preview action/i,
+    });
+    expect(previewButton).toHaveStyle({ backgroundColor: "#ff6600" });
+
+    fireEvent.click(screen.getByRole("button", { name: /reset to defaults/i }));
+
+    expect(previewButton).toHaveStyle({ backgroundColor: "#4e85ff" });
+  });
+});

--- a/src/pages/ThemePlayground.tsx
+++ b/src/pages/ThemePlayground.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState, type CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import TokenEditor from "../components/TokenEditor";
+
+const DEFAULT_TOKENS = {
+  primary: "#4e85ff",
+  accent: "#1ed6a4",
+  surface: "#0f172a",
+};
+
+type TokenKey = keyof typeof DEFAULT_TOKENS;
+
+export default function ThemePlayground() {
+  const [tokens, setTokens] = useState(DEFAULT_TOKENS);
+
+  const cssPreview = useMemo(
+    () =>
+      [
+        ":root {",
+        `  --theme-primary: ${tokens.primary};`,
+        `  --theme-accent: ${tokens.accent};`,
+        `  --theme-surface: ${tokens.surface};`,
+        "}",
+      ].join("\n"),
+    [tokens],
+  );
+
+  const previewStyle = useMemo(
+    () =>
+      ({
+        "--theme-primary": tokens.primary,
+        "--theme-accent": tokens.accent,
+        "--theme-surface": tokens.surface,
+      }) as CSSProperties,
+    [tokens],
+  );
+
+  const handleTokenChange = (key: TokenKey, value: string) => {
+    setTokens((current) => ({ ...current, [key]: value }));
+  };
+
+  const resetTokens = () => {
+    setTokens(DEFAULT_TOKENS);
+  };
+
+  const exportCss = async () => {
+    const css = cssPreview;
+
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(css);
+    }
+  };
+
+  return (
+    <section className="theme-playground surface" style={previewStyle}>
+      <div className="theme-playground__header">
+        <div>
+          <p className="eyebrow">Theme playground</p>
+          <h1>Theme playground</h1>
+          <p className="theme-playground__copy">
+            Adjust the core color tokens and preview how the UI responds in real
+            time.
+          </p>
+        </div>
+        <div className="theme-playground__actions">
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => void exportCss()}
+          >
+            Export CSS
+          </button>
+          <button
+            className="primary-button"
+            type="button"
+            onClick={resetTokens}
+          >
+            Reset to defaults
+          </button>
+        </div>
+      </div>
+
+      <div className="theme-playground__layout">
+        <div
+          className="theme-playground__editor"
+          aria-label="Theme token editor"
+        >
+          <TokenEditor
+            label="Primary token"
+            tokenKey="primary"
+            value={tokens.primary}
+            onChange={(value) => handleTokenChange("primary", value)}
+          />
+          <TokenEditor
+            label="Accent token"
+            tokenKey="accent"
+            value={tokens.accent}
+            onChange={(value) => handleTokenChange("accent", value)}
+          />
+          <TokenEditor
+            label="Surface token"
+            tokenKey="surface"
+            value={tokens.surface}
+            onChange={(value) => handleTokenChange("surface", value)}
+          />
+        </div>
+
+        <div className="theme-playground__preview" aria-label="Theme preview">
+          <div className="theme-playground__card">
+            <div className="theme-playground__card-header">
+              <span className="theme-playground__pill">Preview</span>
+              <span className="theme-playground__pill theme-playground__pill--muted">
+                Live
+              </span>
+            </div>
+            <h2>GrantFox campaign concept</h2>
+            <p>
+              Use this sandbox to tune a new visual direction while preserving
+              accessible contrast.
+            </p>
+            <div className="theme-playground__actions-inline">
+              <button
+                className="primary-button"
+                type="button"
+                aria-label="Preview action"
+                style={{
+                  backgroundColor: tokens.primary,
+                  borderColor: tokens.primary,
+                }}
+              >
+                Preview action
+              </button>
+              <button
+                className="secondary-button"
+                type="button"
+                style={{ borderColor: tokens.accent, color: tokens.accent }}
+              >
+                Secondary action
+              </button>
+            </div>
+          </div>
+
+          <div className="theme-playground__card theme-playground__card--compact">
+            <h3>Suggested usage</h3>
+            <ul>
+              <li>Primary color for core buttons</li>
+              <li>Accent color for highlights and status</li>
+              <li>Surface color for panels and cards</li>
+            </ul>
+          </div>
+
+          <pre className="theme-playground__css-preview">{cssPreview}</pre>
+
+          <Link className="theme-playground__link" to="/dashboard">
+            Go back to dashboard
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,12 @@
 // vitest.config.ts
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: "jsdom",
     // Optional: include files with .test. or .spec.
-    include: ['src/**/*.test.{ts,tsx}'],
-    // Setup files can be added if needed.
-    // setupFiles: './src/setupTests.ts',
+    include: ["src/**/*.test.{ts,tsx}"],
     // Enable CSS handling if components import CSS.
     css: true,
   },


### PR DESCRIPTION
Closes #191 

## Summary
This PR adds a new Theme Playground route that lets designers preview and tune core theme tokens in real time.

## What changed
- Added a new /theme-playground route
- Built a live token editor for:
  - primary
  - accent
  - surface
- Added side-by-side preview UI that updates immediately as tokens change
- Added export support to copy generated CSS variables
- Added a reset action to restore the default theme values
- Added basic automated coverage for live updates and reset behavior
- Updated documentation to include the new route and feature

## Why
This improves the design workflow by giving contributors a fast way to explore token changes without needing to edit styles manually or reason about the full app surface.

## Notes
- The playground is responsive and uses the existing app theme structure
- The implementation is designed to be easy to review and extend

## Verification
- Added a focused test for live token updates and reset behavior
- Verified the app compiles cleanly after the change
