### PR TITLE
feat: pin API to dashboard

### DIFF
--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -14,6 +14,7 @@ import { useCollections } from "../state/collectionsStore";
 import type { APIItem } from "../data/mockApis";
 import RatingHistogram from "./RatingHistogram";
 import { useCompareStore, compareStore } from "../state/compareStore";
+import { usePinnedApis, pinnedApisStore } from "../state/pinnedApis";
 import Sparkline from "./Sparkline";
 
 // ─── Skeleton ────────────────────────────────────────────────────────────────
@@ -315,6 +316,57 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
   );
 }
 
+// ─── Pin button ───────────────────────────────────────────────────────────────
+
+/** Quick-menu button that pins/unpins an API to the dashboard. */
+function PinButton({ apiId }: { apiId: string }) {
+  const pinned = usePinnedApis();
+  const isPinned = pinned.has(apiId);
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); pinnedApisStore.toggle(apiId); }}
+      style={{
+        position: "absolute",
+        top: "48px",
+        right: "8px",
+        background: isPinned ? "var(--accent, rgba(78,133,255,0.9))" : "rgba(0,0,0,0.5)",
+        border: "none",
+        borderRadius: "50%",
+        width: "32px",
+        height: "32px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        zIndex: 10,
+        transition: "background 160ms ease, transform 160ms ease",
+        flexShrink: 0,
+      }}
+      onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.transform = "scale(1.1)")}
+      onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.transform = "scale(1)")}
+      aria-label={isPinned ? `Unpin ${apiId} from dashboard` : `Pin ${apiId} to dashboard`}
+      aria-pressed={isPinned}
+    >
+      {/* Pin icon */}
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill={isPinned ? "white" : "none"}
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="12" y1="17" x2="12" y2="22" />
+        <path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z" />
+      </svg>
+    </button>
+  );
+}
+
 // ─── ApiCard ─────────────────────────────────────────────────────────────────
 
 const EM_DASH = "—";
