### PR TITLE
feat(ui): rating histogram tooltip on marketplace ApiCard

### DIFF
--- a/docs/RatingHistogram.md
+++ b/docs/RatingHistogram.md
@@ -1,0 +1,62 @@
+# RatingHistogram
+
+Tooltip that reveals a 5-star rating distribution when the user hovers, focuses, or long-presses a rating display. Used by the marketplace `ApiCard` next to the inline rating (e.g. `4.6 ★`).
+
+## Usage
+
+```tsx
+import RatingHistogram from "../components/RatingHistogram";
+
+<RatingHistogram
+  rating={api.rating}
+  distribution={api.ratingDistribution}
+  placement="top-end"
+>
+  ⭐ {api.rating}
+</RatingHistogram>;
+```
+
+The child node is the always-visible trigger content. The tooltip is rendered on top of it when the trigger is hovered, focused, or long-pressed.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `rating` | `number` | — | Average rating (0–5). Shown prominently in the tooltip header. |
+| `distribution` | `Record<number, number>` | derived from `rating` | Per-star review counts keyed by star value (1–5). When omitted, a plausible distribution is generated so the tooltip is never empty. |
+| `children` | `ReactNode` | — | The trigger content (typically the inline rating string). |
+| `placement` | `"top" \| "top-start" \| "top-end"` | `"top"` | How the tooltip anchors relative to the trigger. `top-end` is recommended when the trigger sits near the right edge of a container (as it does in `ApiCard`) so the 240px-wide popover does not overflow. |
+
+## Interactions
+
+| Input | Behavior |
+| --- | --- |
+| Mouse hover | Shows on `mouseenter`. Hides ~120ms after the pointer leaves both the trigger and the tooltip (the grace period satisfies WCAG 1.4.13 "Hoverable" — users can move the pointer onto the tooltip without it disappearing). |
+| Keyboard focus | Shows on `focus`, hides on `blur`. The trigger is included in tab order (`tabIndex={0}`). |
+| Touch long-press | Holding the trigger for ≥400ms reveals the tooltip; releasing hides it. A short tap does not reveal the tooltip. |
+| `Escape` | Dismisses the tooltip while it is visible. |
+| Click on trigger | Does not propagate, so clicking the rating inside a clickable card (e.g. `ApiCard`) does not navigate. |
+
+## Accessibility
+
+- WCAG 2.1 AA SC 1.4.13 (Content on Hover or Focus):
+  - **Dismissible** via Escape.
+  - **Hoverable** — the close timer is cancelled when the pointer enters the tooltip, so users with motor impairments can move onto it.
+  - **Persistent** until pointer/focus leaves or the user dismisses.
+- The trigger exposes an `aria-label` of the form `"Rating 4.6 out of 5, 124 reviews"` so screen-reader users always hear the rating context, even when the tooltip is not opened.
+- While the tooltip is visible, the trigger sets `aria-describedby` to the tooltip's `id`, and the tooltip itself uses `role="tooltip"`.
+- Each histogram row has an `aria-label` like `"5 stars: 85 reviews"`.
+
+## Design tokens
+
+All colors come from the existing design-token set (`--surface`, `--text`, `--muted`, `--accent`, `--surface-soft`, `--shadow`, `--transition-speed`). The component therefore renders correctly under both `[data-theme="dark"]` and `[data-theme="light"]` without additional work.
+
+## Responsive behavior
+
+The tooltip is 240px wide with `max-width: calc(100vw - 32px)` so it never overflows the viewport on small screens. When placed near a container edge in `ApiCard`, `placement="top-end"` keeps it anchored within the card.
+
+## Edge cases
+
+- All-zero distribution: rows render with 0% bars and the "X reviews" subtotal is suppressed.
+- Missing `distribution`: a plausible mock is derived from `rating` so the tooltip is never empty.
+- Mounted inside a clickable ancestor: trigger `onClick` stops propagation; Enter/Space on the trigger also stop propagation.

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -15,6 +15,7 @@ import type { APIItem } from "../data/mockApis";
 import RatingHistogram from "./RatingHistogram";
 import { useCompareStore, compareStore } from "../state/compareStore";
 import Sparkline from "./Sparkline";
+import { TagIcon, ClockIcon, BoltIcon } from "./icons";
 
 // ─── Skeleton ────────────────────────────────────────────────────────────────
 
