### PR TITLE
Add 'open in new tab' affordance on external doc links

### DIFF
--- a/src/components/ExternalLink.test.tsx
+++ b/src/components/ExternalLink.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ExternalLink from "./ExternalLink";
+
+describe("ExternalLink", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders children correctly", () => {
+    render(<ExternalLink href="https://example.com">Example</ExternalLink>);
+    expect(screen.getByText("Example").tagName).toBe("A");
+  });
+
+  it("adds target and rel for external http links", () => {
+    render(
+      <ExternalLink href="https://docs.example.com">
+        External docs
+      </ExternalLink>,
+    );
+
+    const link = screen.getByText("External docs");
+    expect(link.getAttribute("href")).toBe("https://docs.example.com");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("adds aria-label describing external navigation", () => {
+    render(
+      <ExternalLink href="https://docs.example.com" aria-label="API docs">
+        API docs
+      </ExternalLink>,
+    );
+
+    const link = screen.getByLabelText("API docs, opens in new tab");
+    expect(link).toBeTruthy();
+  });
+
+  it("renders an external link icon for external URLs", () => {
+    const { container } = render(
+      <ExternalLink href="https://example.com">External</ExternalLink>,
+    );
+
+    const link = container.querySelector("a");
+    const svg = link?.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not add external attributes for internal relative links", () => {
+    render(<ExternalLink href="/docs">Docs</ExternalLink>);
+
+    const link = screen.getByText("Docs");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+
+  it("does not add external attributes for hash links", () => {
+    render(<ExternalLink href="#section">Section</ExternalLink>);
+
+    const link = screen.getByText("Section");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+
+  it("does not add external attributes for same-origin absolute links when mocked", () => {
+    const originalOrigin = window.location.origin;
+    Object.defineProperty(window, "location", {
+      value: { origin: "https://callora.io" },
+      writable: true,
+    });
+
+    render(<ExternalLink href="https://callora.io/docs"> docs</ExternalLink>);
+
+    const link = screen.getByText(" docs");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+
+    Object.defineProperty(window, "location", {
+      value: { origin: originalOrigin },
+      writable: true,
+    });
+  });
+
+  it("passes through additional anchor props", () => {
+    render(
+      <ExternalLink href="https://example.com" title="External site" className="custom-link">
+        Site
+      </ExternalLink>,
+    );
+
+    const link = screen.getByText("Site");
+    expect(link.getAttribute("title")).toBe("External site");
+    expect(link.getAttribute("class")).toBe("custom-link");
+  });
+
+  it("does not render an icon for internal links", () => {
+    const { container } = render(
+      <ExternalLink href="/marketplace">Marketplace</ExternalLink>,
+    );
+
+    const link = container.querySelector("a");
+    expect(link?.querySelector("svg")).toBeNull();
+  });
+
+  it("does not set an aria-label for internal links without one", () => {
+    render(<ExternalLink href="/docs">Docs</ExternalLink>);
+
+    const link = screen.getByText("Docs");
+    expect(link.getAttribute("aria-label")).toBeNull();
+  });
+
+  it("treats undefined href as internal", () => {
+    render(<ExternalLink>Missing href</ExternalLink>);
+
+    const link = screen.getByText("Missing href");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+});

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+type ExternalLinkProps = React.ComponentPropsWithoutRef<"a"> & {
+  children: React.ReactNode;
+};
+
+function isExternal(href?: string): boolean {
+  if (!href) return false;
+  if (href.startsWith("#") || href.startsWith("/") || href.startsWith("?") || href.startsWith("./") || href.startsWith("../")) {
+    return false;
+  }
+  try {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const absolute = new URL(href, origin);
+    return absolute.origin !== origin;
+  } catch {
+    return false;
+  }
+}
+
+export default function ExternalLink({
+  href,
+  children,
+  ...rest
+}: ExternalLinkProps) {
+  const external = isExternal(href);
+  const baseAriaLabel = (rest as Record<string, unknown>)["aria-label"] as string | undefined;
+  const ariaLabel = external
+    ? `${baseAriaLabel ?? ""}${baseAriaLabel ? ", " : ""}opens in new tab`
+    : baseAriaLabel;
+
+  const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    ...rest,
+    href,
+    "aria-label": ariaLabel,
+  };
+
+  if (external) {
+    anchorProps.target = "_blank";
+    anchorProps.rel = "noopener noreferrer";
+  }
+
+  return (
+    <a {...anchorProps}>
+      {children}
+      {external && (
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            marginLeft: 4,
+            verticalAlign: "middle",
+            color: "var(--muted)",
+            lineHeight: 1,
+          }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
+        </span>
+      )}
+      <style>{`
+        a:focus-visible {
+          outline: 2px solid var(--accent);
+          outline-offset: 2px;
+          box-shadow: var(--focus-ring);
+          border-radius: 4px;
+        }
+      `}</style>
+    </a>
+  );
+}


### PR DESCRIPTION
(closes #260)

Adds a shared `ExternalLink` component that automatically detects external URLs, appends `target`/`rel` when needed, and renders a visible external-link icon with an updated aria-label. Refactors existing external anchor usages to use the new component, reducing duplication while keeping internal links unchanged. Focused unit tests cover detection, attribute application, accessibility labeling, prop pass-through, and icon rendering.