### PR TITLE
chore: replace emoji glyphs with theme-aware SVG icons

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -98,6 +98,26 @@ These tokens are shared across both light and dark themes.
 
 ---
 
+## Iconography
+
+To keep the bundle size small and ensure theme consistency, Callora uses a custom, lightweight SVG icon set instead of external libraries.
+
+### Guidelines for Icons
+- **Theme Awareness**: All custom SVG icons must use `fill="none" stroke="currentColor"` so that they automatically adapt to theme switches.
+- **Stroke Style**: Keep the stroke width consistent at `1.6px` across all icons.
+- **Allowed Sizes**: Custom SVG icons must be used in **16px** (`size={16}`) or **20px** (`size={20}`) sizes only. No other sizes are allowed to prevent blurriness and maintain visual alignment.
+- **Accessibility**: All icons must have `aria-hidden="true"` when decorative (default behaviour) or carry a descriptive `aria-label` when used standalone.
+- **Barrel Export**: Export new icons as named exports in `src/components/icons/index.tsx`.
+
+### Available Icons
+- `TagIcon` (16px/20px) - Represents category tags or categories.
+- `CheckIcon` (16px/20px) - Represents successful statuses, features list items, or checkmarks.
+- `WarningIcon` (16px/20px) - Represents validation errors, price range warnings, or alert messages.
+- `BoltIcon` (16px/20px) - Represents system uptime, fast status, or performance.
+- `ClockIcon` (16px/20px) - Represents latency, response times, or duration.
+
+---
+
 ## Component Library
 
 All shared components are located in `src/components/`. Use these components instead of building custom UI elements.

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -1,6 +1,7 @@
 import Skeleton from "./Skeleton";
 import { formatPrice } from "../utils/format";
 import type { APIItem } from "../data/mockApis";
+import { TagIcon, ClockIcon, BoltIcon } from "./icons";
 
 export function ApiCardSkeleton() {
   return (
@@ -210,8 +211,12 @@ export default function ApiCard({
               background: "rgba(255,255,255,0.02)",
               padding: "4px 8px",
               borderRadius: 8,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
             }}
           >
+            <TagIcon size={16} />
             {t}
           </span>
         ))}
@@ -238,14 +243,18 @@ export default function ApiCard({
           </div>
 
           <div className="api-card__stat">
-            <span className="api-card__stat-label">Latency</span>
+            <span className="api-card__stat-label" style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <ClockIcon size={16} /> Latency
+            </span>
             {renderStatValue(
               avgLatencyMs !== undefined ? `${avgLatencyMs} ms` : undefined,
             )}
           </div>
 
           <div className="api-card__stat">
-            <span className="api-card__stat-label">Uptime</span>
+            <span className="api-card__stat-label" style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <BoltIcon size={16} /> Uptime
+            </span>
             {renderStatValue(
               uptimePercent !== undefined
                 ? `${uptimePercent.toFixed(2)}%`

--- a/src/components/FiltersSidebar.tsx
+++ b/src/components/FiltersSidebar.tsx
@@ -1,3 +1,5 @@
+import { WarningIcon } from "./icons";
+
 export const ALL_CATEGORIES = [
   "Data & Analytics",
   "Payment Processing",
@@ -100,7 +102,7 @@ export default function FiltersSidebar({
                 }}
                 role="alert"
               >
-                <span>⚠️</span> Min price cannot exceed max price.
+                <WarningIcon size={16} /> Min price cannot exceed max price.
               </div>
             )}
           </fieldset>

--- a/src/components/icons/BoltIcon.tsx
+++ b/src/components/icons/BoltIcon.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: 16 | 20;
+}
+
+export function BoltIcon({ size = 16, className, ...props }: IconProps) {
+  const ariaHidden = props["aria-label"] ? undefined : "true";
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+    </svg>
+  );
+}

--- a/src/components/icons/CheckIcon.tsx
+++ b/src/components/icons/CheckIcon.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: 16 | 20;
+}
+
+export function CheckIcon({ size = 16, className, ...props }: IconProps) {
+  const ariaHidden = props["aria-label"] ? undefined : "true";
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/src/components/icons/ClockIcon.tsx
+++ b/src/components/icons/ClockIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: 16 | 20;
+}
+
+export function ClockIcon({ size = 16, className, ...props }: IconProps) {
+  const ariaHidden = props["aria-label"] ? undefined : "true";
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}

--- a/src/components/icons/TagIcon.tsx
+++ b/src/components/icons/TagIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: 16 | 20;
+}
+
+export function TagIcon({ size = 16, className, ...props }: IconProps) {
+  const ariaHidden = props["aria-label"] ? undefined : "true";
+  
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+      <line x1="7" y1="7" x2="7.01" y2="7" />
+    </svg>
+  );
+}

--- a/src/components/icons/WarningIcon.tsx
+++ b/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+  size?: 16 | 20;
+}
+
+export function WarningIcon({ size = 16, className, ...props }: IconProps) {
+  const ariaHidden = props["aria-label"] ? undefined : "true";
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={ariaHidden}
+      {...props}
+    >
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}

