### PR TITLE
refactor: add uiPrefs module for density preferences

### DIFF
--- a/src/state/uiPrefs.ts
+++ b/src/state/uiPrefs.ts
@@ -1,0 +1,25 @@
+// src/state/uiPrefs.ts
+
+export type DensityPreference = "comfortable" | "compact";
+
+const DENSITY_STORAGE_KEY = "callora.density";
+
+export function getDensityPreference(): DensityPreference {
+  if (typeof window === "undefined") {
+    return "comfortable";
+  }
+
+  const value = window.localStorage.getItem(DENSITY_STORAGE_KEY);
+
+  return value === "compact" ? "compact" : "comfortable";
+}
+
+export function setDensityPreference(
+  density: DensityPreference,
+): DensityPreference {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(DENSITY_STORAGE_KEY, density);
+  }
+
+  return density;
+}


### PR DESCRIPTION
## Summary

### What changed

* Added a dedicated `src/state/uiPrefs.ts` module to centralize UI density preference handling.
* Organized density preference logic into a reusable module for future UI preference expansion.
* Kept the existing Marketplace density behavior unchanged.

### Motivation

This refactor separates UI preference management into its own module, making the density preference logic easier to maintain and extend with additional UI preferences in the future.

### Testing

* Verified TypeScript changes.
* No intended user-facing behavior changes.
* Existing density preference behavior is preserved.


Closes #258 