### PR TITLE
feat: smoother theme transition for dark mode switch

### DIFF
--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import './styles/theme-transition.css';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -21,6 +22,16 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const resolvedTheme = document.documentElement.getAttribute('data-theme');
     return (resolvedTheme === 'light' || resolvedTheme === 'dark') ? resolvedTheme : 'dark';
   });
+
+  // Enable color-token transitions only after the first paint, so the initial
+  // theme is applied instantly (no flash) while subsequent switches animate.
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const id = window.requestAnimationFrame(() => {
+      root.classList.add('theme-transitions-ready');
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('callora-theme', theme);

--- a/src/styles/theme-transition.css
+++ b/src/styles/theme-transition.css
@@ -1,0 +1,31 @@
+/**
+ * theme-transition.css
+ *
+ * Smooth the light <-> dark theme switch by animating the color tokens
+ * (background, text and border colors) instead of swapping them instantly.
+ *
+ * The transition is only active once the ThemeProvider has mounted and added
+ * the `theme-transitions-ready` class to <html>. This prevents the colors from
+ * animating on the very first paint (which would otherwise look like a flash
+ * of the wrong theme fading in).
+ */
+
+html.theme-transitions-ready,
+html.theme-transitions-ready body,
+html.theme-transitions-ready *:not(.no-theme-transition) {
+  transition:
+    background-color var(--transition-speed, 240ms) ease,
+    border-color var(--transition-speed, 240ms) ease,
+    color var(--transition-speed, 240ms) ease,
+    fill var(--transition-speed, 240ms) ease,
+    stroke var(--transition-speed, 240ms) ease;
+}
+
+/* Respect users who prefer reduced motion: switch instantly. */
+@media (prefers-reduced-motion: reduce) {
+  html.theme-transitions-ready,
+  html.theme-transitions-ready body,
+  html.theme-transitions-ready * {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #291.

Adds a new `theme-transition.css` that animates the color tokens (background, text, border, fill, stroke) so light <-> dark switches fade smoothly instead of snapping. ThemeContext imports the stylesheet and adds a `theme-transitions-ready` class on `<html>` after the first paint, so the initial theme still applies instantly with no flash. A `prefers-reduced-motion` guard disables the animation for users who request it.