--- a/src/components/icons/icons.test.tsx
+++ b/src/components/icons/icons.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TagIcon, CheckIcon, WarningIcon, BoltIcon, ClockIcon } from "./index";
+
+const iconComponents = [
+  { name: "TagIcon", Component: TagIcon },
+  { name: "CheckIcon", Component: CheckIcon },
+  { name: "WarningIcon", Component: WarningIcon },
+  { name: "BoltIcon", Component: BoltIcon },
+  { name: "ClockIcon", Component: ClockIcon },
+];
+
+describe("Theme-Aware SVG Icon Set", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  iconComponents.forEach(({ name, Component }) => {
+    describe(name, () => {
+      it("renders with default size 16 and aria-hidden", () => {
+        const { container } = render(<Component />);
+        const svg = container.querySelector("svg");
+        
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute("width")).toBe("16");
+        expect(svg?.getAttribute("height")).toBe("16");
+        expect(svg?.getAttribute("aria-hidden")).toBe("true");
+        expect(svg?.getAttribute("stroke-width")).toBe("1.6");
+        expect(svg?.getAttribute("fill")).toBe("none");
+      });
+
+      it("respects size prop of 20", () => {
+        const { container } = render(<Component size={20} />);
+        const svg = container.querySelector("svg");
+        
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute("width")).toBe("20");
+        expect(svg?.getAttribute("height")).toBe("20");
+      });
+
+      it("overrides aria-hidden when aria-label is provided", () => {
+        const { container } = render(<Component aria-label="custom label" />);
+        const svg = container.querySelector("svg");
+        
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute("aria-hidden")).toBeNull();
+        expect(svg?.getAttribute("aria-label")).toBe("custom label");
+      });
+
+      it("passes through standard SVG attributes", () => {
+        const { container } = render(<Component className="custom-icon-class" data-testid="icon" />);
+        const svg = container.querySelector("svg");
+        
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute("class")).toContain("custom-icon-class");
+        expect(svg?.getAttribute("data-testid")).toBe("icon");
+      });
+    });
+  });
+});

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,0 +1,5 @@
+export { TagIcon } from "./TagIcon";
+export { CheckIcon } from "./CheckIcon";
+export { WarningIcon } from "./WarningIcon";
+export { BoltIcon } from "./BoltIcon";
+export { ClockIcon } from "./ClockIcon";

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -8,6 +8,7 @@ import { findApiById } from "../data/mockApis";
 import EmptyState from "../components/EmptyState";
 import { formatPrice } from "../utils/format";
 import { API_BASE_URL, LOADING_DELAY_MS } from "../config/constants";
+import { CheckIcon, ClockIcon, BoltIcon } from "../components/icons";
 
 /**
  * ApiDetailPage Component
@@ -684,14 +685,14 @@ print(data)`;
                             marginTop: 20,
                           }}
                         >
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ Unlimited Throughput
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> Unlimited Throughput
                           </li>
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ 99.9% Uptime SLA
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> 99.9% Uptime SLA
                           </li>
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ Community Support
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> Community Support
                           </li>
                         </ul>
                       </div>
@@ -719,14 +720,14 @@ print(data)`;
                             marginTop: 20,
                           }}
                         >
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ Dedicated Node
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> Dedicated Node
                           </li>
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ 24/7 Phone Support
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> 24/7 Phone Support
                           </li>
-                          <li style={{ marginBottom: 10 }}>
-                            ✅ Custom Rate Limits
+                          <li style={{ marginBottom: 10, display: "inline-flex", alignItems: "center", gap: 6 }}>
+                            <CheckIcon size={16} style={{ color: "var(--success)" }} /> Custom Rate Limits
                           </li>
                         </ul>
                         <button


### PR DESCRIPTION
closes #152  
This PR addresses inconsistent rendering of emoji glyphs across different operating systems (OSes) and ensures icons respond properly to the user's selected light/dark theme. We replace mixed emoji glyphs (⚠️, ✅, 🏷️) in ApiCard.tsx, FiltersSidebar.tsx, and ApiDetailPage.tsx with a curated set of SVG icons.

Key Changes
1. New Custom Icon Set
We created a lightweight and theme-aware SVG icon components directory under src/components/icons/ with a consistent 1.6px stroke width:

TagIcon: Used for category tags.
CheckIcon: Used for checkmarks in pricing lists and features.
WarningIcon: Used for error alerts and validation warnings.
BoltIcon: Used for speed/uptime metrics.
ClockIcon: Used for latency/time metrics.
index.tsx: Exports the named icon components.
2. Component Integration
FiltersSidebar: Replaced the warning emoji ⚠️ with <WarningIcon size={16} />.
ApiDetailPage: Replaced the standard/enterprise plan checkmarks (✅) with <CheckIcon size={16} />, styled with the var(--success) theme token.
ApiCard:
Added <TagIcon size={16} /> inside each tag pill.
Added <ClockIcon size={16} /> and <BoltIcon size={16} /> into the latency and uptime stats labels respectively for better accessibility and design harmony.
3. Documentation
Updated docs/UI-Design-System.md with an Iconography section specifying the design requirements (allowed sizes 16px/20px, consistent 1.6px stroke width, currentColor inheritance, and aria-hidden / aria-label accessibility rules).
4. Tests
Created src/components/icons/icons.test.tsx to verify size configurations, SVGs, and accessibility attributes. All 130 tests pass successfully.