@@ -385,6 +437,9 @@ export default function ApiCard({
     >
       {/* Absolutely-positioned bookmark button in the top-right corner */}
       <BookmarkButton endpointId={api.id} />
+
+      {/* Pin/unpin button — below bookmark, top-right */}
+      <PinButton apiId={api.id} />
       
       {/* Compare button - absolutely positioned, top-left */}
       <button

--- a/src/state/pinnedApis.test.ts
+++ b/src/state/pinnedApis.test.ts
@@ -1,0 +1,163 @@
+/**
+ * pinnedApis.test.ts
+ *
+ * Tests for the pinnedApisStore external store and usePinnedApis hook.
+ * Covers: pin, unpin, toggle, isPinned, localStorage persistence,
+ *         duplicate pin guard, idempotent unpin, and _reset helper.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { pinnedApisStore, usePinnedApis } from "./pinnedApis";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = "callora_pinned_apis";
+
+function storedIds(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+  } catch {
+    return [];
+  }
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorage.clear();
+  pinnedApisStore._reset();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  pinnedApisStore._reset();
+});
+
+// ─── Store unit tests ─────────────────────────────────────────────────────────
+
+describe("pinnedApisStore", () => {
+  it("starts empty", () => {
+    expect(pinnedApisStore.getSnapshot().size).toBe(0);
+  });
+
+  it("pin adds an API id", () => {
+    pinnedApisStore.pin("api-1");
+    expect(pinnedApisStore.isPinned("api-1")).toBe(true);
+  });
+
+  it("pin is idempotent (duplicate ignored)", () => {
+    pinnedApisStore.pin("api-1");
+    pinnedApisStore.pin("api-1");
+    expect(pinnedApisStore.getSnapshot().size).toBe(1);
+  });
+
+  it("unpin removes an API id", () => {
+    pinnedApisStore.pin("api-1");
+    pinnedApisStore.unpin("api-1");
+    expect(pinnedApisStore.isPinned("api-1")).toBe(false);
+  });
+
+  it("unpin is idempotent when id is not pinned", () => {
+    expect(() => pinnedApisStore.unpin("not-pinned")).not.toThrow();
+    expect(pinnedApisStore.getSnapshot().size).toBe(0);
+  });
+
+  it("toggle pins an unpinned API", () => {
+    pinnedApisStore.toggle("api-2");
+    expect(pinnedApisStore.isPinned("api-2")).toBe(true);
+  });
+
+  it("toggle unpins a pinned API", () => {
+    pinnedApisStore.pin("api-2");
+    pinnedApisStore.toggle("api-2");
+    expect(pinnedApisStore.isPinned("api-2")).toBe(false);
+  });
+
+  it("isPinned returns false for unknown id", () => {
+    expect(pinnedApisStore.isPinned("unknown")).toBe(false);
+  });
+
+  it("multiple ids can be pinned independently", () => {
+    pinnedApisStore.pin("api-1");
+    pinnedApisStore.pin("api-2");
+    expect(pinnedApisStore.isPinned("api-1")).toBe(true);
+    expect(pinnedApisStore.isPinned("api-2")).toBe(true);
+    pinnedApisStore.unpin("api-1");
+    expect(pinnedApisStore.isPinned("api-1")).toBe(false);
+    expect(pinnedApisStore.isPinned("api-2")).toBe(true);
+  });
+});
+
+// ─── localStorage persistence ─────────────────────────────────────────────────
+
+describe("localStorage persistence", () => {
+  it("pin persists to localStorage", () => {
+    pinnedApisStore.pin("api-1");
+    expect(storedIds()).toContain("api-1");
+  });
+
+  it("unpin removes from localStorage", () => {
+    pinnedApisStore.pin("api-1");
+    pinnedApisStore.unpin("api-1");
+    expect(storedIds()).not.toContain("api-1");
+  });
+
+  it("toggle persists updated state", () => {
+    pinnedApisStore.toggle("api-3");
+    expect(storedIds()).toContain("api-3");
+    pinnedApisStore.toggle("api-3");
+    expect(storedIds()).not.toContain("api-3");
+  });
+
+  it("gracefully handles corrupt localStorage", () => {
+    // Simulate corrupt data by directly writing invalid JSON — the store
+    // ignores it on next initialisation and stays functional at runtime.
+    localStorage.setItem(STORAGE_KEY, "{not-valid-json}");
+    // The live store is already initialised; just ensure operations don't throw.
+    expect(() => pinnedApisStore.pin("api-safe")).not.toThrow();
+    expect(pinnedApisStore.isPinned("api-safe")).toBe(true);
+  });
+});
+
+// ─── usePinnedApis hook ───────────────────────────────────────────────────────
+
+describe("usePinnedApis hook", () => {
+  it("returns empty Set initially", () => {
+    const { result } = renderHook(() => usePinnedApis());
+    expect(result.current.size).toBe(0);
+  });
+
+  it("reflects pin action", () => {
+    const { result } = renderHook(() => usePinnedApis());
+    act(() => { pinnedApisStore.pin("api-hook"); });
+    expect(result.current.has("api-hook")).toBe(true);
+  });
+
+  it("reflects unpin action", () => {
+    const { result } = renderHook(() => usePinnedApis());
+    act(() => { pinnedApisStore.pin("api-hook"); });
+    act(() => { pinnedApisStore.unpin("api-hook"); });
+    expect(result.current.has("api-hook")).toBe(false);
+  });
+
+  it("reflects toggle action", () => {
+    const { result } = renderHook(() => usePinnedApis());
+    act(() => { pinnedApisStore.toggle("api-toggle"); });
+    expect(result.current.has("api-toggle")).toBe(true);
+    act(() => { pinnedApisStore.toggle("api-toggle"); });
+    expect(result.current.has("api-toggle")).toBe(false);
+  });
+
+  it("notifies all subscribers", () => {
+    const cb = vi.fn();
+    const unsub = pinnedApisStore.subscribe(cb);
+    pinnedApisStore.pin("api-sub");
+    expect(cb).toHaveBeenCalledTimes(1);
+    pinnedApisStore.unpin("api-sub");
+    expect(cb).toHaveBeenCalledTimes(2);
+    unsub();
+    pinnedApisStore.pin("api-sub");
+    expect(cb).toHaveBeenCalledTimes(2); // no more calls after unsub
+  });
+});

--- a/src/state/pinnedApis.ts
+++ b/src/state/pinnedApis.ts
@@ -1,0 +1,118 @@
+/**
+ * pinnedApis.ts
+ *
+ * External store for pinned API IDs.
+ * Uses useSyncExternalStore (same pattern as compareStore).
+ * Persists to localStorage under "callora_pinned_apis".
+ *
+ * Usage:
+ *   const pinned = usePinnedApis();          // Set<string>
+ *   pinnedApisStore.pin("weather-001");
+ *   pinnedApisStore.unpin("weather-001");
+ *   pinnedApisStore.toggle("weather-001");
+ *   pinnedApisStore.isPinned("weather-001"); // boolean
+ */
+
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "callora_pinned_apis";
+
+// ─── Internal state ───────────────────────────────────────────────────────────
+
+let state: Set<string> = new Set();
+
+try {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) state = new Set(parsed);
+  }
+} catch {
+  // Corrupt storage – start fresh
+}
+
+const listeners = new Set<() => void>();
+
+function persist() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...state]));
+  } catch {
+    // Storage quota exceeded – ignore
+  }
+}
+
+function emitChange() {
+  for (const listener of listeners) listener();
+}
+
+// ─── Store ───────────────────────────────────────────────────────────────────
+
+export const pinnedApisStore = {
+  pin(apiId: string): void {
+    if (state.has(apiId)) return;
+    state = new Set([...state, apiId]);
+    persist();
+    emitChange();
+  },
+
+  unpin(apiId: string): void {
+    if (!state.has(apiId)) return;
+    state = new Set([...state].filter((id) => id !== apiId));
+    persist();
+    emitChange();
+  },
+
+  toggle(apiId: string): void {
+    state.has(apiId)
+      ? pinnedApisStore.unpin(apiId)
+      : pinnedApisStore.pin(apiId);
+  },
+
+  isPinned(apiId: string): boolean {
+    return state.has(apiId);
+  },
+
+  /** For testing: reset store to empty (does not touch localStorage). */
+  _reset(): void {
+    state = new Set();
+    emitChange();
+  },
+
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    // Cross-tab sync
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && e.newValue) {
+        try {
+          const parsed = JSON.parse(e.newValue);
+          if (Array.isArray(parsed)) {
+            state = new Set(parsed);
+            emitChange();
+          }
+        } catch {
+          // ignore
+        }
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(listener);
+      window.removeEventListener("storage", onStorage);
+    };
+  },
+
+  getSnapshot(): Set<string> {
+    return state;
+  },
+};
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/** Returns the current Set of pinned API IDs. Triggers re-render on change. */
+export function usePinnedApis(): Set<string> {
+  return useSyncExternalStore(
+    pinnedApisStore.subscribe,
+    pinnedApisStore.getSnapshot,
+    pinnedApisStore.getSnapshot
+  );
+}


### PR DESCRIPTION
feat: pin/unpin API from ApiCard quick menu
  
  Adds a pin button to each ApiCard so users can pin/unpin APIs to the dashboard directly from
  the marketplace.
  
  Changes
  
  - src/state/pinnedApis.ts — new external store (useSyncExternalStore) persisting pinned API IDs
  to localStorage. Exports pinnedApisStore (pin/unpin/toggle/isPinned) and usePinnedApis() hook.
  Cross-tab sync included.
  - src/components/ApiCard.tsx — new PinButton component mounted below the BookmarkButton
  (top-right). Filled accent when pinned, dark when unpinned. Accessible: aria-label,
  aria-pressed.
  - src/state/pinnedApis.test.ts — 18 focused tests covering store operations, idempotency,
  localStorage persistence, corrupt storage resilience, and hook reactivity.
  
  Testing
  
  ✓ src/state/pinnedApis.test.ts  18/18 passed
  
  No new TypeScript errors introduced.

closes #256