### PR TITLE
feat: 24h health timeline strip on ApiDetailPage

### DIFF
--- a/src/components/HealthTimeline.tsx
+++ b/src/components/HealthTimeline.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useRef, KeyboardEvent } from "react";
+
+export type HealthStatus = "operational" | "degraded" | "down";
+
+interface HealthTimelineProps {
+  data?: HealthStatus[];
+}
+
+const statusColors = {
+  operational: "#10b981", // Green
+  degraded: "#f59e0b", // Yellow
+  down: "#ef4444", // Red
+};
+
+// Patterns for color-blind accessibility
+const statusPatterns = {
+  operational: "none",
+  degraded: "repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(0,0,0,0.15) 4px, rgba(0,0,0,0.15) 8px)",
+  down: "repeating-linear-gradient(45deg, rgba(0,0,0,0.3), rgba(0,0,0,0.3) 4px, transparent 4px, transparent 8px), repeating-linear-gradient(-45deg, rgba(0,0,0,0.3), rgba(0,0,0,0.3) 4px, transparent 4px, transparent 8px)",
+};
+
+const statusLabels = {
+  operational: "Operational",
+  degraded: "Degraded",
+  down: "Down",
+};
+
+export default function HealthTimeline({ data = [] }: HealthTimelineProps) {
+  // Ensure we have exactly 24 items, default to operational if not provided
+  const timelineData = Array(24).fill("operational").map((def, i) => data[i] || def);
+  
+  const [activeTooltip, setActiveTooltip] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index;
+    if (e.key === "ArrowRight") {
+      nextIndex = Math.min(23, index + 1);
+    } else if (e.key === "ArrowLeft") {
+      nextIndex = Math.max(0, index - 1);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setActiveTooltip(activeTooltip === index ? null : index);
+      return;
+    }
+
+    if (nextIndex !== index) {
+      e.preventDefault();
+      const buttons = containerRef.current?.querySelectorAll("button");
+      buttons?.[nextIndex]?.focus();
+      setActiveTooltip(null); // Hide tooltip when moving focus
+    }
+  };
+
+  const getHourLabel = (index: number) => {
+    // Current time minus (23 - index) hours
+    const date = new Date();
+    date.setHours(date.getHours() - (23 - index));
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <div 
+        style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}
+      >
+        <span style={{ fontSize: 12, color: "var(--muted)" }}>24 hours ago</span>
+        <span style={{ fontSize: 12, color: "var(--muted)" }}>Now</span>
+      </div>
+      <div 
+        ref={containerRef}
+        style={{ 
+          display: "flex", 
+          height: 32, 
+          gap: 2, 
+          width: "100%", 
+          position: "relative" 
+        }}
+        role="group"
+        aria-label="24-hour health timeline"
+      >
+        {timelineData.map((status, index) => {
+          const hourLabel = getHourLabel(index);
+          const statusLabel = statusLabels[status];
+          const isTooltipVisible = activeTooltip === index;
+
+          return (
+            <div 
+              key={index} 
+              style={{ flex: 1, position: "relative" }}
+              onMouseEnter={() => setActiveTooltip(index)}
+              onMouseLeave={() => setActiveTooltip(null)}
+              onBlur={() => setActiveTooltip(null)}
+            >
+              <button
+                type="button"
+                aria-label={`${hourLabel}: ${statusLabel}`}
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  backgroundColor: statusColors[status],
+                  backgroundImage: statusPatterns[status],
+                  border: "none",
+                  borderRadius: 2,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+              />
+              {isTooltipVisible && (
+                <div
+                  style={{
+                    position: "absolute",
+                    bottom: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    marginBottom: 8,
+                    backgroundColor: "var(--bg-elevated, #1f2937)",
+                    color: "var(--text-main, #f9fafb)",
+                    padding: "6px 10px",
+                    borderRadius: 6,
+                    fontSize: 12,
+                    whiteSpace: "nowrap",
+                    zIndex: 10,
+                    pointerEvents: "none",
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                    border: "1px solid var(--border-subtle, #374151)"
+                  }}
+                  role="tooltip"
+                  aria-live="polite"
+                >
+                  <strong style={{ display: "block", marginBottom: 4 }}>{hourLabel}</strong>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span 
+                      style={{ 
+                        width: 10, 
+                        height: 10, 
+                        borderRadius: "50%", 
+                        backgroundColor: statusColors[status],
+                        backgroundImage: statusPatterns[status],
+                        display: "inline-block" 
+                      }} 
+                    />
+                    <span>{statusLabel}</span>
+                  </div>
+                  {/* Tooltip arrow */}
+                  <div 
+                    style={{
+                      position: "absolute",
+                      top: "100%",
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      borderWidth: "5px",
+                      borderStyle: "solid",
+                      borderColor: "var(--border-subtle, #374151) transparent transparent transparent"
+                    }} 
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/data/mockApis.ts
+++ b/src/data/mockApis.ts
@@ -26,6 +26,7 @@ export type APIItem = {
   endpoints?: Array<any>;
   stats?: { totalCalls?: number; avgResponseMs?: number; uptimePct?: number };
   ratingDistribution?: Record<number, number>;
+  hourlyHealth?: ("operational" | "degraded" | "down")[];
 };
 
 export const MOCK_APIS: APIItem[] = [
@@ -78,6 +79,7 @@ export const MOCK_APIS: APIItem[] = [
     ],
     stats: { totalCalls: 382412, avgResponseMs: 180, uptimePct: 99.97 },
     ratingDistribution: { 5: 85, 4: 25, 3: 10, 2: 2, 1: 2 },
+    hourlyHealth: Array(24).fill("operational").map((_, i) => i === 12 || i === 13 ? "degraded" : "operational"),
   },
   {
     id: "pay-qr",
@@ -115,6 +117,7 @@ export const MOCK_APIS: APIItem[] = [
         verified: false,
       },
     ],
+    hourlyHealth: Array(24).fill("operational"),
   },
   {
     id: "msg-01",
@@ -144,6 +147,7 @@ export const MOCK_APIS: APIItem[] = [
         verified: true,
       },
     ],
+    hourlyHealth: Array(24).fill("operational").map((_, i) => i > 18 && i < 22 ? "down" : "operational"),
   },
   // minimal demo items
   ...Array.from({ length: 10 }).map((_, i) => {
@@ -174,6 +178,7 @@ export const MOCK_APIS: APIItem[] = [
         avgResponseMs: avgLatencyMs,
         uptimePct: uptimePercent,
       },
+      hourlyHealth: Array(24).fill("operational").map(() => Math.random() > 0.9 ? (Math.random() > 0.5 ? "degraded" : "down") : "operational"),
     };
   }),
 ];

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -10,6 +10,7 @@ import type { Review } from "../data/mockApis";
 import EmptyState from "../components/EmptyState";
 import { formatPrice } from "../utils/format";
 import { Icons } from "../utils/icons";
+import HealthTimeline from "../components/HealthTimeline";
 import { API_BASE_URL, LOADING_DELAY_MS } from "../config/constants";
 
 /**
@@ -1327,6 +1328,7 @@ print(data)`;
                       </span>
                     </div>
                   </div>
+                  <HealthTimeline data={api.hourlyHealth as any} />
                 </div>
 
                 <div


### PR DESCRIPTION
Closes #161

**Description:**
This PR addresses the UI/UX issue by adding a 24-cell timeline strip to the `ApiDetailPage` health sidebar. This feature gives users an immediate visual representation of the API's reliability over the past 24 hours.

**Changes made:**
* **`src/components/HealthTimeline.tsx`:** Created a new accessible React component that renders a 24-cell grid. 
  * Displays "operational", "degraded", or "down" statuses using color mapping.
  * Ensures color-blind accessibility by adding unique geometric pattern overlays (`repeating-linear-gradient`) to degraded and down statuses.
  * Implemented keyboard accessibility: users can focus and use arrow keys (`ArrowRight`, `ArrowLeft`) to tab through the timeline, and use `Enter` or hover over cells to display a custom tooltip showing the specific time and status.
* **`src/data/mockApis.ts`:** Updated the `APIItem` type to include an `hourlyHealth` array. Populated the mock APIs with 24-hour health status arrays to render realistic data on the timeline.
* **`src/pages/ApiDetailPage.tsx`:** Integrated the `<HealthTimeline />` component directly below the API Health status tokens in the existing sidebar layout without breaking the current responsive structure.

**Testing:**
- Verified that arrow keys move focus successfully between timeline cells and that `Enter` correctly toggles the tooltip.
- Verified visual clarity of the added color-blind patterns.
- Confirmed the strip container is responsive and prevents horizontal scrolling on narrow viewports (320px).
- Validated that screen readers correctly announce the time and status via `aria-label` when cells are focused.