### PR TITLE
feat: accessible Reset button on ApiUsage filters

### DIFF
--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -195,6 +195,7 @@ export default function ApiUsage() {
   const [responseTime, setResponseTime] = useState<number | null>(null);
   const [callCost, setCallCost] = useState<number | null>(null);
   const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'error'>('all');
+  const [filterResetMessage, setFilterResetMessage] = useState('');
   const [callHistory, setCallHistory] = useState<CallRecord[]>(MOCK_CALL_HISTORY);
 
   const filteredCallHistory = filterCallsByRange(statusFilter === 'all' ? callHistory : callHistory.filter(call => call.status === statusFilter));
@@ -270,6 +271,17 @@ export default function ApiUsage() {
     avgResponseTime: 180,
     successRate: 94.2
   });
+
+  // Whether any call-history filter differs from its default value.
+  const filtersAreActive = statusFilter !== 'all' || selectedRange.preset !== '24h';
+
+  // Reset all call-history filters to their defaults and announce the change
+  // to assistive technology via the aria-live region below.
+  const handleResetFilters = () => {
+    setStatusFilter('all');
+    setSelectedRange({ preset: '24h' });
+    setFilterResetMessage('Filters reset. Showing all calls from the last 24 hours.');
+  };
 
   const handleCopyApiKey = async () => {
     try {
@@ -606,10 +618,19 @@ export default function ApiUsage() {
                 { id: 'error', label: 'Error' },
               ]}
               activeTab={statusFilter}
-              onChange={(id) =>
-                setStatusFilter(id as 'all' | 'success' | 'error')
-              }
+              onChange={(id) => {
+                setStatusFilter(id as 'all' | 'success' | 'error');
+                setFilterResetMessage('');
+              }}
             />
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={handleResetFilters}
+              disabled={!filtersAreActive}
+            >
+              Reset Filters
+            </button>
             <button className="secondary-button" onClick={() => handleExportHistory('csv')}>
               Export CSV
             </button>
@@ -618,6 +639,11 @@ export default function ApiUsage() {
             </button>
           </div>
         </div>
+
+        {/* Screen-reader announcement for filter reset (WCAG 2.1 AA) */}
+        <p className="sr-only" role="status" aria-live="polite">
+          {filterResetMessage}
+        </p>
 
         <div className="call-history-table" aria-busy={isLoading}>
            <div className="table-header">

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,19 @@
     --focus-ring-offset: 0 0 0 5px rgba(78, 133, 255, 0.55);
 }
 
+/* Visually hidden, but available to screen readers (WCAG 2.1 AA). */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 [data-theme="dark"] {
     --page-bg: #0b1020;
     --surface: rgba(14, 20, 39, 0.86);


### PR DESCRIPTION
Closes #294.

Adds a single 'Reset Filters' button to the Call History controls on the API Usage page. It clears both the status filter and the date range back to their defaults (All Status, last 24 hours), and is disabled when no filters are active. A `role="status" aria-live="polite"` region announces the reset to screen readers, and a global `.sr-only` utility class (already referenced elsewhere but previously undefined) was added for WCAG 2.1 AA support.