### PR TITLE
Add MarketplacePage 'Recently active' rail

### DIFF
--- a/src/components/RecentlyActiveRail.test.tsx
+++ b/src/components/RecentlyActiveRail.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RecentlyActiveRail from "./RecentlyActiveRail";
+import type { APIItem } from "../data/mockApis";
+
+function makeApi(over: Partial<APIItem>): APIItem {
+  return {
+    id: "x",
+    name: "Sample API",
+    provider: { name: "Acme" },
+    description: "desc",
+    pricePerRequest: 0.01,
+    ...over,
+  };
+}
+
+const apis: APIItem[] = [
+  makeApi({ id: "a", name: "Alpha", createdAt: "2026-06-28", usageCount: 10 }),
+  makeApi({ id: "b", name: "Bravo", createdAt: "2026-01-01", usageCount: 99 }),
+  makeApi({ id: "c", name: "Charlie", createdAt: "2026-06-29", usageCount: 1 }),
+];
+
+describe("RecentlyActiveRail", () => {
+  afterEach(() => cleanup());
+
+  it("renders a labelled region with a heading", () => {
+    render(<RecentlyActiveRail apis={apis} />);
+    expect(
+      screen.getByRole("region", { name: /recently active apis/i }),
+    ).toBeTruthy();
+    expect(screen.getByText("Recently active")).toBeTruthy();
+  });
+
+  it("orders items by most recent first", () => {
+    render(<RecentlyActiveRail apis={apis} />);
+    const buttons = screen.getAllByRole("button");
+    // Charlie (06-29) before Alpha (06-28) before Bravo (01-01)
+    expect(buttons[0].textContent).toContain("Charlie");
+    expect(buttons[1].textContent).toContain("Alpha");
+    expect(buttons[2].textContent).toContain("Bravo");
+  });
+
+  it("respects the limit prop", () => {
+    render(<RecentlyActiveRail apis={apis} limit={2} />);
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("renders nothing when there are no APIs", () => {
+    const { container } = render(<RecentlyActiveRail apis={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("invokes onSelect with the chosen API", () => {
+    const onSelect = vi.fn();
+    render(<RecentlyActiveRail apis={apis} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole("button", { name: /charlie/i }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe("c");
+  });
+});

--- a/src/components/RecentlyActiveRail.tsx
+++ b/src/components/RecentlyActiveRail.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from "react";
+import type { APIItem } from "../data/mockApis";
+
+/**
+ * RecentlyActiveRail — a horizontally scrollable rail of APIs that have seen
+ * the most recent usage. Surfaced on the Marketplace to help users discover
+ * actively-maintained, in-demand APIs at a glance.
+ *
+ * Accessibility (WCAG 2.1 AA):
+ * - Rendered as a labelled region with a scrollable list.
+ * - Each card is a real <button> so it is keyboard focusable and operable.
+ * - Uses design tokens + dark-mode-friendly CSS variables only.
+ */
+
+type RecentlyActiveRailProps = {
+  /** Source list of APIs to derive the "recently active" set from. */
+  apis: APIItem[];
+  /** Maximum number of APIs to show in the rail. Defaults to 8. */
+  limit?: number;
+  /** Invoked when a rail card is activated (click / Enter / Space). */
+  onSelect?: (api: APIItem) => void;
+};
+
+/** Compact relative-time label, e.g. "3d ago". Falls back to "recently". */
+function relativeUsage(api: APIItem): string {
+  const iso = api.createdAt;
+  if (!iso) return "recently";
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return "recently";
+  const diffMs = Date.now() - ts;
+  const diffDays = Math.floor(diffMs / 86_400_000);
+  if (diffDays <= 0) return "today";
+  if (diffDays === 1) return "1d ago";
+  if (diffDays < 30) return `${diffDays}d ago`;
+  const months = Math.floor(diffDays / 30);
+  return months === 1 ? "1mo ago" : `${months}mo ago`;
+}
+
+export default function RecentlyActiveRail({
+  apis,
+  limit = 8,
+  onSelect,
+}: RecentlyActiveRailProps): JSX.Element | null {
+  // Rank by most recent creation/usage, then by raw usage volume as a tiebreak.
+  const items = useMemo(() => {
+    return apis
+      .slice()
+      .sort((a, b) => {
+        const da = Date.parse(a.createdAt ?? "1970-01-01");
+        const db = Date.parse(b.createdAt ?? "1970-01-01");
+        if (db !== da) return db - da;
+        return (b.usageCount ?? 0) - (a.usageCount ?? 0);
+      })
+      .slice(0, Math.max(0, limit));
+  }, [apis, limit]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      className="recently-active-rail"
+      aria-label="Recently active APIs"
+      style={{ marginBottom: "1.5rem" }}
+    >
+      <h2
+        style={{
+          fontSize: "0.95rem",
+          fontWeight: 600,
+          margin: "0 0 0.625rem",
+          color: "var(--text-main)",
+        }}
+      >
+        Recently active
+      </h2>
+
+      <ul
+        style={{
+          display: "flex",
+          gap: "0.75rem",
+          listStyle: "none",
+          margin: 0,
+          padding: "0 0 0.25rem",
+          overflowX: "auto",
+          scrollSnapType: "x proximity",
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        {items.map((api) => (
+          <li
+            key={api.id}
+            style={{ flex: "0 0 auto", scrollSnapAlign: "start" }}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect?.(api)}
+              aria-label={`${api.name} by ${api.provider?.name ?? "Unknown"}, last active ${relativeUsage(api)}`}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.25rem",
+                width: "190px",
+                textAlign: "left",
+                padding: "0.75rem",
+                borderRadius: "0.5rem",
+                border: "1px solid var(--border-subtle, #e5e7eb)",
+                background: "var(--bg-highlight, var(--card-bg, #fff))",
+                color: "var(--text-main)",
+                cursor: "pointer",
+              }}
+            >
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.375rem",
+                  fontSize: "0.6875rem",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.03em",
+                  color: "var(--success, #10b981)",
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: "6px",
+                    height: "6px",
+                    borderRadius: "50%",
+                    background: "currentColor",
+                  }}
+                />
+                {relativeUsage(api)}
+              </span>
+              <span
+                style={{
+                  fontSize: "0.875rem",
+                  fontWeight: 600,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {api.name}
+              </span>
+              <span
+                style={{
+                  fontSize: "0.75rem",
+                  color: "var(--muted, #6b7280)",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {api.provider?.name ?? "Unknown provider"}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -18,6 +18,7 @@ import {
   type DensityPreference,
 } from "../utils/density";
 import CompareDrawer from "../components/CompareDrawer";
+import RecentlyActiveRail from "../components/RecentlyActiveRail";
 
 export default function MarketplacePage(): JSX.Element {
   useDocumentTitle(
@@ -331,6 +332,9 @@ export default function MarketplacePage(): JSX.Element {
         </div>
         <SortDropdown value={sortParam} onChange={setSortParam} />
       </div>
+
+      {/* Rail of APIs with the most recent usage */}
+      <RecentlyActiveRail apis={MOCK_APIS} onSelect={handleViewDetails} />
 
       {/* Bottom: filters left, content right */}
       <div className="marketplace-layout">


### PR DESCRIPTION
Adds a horizontally scrollable "Recently active" rail to the Marketplace, surfacing APIs with the most recent usage.

- New `RecentlyActiveRail` component (accessible region, keyboard-operable cards, relative-time labels, design tokens + dark mode).
- Wired into `MarketplacePage` above the results grid; clicking a card opens the API details.
- Focused vitest suite covering ordering, limit, empty state, and onSelect (5 tests passing).

Closes #286