### PR TITLE
Polish API rating widget with 0-decimal display

### DIFF
--- a/src/components/StarRating.test.tsx
+++ b/src/components/StarRating.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import StarRating, { formatRating } from "./StarRating";
+
+describe("formatRating", () => {
+  afterEach(() => cleanup());
+
+  it("pads whole numbers to one decimal by default", () => {
+    expect(formatRating(4)).toBe("4.0");
+    expect(formatRating(5)).toBe("5.0");
+  });
+
+  it("rounds half-up consistently", () => {
+    expect(formatRating(4.25, 1)).toBe("4.3");
+    expect(formatRating(4.24, 1)).toBe("4.2");
+  });
+
+  it("supports a 0-decimal display", () => {
+    expect(formatRating(4.6, 0)).toBe("5");
+    expect(formatRating(4.4, 0)).toBe("4");
+  });
+
+  it("clamps out-of-range values to 0–5", () => {
+    expect(formatRating(-2)).toBe("0.0");
+    expect(formatRating(9)).toBe("5.0");
+  });
+
+  it("treats non-finite input as 0", () => {
+    expect(formatRating(NaN)).toBe("0.0");
+    expect(formatRating(Infinity)).toBe("0.0");
+  });
+});
+
+describe("StarRating", () => {
+  afterEach(() => cleanup());
+
+  it("renders an accessible label with the padded value", () => {
+    render(<StarRating value={4} />);
+    expect(screen.getByRole("img", { name: "Rated 4.0 out of 5" })).toBeTruthy();
+  });
+
+  it("shows the padded number in the visible label", () => {
+    render(<StarRating value={4.6} />);
+    expect(screen.getByText("4.6")).toBeTruthy();
+  });
+
+  it("can hide the numeric label", () => {
+    render(<StarRating value={4.6} hideNumber />);
+    expect(screen.queryByText("4.6")).toBeNull();
+  });
+});

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -1,0 +1,92 @@
+import type { CSSProperties } from "react";
+
+/**
+ * StarRating — a small, accessible rating widget.
+ *
+ * Polish goals (issue #285):
+ * - Round ratings consistently (half-up) so the same numeric value always
+ *   renders the same way.
+ * - Pad the display to a fixed number of decimals so values never jump width
+ *   in a list (e.g. "4.0", "4.6", "5.0" instead of "4", "4.6", "5").
+ *
+ * Accessibility (WCAG 2.1 AA):
+ * - Exposes a descriptive `aria-label` ("Rated 4.6 out of 5").
+ * - Star glyphs are decorative (`aria-hidden`); the padded number is the
+ *   accessible value.
+ * - Colour comes from design tokens so it stays legible in dark mode.
+ */
+
+const MAX_STARS = 5;
+
+export type StarRatingProps = {
+  /** Raw rating value, expected in the 0–5 range. Clamped defensively. */
+  value: number;
+  /** Decimal places for the displayed number. Defaults to 1 ("4.0"). */
+  decimals?: number;
+  /** Hide the numeric label and show stars only. */
+  hideNumber?: boolean;
+  /** Optional extra class for layout. */
+  className?: string;
+  style?: CSSProperties;
+};
+
+/**
+ * Round a rating consistently (half-up) to the given number of decimals and
+ * return a zero-padded fixed-width string.
+ *
+ * Exported so display logic can be unit-tested without rendering.
+ */
+export function formatRating(value: number, decimals = 1): string {
+  const safe = Number.isFinite(value) ? value : 0;
+  const clamped = Math.min(MAX_STARS, Math.max(0, safe));
+  // toFixed already rounds half-up for positive numbers and pads decimals.
+  return clamped.toFixed(Math.max(0, decimals));
+}
+
+export default function StarRating({
+  value,
+  decimals = 1,
+  hideNumber = false,
+  className,
+  style,
+}: StarRatingProps): JSX.Element {
+  const display = formatRating(value, decimals);
+  // Number of fully "lit" stars, rounded to the nearest whole star.
+  const litStars = Math.round(Math.min(MAX_STARS, Math.max(0, value || 0)));
+
+  return (
+    <span
+      className={className}
+      role="img"
+      aria-label={`Rated ${display} out of ${MAX_STARS}`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.25rem",
+        color: "var(--rating-color, #f59e0b)",
+        fontVariantNumeric: "tabular-nums",
+        ...style,
+      }}
+    >
+      <span aria-hidden="true" style={{ letterSpacing: "1px", lineHeight: 1 }}>
+        {Array.from({ length: MAX_STARS }, (_, i) =>
+          i < litStars ? "★" : "☆",
+        ).join("")}
+      </span>
+      {!hideNumber && (
+        <span
+          aria-hidden="true"
+          style={{
+            color: "var(--text-main)",
+            fontSize: "0.8125rem",
+            fontWeight: 600,
+            // Fixed width keeps numbers aligned in lists regardless of value.
+            minWidth: `${display.length}ch`,
+          }}
+        >
+          {display}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
Adds a reusable `StarRating` widget that rounds ratings consistently (half-up) and pads the display to a fixed decimal width so values don't jump in lists.

- `formatRating(value, decimals)` helper: clamps to 0–5, treats non-finite input as 0, rounds half-up, and zero-pads (e.g. `4` -> `4.0`, `4.6` with `decimals=0` -> `5`).
- Accessible widget: descriptive `aria-label`, decorative stars, tabular-nums + fixed width, design tokens for dark mode.
- 8 focused vitest cases covering rounding, padding, clamping, and rendering.

Closes #285