### PR TITLE
feat: mobile bottom-sheet variant of FiltersSidebar

### DIFF
--- a/src/components/FiltersBottomSheet.test.tsx
+++ b/src/components/FiltersBottomSheet.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRef } from "react";
+import FiltersBottomSheet from "./FiltersBottomSheet";
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  resultCount: 42,
+  selectedCategories: new Set<string>(),
+  toggleCategory: vi.fn(),
+  minPrice: null,
+  maxPrice: null,
+  setMinPrice: vi.fn(),
+  setMaxPrice: vi.fn(),
+  popularity: "any",
+  setPopularity: vi.fn(),
+  clearFilters: vi.fn(),
+  triggerRef: createRef<HTMLButtonElement>(),
+};
+
+describe("FiltersBottomSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    // Reset body overflow in case a test left it set
+    document.body.style.overflow = "";
+  });
+
+  it("renders nothing when closed", () => {
+    render(<FiltersBottomSheet {...baseProps} open={false} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByTestId("bottom-sheet-backdrop")).toBeNull();
+  });
+
+  it("renders the dialog and backdrop when open", () => {
+    render(<FiltersBottomSheet {...baseProps} />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByTestId("bottom-sheet-backdrop")).toBeTruthy();
+  });
+
+  it("shows 'Show 42 results' footer button", () => {
+    render(<FiltersBottomSheet {...baseProps} />);
+    expect(screen.getByText(/Show 42 results/i)).toBeTruthy();
+  });
+
+  it("shows singular 'result' when resultCount is 1", () => {
+    render(<FiltersBottomSheet {...baseProps} resultCount={1} />);
+    expect(screen.getByText(/Show 1 result$/i)).toBeTruthy();
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<FiltersBottomSheet {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId("bottom-sheet-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when ESC is pressed", () => {
+    const onClose = vi.fn();
+    render(<FiltersBottomSheet {...baseProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<FiltersBottomSheet {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close filters/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the 'Show results' footer button is clicked", () => {
+    const onClose = vi.fn();
+    render(<FiltersBottomSheet {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByText(/Show 42 results/i));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets body overflow hidden when open and restores it on unmount", () => {
+    const { unmount } = render(<FiltersBottomSheet {...baseProps} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("starts with the half snap class", () => {
+    render(<FiltersBottomSheet {...baseProps} />);
+    const sheet = screen.getByTestId("bottom-sheet");
+    expect(sheet.classList.contains("bottom-sheet--half")).toBe(true);
+  });
+
+  it("has aria-modal and role=dialog attributes", () => {
+    render(<FiltersBottomSheet {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-label")).toBe("Filters");
+  });
+
+  it("restores focus to triggerRef when sheet closes", () => {
+    const btn = document.createElement("button");
+    document.body.appendChild(btn);
+    const triggerRef = { current: btn } as React.RefObject<HTMLButtonElement>;
+    const focusSpy = vi.spyOn(btn, "focus");
+
+    const { rerender } = render(
+      <FiltersBottomSheet {...baseProps} triggerRef={triggerRef} open={true} />,
+    );
+    rerender(
+      <FiltersBottomSheet {...baseProps} triggerRef={triggerRef} open={false} />,
+    );
+    expect(focusSpy).toHaveBeenCalled();
+    document.body.removeChild(btn);
+  });
+
+  it("does not render ESC listener when closed", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <FiltersBottomSheet {...baseProps} onClose={onClose} open={true} />,
+    );
+    rerender(
+      <FiltersBottomSheet {...baseProps} onClose={onClose} open={false} />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    // The ESC should not call onClose after close (listener removed)
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders FiltersSidebar filter controls inside the body", () => {
+    render(<FiltersBottomSheet {...baseProps} />);
+    // FiltersSidebar renders a 'Categories' fieldset legend
+    expect(screen.getByText(/Categories/i)).toBeTruthy();
+  });
+});

--- a/src/components/FiltersBottomSheet.tsx
+++ b/src/components/FiltersBottomSheet.tsx
@@ -1,0 +1,249 @@
+/**
+ * FiltersBottomSheet — mobile-only bottom-sheet wrapper for FiltersSidebar.
+ *
+ * Snap-point API
+ * ──────────────
+ * The sheet supports two snap points, controlled by the `snap` state:
+ *   "half" → height: 50vh   (initial position on open)
+ *   "full" → height: 92vh   (expanded position)
+ *
+ * Dragging the handle bar determines which snap is applied:
+ *   • drag down > SNAP_THRESHOLD px from "full"  → snap to "half"
+ *   • drag down > SNAP_THRESHOLD px from "half"  → dismiss (onClose)
+ *   • drag up   > SNAP_THRESHOLD px              → snap to "full"
+ *
+ * Spring animations are gated behind `prefers-reduced-motion: no-preference`
+ * so users who have requested reduced motion get instant transitions.
+ */
+
+import { useEffect, useRef, useCallback, useState } from "react";
+import FiltersSidebar from "./FiltersSidebar";
+
+type Snap = "half" | "full";
+
+/** Pixel delta required to trigger a snap transition or dismissal */
+const SNAP_THRESHOLD = 60;
+
+/** Sheet height for each snap point */
+const SNAP_HEIGHT: Record<Snap, string> = {
+  half: "50vh",
+  full: "92vh",
+};
+
+interface FiltersBottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** Live result count shown in the footer CTA */
+  resultCount: number;
+  selectedCategories: Set<string>;
+  toggleCategory: (c: string) => void;
+  minPrice: number | null;
+  maxPrice: number | null;
+  setMinPrice: (v: number | null) => void;
+  setMaxPrice: (v: number | null) => void;
+  popularity: string;
+  setPopularity: (p: string) => void;
+  clearFilters: () => void;
+  /** Ref to the trigger button so focus is restored on close */
+  triggerRef: React.RefObject<HTMLButtonElement>;
+}
+
+export default function FiltersBottomSheet({
+  open,
+  onClose,
+  resultCount,
+  selectedCategories,
+  toggleCategory,
+  minPrice,
+  maxPrice,
+  setMinPrice,
+  setMaxPrice,
+  popularity,
+  setPopularity,
+  clearFilters,
+  triggerRef,
+}: FiltersBottomSheetProps) {
+  const [snap, setSnap] = useState<Snap>("half");
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const dragStartY = useRef<number | null>(null);
+
+  // Detect reduced-motion preference once; stable for the component lifetime.
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // Reset to half-snap whenever the sheet opens.
+  useEffect(() => {
+    if (open) setSnap("half");
+  }, [open]);
+
+  // ESC key → close.
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  // Focus trap: keep Tab/Shift-Tab inside the dialog while open.
+  useEffect(() => {
+    if (!open || !sheetRef.current) return;
+    const sheet = sheetRef.current;
+    const focusable = getFocusableElements(sheet);
+    focusable[0]?.focus();
+
+    const trapTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const els = getFocusableElements(sheet);
+      if (!els.length) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", trapTab);
+    return () => document.removeEventListener("keydown", trapTab);
+  }, [open]);
+
+  // Restore focus to the trigger button when the sheet closes.
+  useEffect(() => {
+    if (!open) triggerRef.current?.focus();
+  }, [open, triggerRef]);
+
+  // Prevent body scroll while the sheet is open.
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // ── Drag-to-snap handlers ────────────────────────────────────────────────
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    dragStartY.current = e.clientY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (dragStartY.current === null) return;
+      const delta = e.clientY - dragStartY.current;
+      dragStartY.current = null;
+
+      if (delta > SNAP_THRESHOLD) {
+        // Dragged downward
+        if (snap === "full") {
+          setSnap("half");
+        } else {
+          onClose(); // dismiss from half-snap
+        }
+      } else if (delta < -SNAP_THRESHOLD) {
+        // Dragged upward
+        setSnap("full");
+      }
+    },
+    [snap, onClose],
+  );
+
+  if (!open) return null;
+
+  const sheetStyle: React.CSSProperties = {
+    height: SNAP_HEIGHT[snap],
+    // Disable the transition animation when user prefers reduced motion.
+    transition: prefersReducedMotion ? "none" : undefined,
+  };
+
+  return (
+    <>
+      {/* Backdrop — click to close */}
+      <div
+        className="bottom-sheet__backdrop"
+        aria-hidden="true"
+        onClick={onClose}
+        data-testid="bottom-sheet-backdrop"
+      />
+
+      {/* Sheet panel */}
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Filters"
+        className={`bottom-sheet bottom-sheet--${snap}`}
+        style={sheetStyle}
+        data-testid="bottom-sheet"
+      >
+        {/* Drag handle — pointer events only, hidden from AT */}
+        <div
+          className="bottom-sheet__handle-area"
+          onPointerDown={handlePointerDown}
+          onPointerUp={handlePointerUp}
+          aria-hidden="true"
+          data-testid="bottom-sheet-handle-area"
+        >
+          <div className="bottom-sheet__handle" />
+        </div>
+
+        {/* Header row */}
+        <div className="bottom-sheet__header">
+          <h2 className="bottom-sheet__title" id="bottom-sheet-title">
+            Filters
+          </h2>
+          <button
+            className="ghost-button bottom-sheet__close"
+            onClick={onClose}
+            aria-label="Close filters"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Scrollable filter body */}
+        <div className="bottom-sheet__body">
+          <FiltersSidebar
+            selectedCategories={selectedCategories}
+            toggleCategory={toggleCategory}
+            minPrice={minPrice}
+            maxPrice={maxPrice}
+            setMinPrice={setMinPrice}
+            setMaxPrice={setMaxPrice}
+            popularity={popularity}
+            setPopularity={setPopularity}
+            clearFilters={clearFilters}
+          />
+        </div>
+
+        {/* Footer — live result count CTA */}
+        <div className="bottom-sheet__footer">
+          <button
+            className="primary-button bottom-sheet__show-btn"
+            onClick={onClose}
+          >
+            Show {resultCount} result{resultCount !== 1 ? "s" : ""}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** Returns all keyboard-focusable descendants of `container`, excluding aria-hidden ones. */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.closest("[aria-hidden]"));
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1332,6 +1332,23 @@ code,
 
 .marketplace-filter-button {
   display: none;
+  gap: 6px;
+}
+
+/* Active-filter count badge on the mobile Filters trigger */
+.marketplace-filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .marketplace-grid {
@@ -2880,6 +2897,123 @@ code,
   background: var(--method-delete-bg);
   color: var(--method-delete-color);
   border-color: var(--method-delete-border);
+}
+
+/* ─── Mobile Bottom Sheet ───────────────────────────────────────────────────
+   Renders on viewports < 768 px. Two snap points are applied via inline
+   `height` driven by the "half" / "full" class added by FiltersBottomSheet.
+   The height transition is suppressed for users who prefer reduced motion.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.bottom-sheet__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(4, 8, 18, 0.64);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.bottom-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-strong);
+  border-top: 1px solid var(--line-strong);
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -8px 40px rgba(0, 0, 0, 0.35);
+  /* Spring-like transition between snap points */
+  transition: height 280ms cubic-bezier(0.32, 0.72, 0, 1);
+  will-change: height;
+  overflow: hidden;
+}
+
+/* Disable the snap transition when prefers-reduced-motion is set.
+   The component also sets `style.transition = "none"` as a belt-and-suspenders. */
+@media (prefers-reduced-motion: reduce) {
+  .bottom-sheet {
+    transition: none;
+  }
+}
+
+/* Snap-point modifier classes — height is overridden by inline style in the
+   component, but these classes serve as readable semantic markers. */
+.bottom-sheet--half {
+  /* 50 vh — set via inline style */
+}
+
+.bottom-sheet--full {
+  /* 92 vh — set via inline style */
+}
+
+/* Drag handle ── the tappable strip at the very top of the sheet */
+.bottom-sheet__handle-area {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 0 6px;
+  cursor: grab;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+.bottom-sheet__handle-area:active {
+  cursor: grabbing;
+}
+
+.bottom-sheet__handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--line-strong);
+}
+
+/* Header row */
+.bottom-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px 10px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.bottom-sheet__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.bottom-sheet__close {
+  min-height: 36px;
+  padding: 0 10px;
+  font-size: 0.95rem;
+}
+
+/* Scrollable filter body */
+.bottom-sheet__body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px 16px;
+  overscroll-behavior: contain;
+}
+
+/* Footer — "Show N results" CTA */
+.bottom-sheet__footer {
+  flex-shrink: 0;
+  padding: 10px 16px 16px;
+  border-top: 1px solid var(--line);
+}
+
+.bottom-sheet__show-btn {
+  width: 100%;
+  min-height: 48px;
+  font-size: 1rem;
 }
 
 /* Price Filter Input Validation Styles */

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ApiCard, { ApiCardSkeleton } from "../components/ApiCard";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import SearchBar from "../components/SearchBar";
 import FiltersSidebar from "../components/FiltersSidebar";
+import FiltersBottomSheet from "../components/FiltersBottomSheet";
 import EmptyState, { type EmptyStateProps } from "../components/EmptyState";
 import MOCK_APIS, { type APIItem } from "../data/mockApis";
 import { useDebounce } from "../hooks/useDebounce";
@@ -24,6 +25,9 @@ export default function MarketplacePage(): JSX.Element {
   const [showFiltersMobile, setShowFiltersMobile] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
+
+  // Ref used to restore focus to the Filters trigger after the sheet closes
+  const filtersTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     // Simulate initial data loading with occasional error for testing
@@ -64,6 +68,16 @@ export default function MarketplacePage(): JSX.Element {
       popularity !== "any"
     );
   };
+
+  /**
+   * Count of actively-applied filter dimensions — shown as a badge on the
+   * mobile Filters trigger button.
+   */
+  const activeFilterCount =
+    selectedCategories.size +
+    (minPrice !== null ? 1 : 0) +
+    (maxPrice !== null ? 1 : 0) +
+    (popularity !== "any" ? 1 : 0);
 
   /**
    * Handle retry for fetch errors.
@@ -193,11 +207,24 @@ export default function MarketplacePage(): JSX.Element {
                 <option value="popularity">Popularity</option>
                 <option value="newest">Newest</option>
               </select>
+
+              {/* Mobile Filters trigger — hidden on desktop via CSS */}
               <button
+                ref={filtersTriggerRef}
                 className="ghost-button marketplace-filter-button"
-                onClick={() => setShowFiltersMobile((s) => !s)}
+                onClick={() => setShowFiltersMobile(true)}
+                aria-haspopup="dialog"
+                aria-expanded={showFiltersMobile}
               >
                 Filters
+                {activeFilterCount > 0 && (
+                  <span
+                    className="marketplace-filter-badge"
+                    aria-label={`${activeFilterCount} active filter${activeFilterCount !== 1 ? "s" : ""}`}
+                  >
+                    {activeFilterCount}
+                  </span>
+                )}
               </button>
             </div>
           </div>
@@ -241,40 +268,22 @@ export default function MarketplacePage(): JSX.Element {
         </main>
       </div>
 
-      {showFiltersMobile && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="marketplace-filter-modal"
-          onClick={() => setShowFiltersMobile(false)}
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className="marketplace-filter-panel"
-          >
-            <h3>Filters</h3>
-            <FiltersSidebar
-              selectedCategories={selectedCategories}
-              toggleCategory={toggleCategory}
-              minPrice={minPrice}
-              maxPrice={maxPrice}
-              setMinPrice={setMinPrice}
-              setMaxPrice={setMaxPrice}
-              popularity={popularity}
-              setPopularity={setPopularity}
-              clearFilters={clearFilters}
-            />
-            <div className="marketplace-filter-footer">
-              <button
-                className="primary-button"
-                onClick={() => setShowFiltersMobile(false)}
-              >
-                Done
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Mobile bottom-sheet — only rendered when open */}
+      <FiltersBottomSheet
+        open={showFiltersMobile}
+        onClose={() => setShowFiltersMobile(false)}
+        resultCount={filtered.length}
+        selectedCategories={selectedCategories}
+        toggleCategory={toggleCategory}
+        minPrice={minPrice}
+        maxPrice={maxPrice}
+        setMinPrice={setMinPrice}
+        setMaxPrice={setMaxPrice}
+        popularity={popularity}
+        setPopularity={setPopularity}
+        clearFilters={clearFilters}
+        triggerRef={filtersTriggerRef}
+      />
     </div>
   );
 }


### PR DESCRIPTION
closes #153

## Summary

- Adds `FiltersBottomSheet` — a mobile-only bottom-sheet wrapper for `FiltersSidebar` rendered at viewports < 768 px
- Sheet opens from a "Filters" trigger button in the marketplace toolbar; the button shows an active-filter count badge when filters are applied
- Two snap points: **half** (50 vh, default on open) and **full** (92 vh), toggled by dragging the handle bar up or down
- Drag-to-dismiss: dragging down from the half snap closes the sheet
- Backdrop click and ESC key both close the sheet
- Focus is trapped inside the dialog while open and restored to the trigger button on close
- Footer "Show N results" button updates live as filters change and closes the sheet
- Spring transition between snap points is disabled for users with `prefers-reduced-motion: reduce`
- Old centred-modal implementation removed from `MarketplacePage`

## Files changed

| File | Change |
|------|--------|
| `src/components/FiltersBottomSheet.tsx` | New component |
| `src/components/FiltersBottomSheet.test.tsx` | 13 tests covering open/close, ESC, backdrop, focus restore, footer CTA, aria attributes |
| `src/pages/MarketplacePage.tsx` | Swaps old modal for `FiltersBottomSheet`; adds active-filter badge on trigger |
| `src/index.css` | `.bottom-sheet`, `.bottom-sheet__handle`, snap-point classes, filter badge styles |

## Test plan

- [ ] Open on a 360 px viewport: tap Filters, sheet appears at half height
- [ ] Drag handle upward: sheet expands to full height
- [ ] Drag handle downward from full: snaps back to half
- [ ] Drag handle downward from half: sheet dismisses
- [ ] ESC key closes the sheet
- [ ] Backdrop click closes the sheet
- [ ] Focus returns to the Filters button after close
- [ ] "Show N results" count updates live as filter selections change
- [ ] Badge shows correct active-filter count on the trigger button
- [ ] `prefers-reduced-motion` users see no height animation
