### PR TITLE
fix: ApiUsage breadcrumb

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -218,8 +218,9 @@ Navigation breadcrumb showing page hierarchy.
 **Accessibility:**
 - `aria-label="breadcrumb"` on nav
 - `aria-current="page"` on current item
-- Keyboard navigation with Enter/Space
-- Custom focus management (onFocus/onBlur)
+- Collapsed middle crumbs open from a real button with `aria-expanded` and `aria-controls`
+- Keyboard navigation supports Enter/Space on links and buttons, Arrow Up/Down, Home, End, and Escape in the collapsed crumbs menu
+- Focus moves into the collapsed menu when opened and returns to the trigger when closed with Escape
 
 **Usage Example:**
 ```tsx

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -5,6 +5,7 @@ import { formatPrice } from './utils/format';
 import RequestBodyEditor from './components/RequestBodyEditor';
 import type { JsonSchema } from './components/RequestBodyEditor';
 import CallHistoryRow from './components/CallHistoryRow';
+import Breadcrumb from './components/Breadcrumb';
 
 type ApiEndpoint = {
   id: string;
@@ -401,6 +402,16 @@ export default function ApiUsage() {
 
   return (
     <div className="api-usage-page">
+      <Breadcrumb
+        items={[
+          { label: 'Marketplace', href: '/marketplace' },
+          {
+            label: 'User Profile API usage',
+            href: '/api-usage',
+            isCurrent: true,
+          },
+        ]}
+      />
       {!isDismissed && (
         <PlanNudge usagePercent={usagePercent} onDismiss={dismiss} />
       )}

--- a/src/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb.test.tsx
@@ -78,6 +78,50 @@ describe("Breadcrumb", () => {
     expect(screen.queryByRole("menu")).toBeNull();
   });
 
+  it("moves focus into collapsed crumbs and supports arrow key navigation", () => {
+    const { container } = render(<Breadcrumb items={longBreadcrumb} />);
+
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+
+    if (!button) throw new Error("Expected breadcrumb ellipsis button");
+
+    fireEvent.click(button);
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(document.activeElement).toBe(menuItems[0]);
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    expect(document.activeElement).toBe(menuItems[1]);
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    expect(document.activeElement).toBe(menuItems[0]);
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "End" });
+    expect(document.activeElement).toBe(menuItems[1]);
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Home" });
+    expect(document.activeElement).toBe(menuItems[0]);
+  });
+
+  it("returns focus to the ellipsis button when closing the popover with Escape", () => {
+    const { container } = render(<Breadcrumb items={longBreadcrumb} />);
+
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+
+    if (!button) throw new Error("Expected breadcrumb ellipsis button");
+
+    fireEvent.click(button);
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(document.activeElement).toBe(button);
+  });
+
   it("applies the link-nav utility class to breadcrumb links", () => {
     render(<Breadcrumb items={longBreadcrumb} />);
     const link = screen.getByRole("link", { name: "Marketplace" });

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 type BreadcrumbItem = {
   label: string;
@@ -40,6 +41,8 @@ function BreadcrumbSeparator() {
 
 export default function Breadcrumb({ items }: BreadcrumbProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const ellipsisButtonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const popoverId = useId();
   const middleItems = useMemo(() => items.slice(1, -1), [items]);
   const shouldCollapseMiddle = middleItems.length > 0;
@@ -50,6 +53,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setIsPopoverOpen(false);
+        ellipsisButtonRef.current?.focus();
       }
     };
 
@@ -59,6 +63,56 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [isPopoverOpen]);
+
+  useEffect(() => {
+    if (!isPopoverOpen) return;
+
+    popoverRef.current
+      ?.querySelector<HTMLAnchorElement>('[role="menuitem"]')
+      ?.focus();
+  }, [isPopoverOpen]);
+
+  const handlePopoverKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ) => {
+    const menuItems = Array.from(
+      event.currentTarget.querySelectorAll<HTMLAnchorElement>(
+        '[role="menuitem"]',
+      ),
+    );
+
+    if (menuItems.length === 0) return;
+
+    const currentIndex = menuItems.indexOf(
+      document.activeElement as HTMLAnchorElement,
+    );
+    const focusMenuItem = (index: number) => {
+      event.preventDefault();
+      menuItems[index]?.focus();
+    };
+
+    switch (event.key) {
+      case "ArrowDown":
+        focusMenuItem((currentIndex + 1) % menuItems.length);
+        break;
+      case "ArrowUp":
+        focusMenuItem(
+          (currentIndex - 1 + menuItems.length) % menuItems.length,
+        );
+        break;
+      case "Home":
+        focusMenuItem(0);
+        break;
+      case "End":
+        focusMenuItem(menuItems.length - 1);
+        break;
+      case "Escape":
+        event.preventDefault();
+        setIsPopoverOpen(false);
+        ellipsisButtonRef.current?.focus();
+        break;
+    }
+  };
 
   return (
     <nav aria-label="breadcrumb" className="breadcrumb-nav">
@@ -225,6 +279,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                 <span className="breadcrumb-collapsed">
                   <BreadcrumbSeparator />
                   <button
+                    ref={ellipsisButtonRef}
                     type="button"
                     className="breadcrumb-ellipsis"
                     aria-label="Show collapsed breadcrumb items"
@@ -236,9 +291,11 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                   </button>
                   {isPopoverOpen && (
                     <div
+                      ref={popoverRef}
                       className="breadcrumb-popover"
                       id={popoverId}
                       role="menu"
+                      onKeyDown={handlePopoverKeyDown}
                     >
                       <ol className="breadcrumb-popover-list">
                         {middleItems.map((middleItem) => (


### PR DESCRIPTION
I added an accessible breadcrumb to the ApiUsage page and improved collapsed breadcrumb keyboard navigation with proper focus handling and `aria-current` support.

Closes #259