@@ -474,7 +475,11 @@ export default function ApiCard({
           </div>
           {api.rating !== undefined && (
             <div style={{ color: "var(--muted)", marginTop: 6 }}>
-              <RatingHistogram rating={api.rating} distribution={api.ratingDistribution}>
+              <RatingHistogram
+                rating={api.rating}
+                distribution={api.ratingDistribution}
+                placement="top-end"
+              >
                 ⭐ {api.rating}
               </RatingHistogram>
             </div>
@@ -543,6 +548,7 @@ export default function ApiCard({
   width={90}
   height={28}
 />
+      </div>
 
       <div
         className="api-marketplace-card-footer"
@@ -602,7 +608,11 @@ export default function ApiCard({
           </span>
           <div style={{ color: "var(--muted)", fontSize: 12 }}>
             {api.rating ? (
-              <RatingHistogram rating={api.rating} distribution={api.ratingDistribution}>
+              <RatingHistogram
+                rating={api.rating}
+                distribution={api.ratingDistribution}
+                placement="top-end"
+              >
                 {api.rating} ★
               </RatingHistogram>
             ) : (

--- a/src/components/RatingHistogram.test.tsx
+++ b/src/components/RatingHistogram.test.tsx
@@ -1,77 +1,154 @@
-import React from "react";
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RatingHistogram from "./RatingHistogram";
 
+const getTrigger = (label: string) =>
+  screen.getByText(label).closest(".rating-histogram") as HTMLElement;
+
 describe("RatingHistogram", () => {
-  it("renders children correctly", () => {
+  it("renders children", () => {
     render(
       <RatingHistogram rating={4.5}>
         <span data-testid="child">4.5 Stars</span>
-      </RatingHistogram>
+      </RatingHistogram>,
     );
     expect(screen.getByTestId("child")).toBeDefined();
   });
 
-  it("shows tooltip on mouse enter and hides on mouse leave", async () => {
+  it("shows tooltip on mouse enter and hides (after grace period) on mouse leave", async () => {
     render(<RatingHistogram rating={4.5}>Hover me</RatingHistogram>);
-    
-    const trigger = screen.getByText("Hover me");
-    
-    // Tooltip should not be visible initially
+    const trigger = getTrigger("Hover me");
+
     expect(screen.queryByRole("tooltip")).toBeNull();
-    
-    // Trigger mouse enter
+
     fireEvent.mouseEnter(trigger);
     expect(await screen.findByRole("tooltip")).toBeDefined();
     expect(screen.getByText("4.5")).toBeDefined();
-    
-    // Trigger mouse leave
+
     fireEvent.mouseLeave(trigger);
     await waitFor(() => {
       expect(screen.queryByRole("tooltip")).toBeNull();
     });
   });
 
-  it("shows tooltip on long press (touch)", async () => {
-    render(<RatingHistogram rating={4.2}>Touch me</RatingHistogram>);
-    
-    const trigger = screen.getByText("Touch me");
-    
-    // Trigger touch start
-    fireEvent.touchStart(trigger);
-    expect(screen.queryByRole("tooltip")).toBeNull();
-    
-    // Wait for the long press duration
-    expect(await screen.findByRole("tooltip", undefined, { timeout: 1000 })).toBeDefined();
-    
-    // Trigger touch end
-    fireEvent.touchEnd(trigger);
-    await waitFor(() => {
-      expect(screen.queryByRole("tooltip")).toBeNull();
-    });
+  it("keeps tooltip open when pointer moves from trigger onto the tooltip (WCAG hoverable)", async () => {
+    render(<RatingHistogram rating={4.5}>Hover me</RatingHistogram>);
+    const trigger = getTrigger("Hover me");
+
+    fireEvent.mouseEnter(trigger);
+    const tooltip = await screen.findByRole("tooltip");
+
+    // Pointer leaves the trigger but enters the tooltip before the close timer fires.
+    fireEvent.mouseLeave(trigger);
+    fireEvent.mouseEnter(tooltip);
+
+    // Wait past the close delay; tooltip should still be present.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(screen.queryByRole("tooltip")).not.toBeNull();
+
+    fireEvent.mouseLeave(tooltip);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
   });
 
-  it("uses provided distribution data", async () => {
-    const customDist = { 5: 100, 4: 50, 3: 0, 2: 0, 1: 0 };
+  it("opens on focus and closes on blur (keyboard accessibility)", async () => {
+    render(<RatingHistogram rating={3.7}>Focus me</RatingHistogram>);
+    const trigger = getTrigger("Focus me");
+
+    fireEvent.focus(trigger);
+    expect(await screen.findByRole("tooltip")).toBeDefined();
+
+    fireEvent.blur(trigger);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+  });
+
+  it("dismisses on Escape (WCAG dismissible)", async () => {
+    render(<RatingHistogram rating={4.0}>Hover me</RatingHistogram>);
+    const trigger = getTrigger("Hover me");
+
+    fireEvent.mouseEnter(trigger);
+    await screen.findByRole("tooltip");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+  });
+
+  it("shows tooltip on long press (touch) and hides on touchend", async () => {
+    render(<RatingHistogram rating={4.2}>Touch me</RatingHistogram>);
+    const trigger = getTrigger("Touch me");
+
+    fireEvent.touchStart(trigger);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    // Wait past the long-press threshold.
+    expect(
+      await screen.findByRole("tooltip", undefined, { timeout: 1000 }),
+    ).toBeDefined();
+
+    fireEvent.touchEnd(trigger);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+  });
+
+  it("does not show tooltip if touch is released before long-press threshold", async () => {
+    render(<RatingHistogram rating={4.2}>Tap me</RatingHistogram>);
+    const trigger = getTrigger("Tap me");
+
+    fireEvent.touchStart(trigger);
+    // Release quickly — short tap should never reveal the tooltip.
+    await new Promise((r) => setTimeout(r, 100));
+    fireEvent.touchEnd(trigger);
+    await new Promise((r) => setTimeout(r, 500));
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("uses provided distribution and renders a row per star value", async () => {
+    const customDist = { 5: 100, 4: 50, 3: 10, 2: 5, 1: 1 };
     render(
       <RatingHistogram rating={4.8} distribution={customDist}>
         Hover me
-      </RatingHistogram>
+      </RatingHistogram>,
     );
-    
-    const trigger = screen.getByText("Hover me");
-    fireEvent.mouseEnter(trigger);
-    
-    // Wait for tooltip to appear
-    await screen.findByRole("tooltip");
+    fireEvent.mouseEnter(getTrigger("Hover me"));
+    const tooltip = await screen.findByRole("tooltip");
 
-    // Find rows and verify counts are rendered
-    expect(screen.getByText("100")).toBeDefined();
-    expect(screen.getByText("50")).toBeDefined();
-    // 1 star count is 0, which might match other things, so let's just check the ones that are unique
-    const tooltip = screen.getByRole("tooltip");
+    // One labelled row per star value.
+    expect(tooltip.querySelectorAll('[aria-label$="reviews"], [aria-label$="review"]').length).toBe(5);
     expect(tooltip.textContent).toContain("100");
     expect(tooltip.textContent).toContain("50");
+    // Total reviews shown.
+    expect(tooltip.textContent).toContain("166 reviews");
+  });
+
+  it("does not crash when all distribution counts are zero", async () => {
+    render(
+      <RatingHistogram rating={0} distribution={{ 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 }}>
+        Hover me
+      </RatingHistogram>,
+    );
+    fireEvent.mouseEnter(getTrigger("Hover me"));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toBeDefined();
+    // No "X reviews" string when total is 0.
+    expect(tooltip.textContent).not.toMatch(/\d+\s+reviews?/);
+  });
+
+  it("stops click propagation so a clickable ancestor is not activated", () => {
+    let parentClicked = false;
+    render(
+      <div onClick={() => (parentClicked = true)}>
+        <RatingHistogram rating={4.5}>Hover me</RatingHistogram>
+      </div>,
+    );
+    fireEvent.click(getTrigger("Hover me"));
+    expect(parentClicked).toBe(false);
+  });
+
+  it("sets aria-describedby only while the tooltip is visible", async () => {
+    render(<RatingHistogram rating={4.5}>Hover me</RatingHistogram>);
+    const trigger = getTrigger("Hover me");
+
+    expect(trigger.getAttribute("aria-describedby")).toBeNull();
+    fireEvent.mouseEnter(trigger);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(trigger.getAttribute("aria-describedby")).toBe(tooltip.id);
   });
 });

--- a/src/components/RatingHistogram.tsx
+++ b/src/components/RatingHistogram.tsx
@@ -1,81 +1,176 @@
-import React, { useState, useRef, useEffect } from "react";
+/**
+ * RatingHistogram
+ *
+ * Wraps a rating display (e.g. "4.6 ★") and reveals a 5-star distribution
+ * tooltip on hover, focus, or long-press (touch).
+ *
+ * Accessibility (WCAG 2.1 AA, SC 1.4.13 Content on Hover or Focus):
+ *  - Dismissible: pressing Escape hides the tooltip.
+ *  - Hoverable: pointer can move from trigger onto the tooltip without
+ *    dismissing it (small close delay + tooltip mouseenter cancels the close).
+ *  - Persistent: tooltip stays until pointer/focus leaves or user dismisses.
+ *  - Keyboard: trigger is focusable (tabIndex 0); focus shows, blur hides.
+ *  - Click on trigger does not propagate to a clickable ancestor (e.g. ApiCard).
+ */
+
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useId,
+} from "react";
+
+export type RatingHistogramPlacement = "top" | "top-start" | "top-end";
 
 export interface RatingHistogramProps {
+  /** Average rating, 0–5. */
   rating: number;
+  /** Per-star counts keyed by star value (1–5). Falls back to a derived mock when omitted. */
   distribution?: Record<number, number>;
+  /** Trigger content (typically the inline rating display). */
   children?: React.ReactNode;
+  /** How to anchor the tooltip relative to the trigger. Defaults to "top". */
+  placement?: RatingHistogramPlacement;
 }
+
+const LONG_PRESS_MS = 400;
+// Brief delay before closing on mouseleave so the pointer can travel from
+// the trigger to the tooltip without it disappearing (WCAG 1.4.13 "Hoverable").
+const HOVER_CLOSE_DELAY_MS = 120;
 
 export default function RatingHistogram({
   rating,
   distribution,
   children,
+  placement = "top",
 }: RatingHistogramProps) {
   const [isVisible, setIsVisible] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
 
-  const dist = distribution || generateMockDistribution(rating);
-  const total = Object.values(dist).reduce((sum, val) => sum + val, 0) || 1;
+  const dist = distribution ?? generateMockDistribution(rating);
+  const total = Object.values(dist).reduce((sum, v) => sum + v, 0);
 
-  // Cleanup timer on unmount
   useEffect(() => {
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
     };
   }, []);
 
-  const handleMouseEnter = () => {
+  // Escape dismisses (WCAG 1.4.13 "Dismissible").
+  useEffect(() => {
+    if (!isVisible) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setIsVisible(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isVisible]);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const open = useCallback(() => {
+    cancelClose();
     setIsVisible(true);
-  };
-  const handleMouseLeave = () => {
-    if (timerRef.current) clearTimeout(timerRef.current);
+  }, [cancelClose]);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = setTimeout(
+      () => setIsVisible(false),
+      HOVER_CLOSE_DELAY_MS,
+    );
+  }, [cancelClose]);
+
+  const closeNow = useCallback(() => {
+    cancelClose();
     setIsVisible(false);
-  };
+  }, [cancelClose]);
 
   const handleTouchStart = () => {
-    // 400ms long press to show histogram on touch devices
-    timerRef.current = setTimeout(() => {
-      setIsVisible(true);
-    }, 400);
+    if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = setTimeout(open, LONG_PRESS_MS);
+  };
+  const handleTouchEnd = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    closeNow();
   };
 
-  const handleTouchEnd = () => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    setIsVisible(false);
+  // Prevent activation of a clickable ancestor (e.g. ApiCard with role="button").
+  const stopBubble = (e: React.SyntheticEvent) => e.stopPropagation();
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.stopPropagation();
+    }
   };
+
+  const placementStyle: React.CSSProperties =
+    placement === "top-end"
+      ? { right: 0 }
+      : placement === "top-start"
+        ? { left: 0 }
+        : { left: "50%", transform: "translateX(-50%)" };
+
+  const ratingLabel = `Rating ${rating.toFixed(1)} out of 5${
+    total > 0 ? `, ${total} reviews` : ""
+  }`;
 
   return (
-    <div
-      className="rating-histogram-trigger"
+    <span
+      className="rating-histogram"
       style={{
         position: "relative",
         display: "inline-flex",
         alignItems: "center",
       }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      tabIndex={0}
+      aria-label={ratingLabel}
+      aria-describedby={isVisible ? tooltipId : undefined}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+      onFocus={open}
+      onBlur={closeNow}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
+      onClick={stopBubble}
+      onKeyDown={handleKeyDown}
     >
       {children}
       {isVisible && (
         <div
-          className="surface rating-tooltip"
+          id={tooltipId}
+          className="surface rating-histogram__tooltip"
           role="tooltip"
+          onMouseEnter={cancelClose}
+          onMouseLeave={scheduleClose}
+          onClick={stopBubble}
           style={{
             position: "absolute",
             bottom: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
             marginBottom: "8px",
             padding: "16px",
             width: "240px",
+            maxWidth: "calc(100vw - 32px)",
             zIndex: 50,
             boxShadow: "var(--shadow)",
             cursor: "default",
+            ...placementStyle,
           }}
-          onClick={(e) => e.stopPropagation()} // Prevent clicking through to parent card
         >
           <div
             style={{
@@ -91,12 +186,23 @@ export default function RatingHistogram({
             <div style={{ color: "var(--muted)", fontSize: "0.85rem" }}>
               out of 5
             </div>
+            {total > 0 && (
+              <div
+                style={{
+                  marginLeft: "auto",
+                  color: "var(--muted)",
+                  fontSize: "0.75rem",
+                }}
+              >
+                {total} {total === 1 ? "review" : "reviews"}
+              </div>
+            )}
           </div>
 
           <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
             {[5, 4, 3, 2, 1].map((star) => {
-              const count = dist[star] || 0;
-              const percent = (count / total) * 100;
+              const count = dist[star] ?? 0;
+              const percent = total > 0 ? (count / total) * 100 : 0;
               return (
                 <div
                   key={star}
@@ -106,7 +212,7 @@ export default function RatingHistogram({
                     gap: "8px",
                     fontSize: "0.75rem",
                   }}
-                  aria-label={`${star} stars: ${count} reviews`}
+                  aria-label={`${star} star${star === 1 ? "" : "s"}: ${count} ${count === 1 ? "review" : "reviews"}`}
                 >
                   <div
                     style={{
@@ -152,10 +258,13 @@ export default function RatingHistogram({
           </div>
         </div>
       )}
-    </div>
+    </span>
   );
 }
 
+// Mock distribution used when an API has no concrete rating breakdown yet.
+// Skews higher for higher averages so the preview "looks right" alongside
+// the average rating.
 function generateMockDistribution(rating: number): Record<number, number> {
   const total = 124;
   const dist: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };


### PR DESCRIPTION
CLOSE #244

## Summary
The marketplace `ApiCard` shows an inline rating (e.g. `4.6 ★`) but there is no way to see how that average breaks down across the five star levels without opening the API detail page. Hover/long-press exposing the distribution was requested in the GrantFox campaign brief.

This PR adds `RatingHistogram`, a small tooltip component that renders a 5-row distribution histogram, and wires it into the two rating slots on `ApiCard`. The tooltip opens on pointer hover, keyboard focus, or touch long-press, and is fully WCAG 2.1 AA compliant for hover content.

## Changes
`src/components/RatingHistogram.tsx` — replaces the existing minimal implementation with a WCAG-compliant version. Adds:
  - keyboard accessibility (`tabIndex={0}`, focus/blur handlers, `aria-describedby` wired via `useId`),
  - Escape-to-dismiss,
  - ~120ms close grace period plus tooltip-side mouseenter cancel so the pointer can travel trigger → tooltip without dismissing (WCAG 1.4.13 "Hoverable"),
  - `placement` prop (`"top"` / `"top-start"` / `"top-end"`) for right-edge anchoring inside narrow containers,
  - viewport-bounded width (`max-width: calc(100vw - 32px)`) so the 240px popover never overflows on small screens,
  - `e.stopPropagation()` on trigger click/keydown so the rating does not activate the surrounding `role="button"` card.

`src/components/RatingHistogram.test.tsx` — expanded from 4 to 11 tests:
  - `renders children`
  - `shows tooltip on mouse enter and hides (after grace period) on mouse leave`
  - `keeps tooltip open when pointer moves from trigger onto the tooltip (WCAG hoverable)`
  - `opens on focus and closes on blur (keyboard accessibility)`
  - `dismisses on Escape (WCAG dismissible)`
  - `shows tooltip on long press (touch) and hides on touchend`
  - `does not show tooltip if touch is released before long-press threshold`
  - `uses provided distribution and renders a row per star value`
  - `does not crash when all distribution counts are zero`
  - `stops click propagation so a clickable ancestor is not activated`
  - `sets aria-describedby only while the tooltip is visible`

`src/components/ApiCard.tsx` — passes `placement="top-end"` to both `RatingHistogram` usages (both sit at the card's right edge, so default centered placement would overflow the card). Also fixes two pre-existing issues that were blocking `tsc -b` on the file: an unclosed `<div>` left over from the sparkline merge in #308 (which had been silently nesting the footer inside the sparkline row), and a missing import for `TagIcon` / `ClockIcon` / `BoltIcon` that the file references but never imported.

`docs/RatingHistogram.md` (new) — component reference covering API, interactions, accessibility guarantees, design tokens, and edge cases.

## Note on the ApiCard JSX fix
The unclosed `<div>` and missing icon imports in `ApiCard.tsx` were introduced by the sparkline merge in #308. Without the fix, this branch's `tsc -b` fails before reaching any RatingHistogram-related code. Fixing them is necessary to land this PR; their inclusion is incidental, not a separate refactor. The fix is two lines: an added `</div>` between the sparkline and the footer, and an `import { TagIcon, ClockIcon, BoltIcon } from "./icons";` line.

## Note on accessibility
`RatingHistogram` satisfies WCAG 2.1 AA SC 1.4.13 (Content on Hover or Focus):
- **Dismissible**: pressing Escape hides the tooltip.
- **Hoverable**: a ~120ms close timer plus the tooltip's own mouseenter handler cancel the close, so users with motor impairments can move the pointer onto the tooltip.
- **Persistent**: visible until pointer/focus leaves both trigger and tooltip, or the user dismisses.

The trigger exposes `aria-label` of the form `"Rating 4.6 out of 5, 124 reviews"` so screen-reader users hear the rating context even when the tooltip is not opened. While the tooltip is visible, the trigger sets `aria-describedby` to the tooltip's `id` and the tooltip uses `role="tooltip"`. Each histogram row carries its own `aria-label` like `"5 stars: 85 reviews"`.

## Note on theming
All colors come from existing design tokens (`--surface`, `--text`, `--muted`, `--accent`, `--surface-soft`, `--shadow`, `--transition-speed`), so the tooltip renders correctly under both `[data-theme="dark"]` and `[data-theme="light"]` without additional CSS.

## Acceptance criteria
- [x] Hover, keyboard focus, and touch long-press all reveal the 5-star distribution
- [x] Escape dismisses; tooltip persists when the pointer moves onto it
- [x] Trigger is in tab order and announces the rating to screen readers
- [x] Renders correctly in both dark and light themes (design tokens only — no theme-specific CSS)
- [x] Responsive: 240px popover bounded to `calc(100vw - 32px)`; `placement="top-end"` keeps it inside the card on narrow viewports
- [x] All 11 `RatingHistogram` tests pass
- [x] No new failures in the rest of the suite vs `main` (the 59 pre-existing failures in `CodeExample`, `Tabs`, `FiltersBottomSheet`, `schema-validate`, `ThemePlayground`, `MarketplacePage`, `ApiDetailPage` are unchanged and unrelated to this PR)
- [x] Docs added at `docs/RatingHistogram.md`
- [x] JSDoc-style comments on the component and its props

## Test plan
- [x] `npx vitest run src/components/RatingHistogram.test.tsx` → 11 passed / 0 failed
- [x] `npx vitest run` → file/test failure counts match `main` baseline (7 failed files / 59 failed tests, all pre-existing in unrelated suites)
- [x] `npx tsc -b` clean for `ApiCard.tsx` and `RatingHistogram.tsx` (remaining TS errors are pre-existing in `src/ApiUsage.tsx` and `src/pages/ApiDetailPage.tsx`)
- [ ] Manual: hover, tab-focus, and long-press the rating on a marketplace card in dark and light theme; verify Escape dismissal and that clicking the rating does not navigate into the card