### PR TITLE
feat: density toggle on MarketplacePage grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 
 - Landing page with product overview
 - Dashboard (usage stats, vault balance)
-- Marketplace (browse and compare APIs)
+- Marketplace (browse and compare APIs, with a density toggle for comfortable or compact card layouts)
 - Billing (USDC deposit, Stellar settlement, transaction tracking)
 - API Usage analytics view
 - 500 error page with retry flow
@@ -42,6 +42,10 @@ Key principles:
    ```
 
 3. Open [http://localhost:5173](http://localhost:5173).
+
+## Marketplace density toggle
+
+The marketplace results view now includes a segmented density control in the search row. Choose Comfortable for the existing card layout or Compact to reduce card padding and hide long descriptions while keeping tags and stats visible. The selection is stored in local storage under the `callora.density` key so it persists across reloads.
 
 ## Scripts
 

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -102,14 +102,17 @@ function renderStatValue(value: string | undefined) {
 
 export default function ApiCard({
   api,
+  density = "comfortable",
   onViewDetails,
 }: {
   api: APIItem;
+  density?: "comfortable" | "compact";
   onViewDetails?: (api: APIItem) => void;
 }) {
   const pricePerCall = api.pricePerCall ?? api.pricePerRequest;
   const avgLatencyMs = api.avgLatencyMs;
   const uptimePercent = api.uptimePercent;
+  const isCompact = density === "compact";
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -120,18 +123,18 @@ export default function ApiCard({
 
   return (
     <article
-      className="preview-card api-marketplace-card"
+      className={`preview-card api-marketplace-card${isCompact ? " api-card--compact" : ""}`}
       role="button"
       tabIndex={0}
       aria-label={`View details for ${api.name}`}
       onClick={() => onViewDetails?.(api)}
       onKeyDown={handleKeyDown}
       style={{
-        padding: 12,
+        padding: isCompact ? 10 : 12,
         display: "flex",
         flexDirection: "column",
-        minHeight: 220,
-        gap: 8,
+        minHeight: isCompact ? 188 : 220,
+        gap: isCompact ? 6 : 8,
       }}
     >
       <div
@@ -168,18 +171,21 @@ export default function ApiCard({
             </div>
           </div>
 
-          <div
-            style={{
-              color: "var(--muted)",
-              marginTop: 6,
-              overflow: "hidden",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-            }}
-          >
-            {api.description}
-          </div>
+          {!isCompact && (
+            <div
+              className="api-marketplace-card-description"
+              style={{
+                color: "var(--muted)",
+                marginTop: 6,
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              {api.description}
+            </div>
+          )}
         </div>
 
         <div

--- a/src/index.css
+++ b/src/index.css
@@ -1277,9 +1277,44 @@ code,
   line-height: 1.05;
 }
 
+.marketplace-search-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
 .marketplace-search {
   flex: 1;
   min-width: 0;
+}
+
+.marketplace-density-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  min-height: 44px;
+}
+
+.density-toggle-button {
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
+}
+
+.density-toggle-button[aria-pressed="true"] {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(78, 133, 255, 0.22);
 }
 
 .marketplace-layout {
@@ -1344,8 +1379,47 @@ code,
   min-width: 0;
   overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 160ms ease, transform 160ms ease, border-color 160ms ease;
+  transition: box-shadow 160ms ease, transform 160ms ease, border-color 160ms ease, padding 180ms ease, gap 180ms ease, min-height 180ms ease;
   border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.api-card--compact {
+  padding: 10px;
+  gap: 6px;
+  min-height: 188px;
+}
+
+.api-card--compact .api-marketplace-card-description {
+  max-height: 0;
+  margin-top: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 180ms ease, opacity 180ms ease, margin-top 180ms ease;
+}
+
+.api-card--compact .api-marketplace-card-title-row {
+  gap: 4px 8px;
+}
+
+.api-card--compact .api-marketplace-card-tags {
+  gap: 6px;
+}
+
+.api-card--compact .api-marketplace-card-footer {
+  gap: 8px;
+}
+
+.api-card--compact .api-card__stats {
+  gap: 8px;
+  padding-top: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .api-marketplace-card,
+  .api-card--compact .api-marketplace-card-description,
+  .density-toggle-button {
+    transition: none;
+  }
 }
 
 .api-marketplace-card:hover {

--- a/src/pages/MarketplacePage.test.tsx
+++ b/src/pages/MarketplacePage.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import MarketplacePage from "./MarketplacePage";
+import { DENSITY_STORAGE_KEY } from "../utils/density";
+
+describe("MarketplacePage density toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("persists compact selection and exposes toggle state", async () => {
+    render(<MarketplacePage />);
+
+    const compactButton = screen.getByRole("button", { name: /compact/i });
+    fireEvent.click(compactButton);
+
+    await waitFor(() => {
+      expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe("compact");
+    });
+
+    expect(compactButton.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -7,10 +7,18 @@ import EmptyState, { type EmptyStateProps } from "../components/EmptyState";
 import MOCK_APIS, { type APIItem } from "../data/mockApis";
 import { useDebounce } from "../hooks/useDebounce";
 import { LOADING_DELAY_MS } from "../config/constants";
+import {
+  readDensityPreference,
+  persistDensityPreference,
+  type DensityPreference,
+} from "../utils/density";
 
 export default function MarketplacePage(): JSX.Element {
   useDocumentTitle('Marketplace – Callora', 'Explore APIs on the Callora marketplace, discover and integrate APIs for your applications.');
   const [search, setSearch] = useState("");
+  const [density, setDensity] = useState<DensityPreference>(() =>
+    readDensityPreference(),
+  );
   // Debounce search input to prevent excessive re-renders on large lists
   const debouncedSearch = useDebounce(search, 300);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
@@ -34,6 +42,10 @@ export default function MarketplacePage(): JSX.Element {
     }, LOADING_DELAY_MS);
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    persistDensityPreference(density);
+  }, [density]);
 
   const toggleCategory = (c: string) => {
     const copy = new Set(selectedCategories);
@@ -143,12 +155,30 @@ export default function MarketplacePage(): JSX.Element {
   return (
     <div className="marketplace-page">
       {/* Top row: title + search only */}
-      <div
-        className="marketplace-header"
-      >
+      <div className="marketplace-header">
         <h1>API Marketplace</h1>
-        <div className="marketplace-search">
-          <SearchBar value={search} onChange={setSearch} />
+        <div className="marketplace-search-row">
+          <div className="marketplace-search">
+            <SearchBar value={search} onChange={setSearch} />
+          </div>
+          <div className="marketplace-density-toggle" role="group" aria-label="Results density">
+            <button
+              type="button"
+              className="density-toggle-button"
+              aria-pressed={density === "comfortable"}
+              onClick={() => setDensity("comfortable")}
+            >
+              Comfortable
+            </button>
+            <button
+              type="button"
+              className="density-toggle-button"
+              aria-pressed={density === "compact"}
+              onClick={() => setDensity("compact")}
+            >
+              Compact
+            </button>
+          </div>
         </div>
       </div>
 
@@ -222,7 +252,12 @@ export default function MarketplacePage(): JSX.Element {
                 ))
               ) : (
                 displayedItems.map((a) => (
-                  <ApiCard key={a.id} api={a} onViewDetails={handleViewDetails} />
+                  <ApiCard
+                    key={a.id}
+                    api={a}
+                    density={density}
+                    onViewDetails={handleViewDetails}
+                  />
                 ))
               )}
             </div>

--- a/src/utils/density.test.ts
+++ b/src/utils/density.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DENSITY_STORAGE_KEY,
+  readDensityPreference,
+  persistDensityPreference,
+} from "./density";
+
+describe("density preferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to comfortable and persists compact selections", () => {
+    expect(readDensityPreference()).toBe("comfortable");
+
+    persistDensityPreference("compact");
+
+    expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe("compact");
+    expect(readDensityPreference()).toBe("compact");
+  });
+
+  it("falls back to comfortable for invalid stored values", () => {
+    localStorage.setItem(DENSITY_STORAGE_KEY, "invalid");
+
+    expect(readDensityPreference()).toBe("comfortable");
+  });
+});

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -1,0 +1,27 @@
+export type DensityPreference = "comfortable" | "compact";
+
+export const DENSITY_STORAGE_KEY = "callora.density";
+
+const DEFAULT_DENSITY: DensityPreference = "comfortable";
+const VALID_DENSITIES: DensityPreference[] = ["comfortable", "compact"];
+
+export function readDensityPreference(): DensityPreference {
+  if (typeof window === "undefined") {
+    return DEFAULT_DENSITY;
+  }
+
+  const storedValue = window.localStorage.getItem(DENSITY_STORAGE_KEY);
+  if (storedValue && VALID_DENSITIES.includes(storedValue as DensityPreference)) {
+    return storedValue as DensityPreference;
+  }
+
+  return DEFAULT_DENSITY;
+}
+
+export function persistDensityPreference(density: DensityPreference): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(DENSITY_STORAGE_KEY, density);
+}


### PR DESCRIPTION
Added a two-button segmented density control beside the marketplace search bar
Wired the selection into the results grid so cards render in either:
Comfortable: existing fuller card layout
Compact: reduced padding, smaller spacing, and hidden long descriptions while preserving tags and stats
Persisted the selected density in local storage under the key callora.density
Added focused tests for the density preference helper and marketplace toggle behavior
Documented the new marketplace density behavior in the README
Closes #154 