### PR TITLE
feat: add Copy-as-cURL button to endpoint cards

### DIFF
--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -15,6 +15,7 @@ import { useRecentlyViewed } from "../hooks/useRecentlyViewed";
 import { API_BASE_URL, LOADING_DELAY_MS } from "../config/constants";
 import EndpointGroupHover, { type EndpointGroupPreview } from "../components/EndpointGroupHover";
 import RatingHistogram from "../components/RatingHistogram";
+import CopyCurlButton from "../components/CopyCurlButton";
 
 /**
  * ApiDetailPage Component
@@ -739,6 +740,13 @@ print(data)`;
                                   <Icons.ExternalLink size={14} />
                                   <span>Insomnia</span>
                                 </button>
+                                <CopyCurlButton
+                                  className="icon-button"
+                                  request={{
+                                    method: ep.method || "GET",
+                                    url: `${API_BASE_URL}${ep.url}`,
+                                  }}
+                                />
                               </div>
                             </div>
                           </div>

--- a/src/utils/toCurl.test.ts
+++ b/src/utils/toCurl.test.ts
@@ -44,4 +44,20 @@ describe("toCurl", () => {
     });
     expect(out).toContain(`--data 'it'\\''s fine'`);
   });
+
+  it("handles empty headers object without emitting -H flags", () => {
+    const out = toCurl({
+      url: "https://api.example.com/v1/ping",
+      headers: {},
+    });
+    expect(out).not.toContain("-H");
+  });
+
+  it("escapes single quotes in header values safely", () => {
+    const out = toCurl({
+      url: "https://api.example.com/v1/data",
+      headers: { "X-Note": "don't fail" },
+    });
+    expect(out).toContain(`-H 'X-Note: don'\\''t fail'`);
+  });
 });


### PR DESCRIPTION
- Wire CopyCurlButton into endpoint-client-buttons in ApiDetailPage
- Extend toCurl tests: empty headers, special chars in header values





Closes #383 