### PR TITLE
feat: tag chips click-to-filter (#360)

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -21,7 +21,7 @@ describe("ApiCard Accessibility and Context Layouts", () => {
     name: "Stellar Metering API",
     endpoint: "/api/v1/meter",
     description: "A mock API for testing.",
-    tags: ["mock"],
+    tags: ["weather", "forecast", "geo"],
     pricePerRequest: 0.01,
   };
 
@@ -35,5 +35,56 @@ describe("ApiCard Accessibility and Context Layouts", () => {
 
     expect(screen.getByRole("menu")).toBeDefined();
     expect(screen.getByText("Copy Endpoint URL")).toBeDefined();
+  });
+
+  it("renders tag chips with correct ARIA labels", () => {
+    render(<ApiCard api={mockApi} />);
+
+    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
+    const forecastChip = screen.getByLabelText("Filter marketplace by tag forecast");
+    const geoChip = screen.getByLabelText("Filter marketplace by tag geo");
+
+    expect(weatherChip).toBeDefined();
+    expect(forecastChip).toBeDefined();
+    expect(geoChip).toBeDefined();
+  });
+
+  it("calls onTagClick when a tag chip is clicked", () => {
+    const handleTagClick = vi.fn();
+    render(<ApiCard api={mockApi} onTagClick={handleTagClick} />);
+
+    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
+    fireEvent.click(weatherChip);
+
+    expect(handleTagClick).toHaveBeenCalledTimes(1);
+    expect(handleTagClick).toHaveBeenCalledWith("weather");
+  });
+
+  it("marks the active tag chip as pressed", () => {
+    render(<ApiCard api={mockApi} activeTag="weather" />);
+
+    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
+    expect(weatherChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("does not mark non-active tag chips as pressed", () => {
+    render(<ApiCard api={mockApi} activeTag="weather" />);
+
+    const forecastChip = screen.getByLabelText("Filter marketplace by tag forecast");
+    expect(forecastChip.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("handles case-insensitive active tag matching", () => {
+    render(<ApiCard api={mockApi} activeTag="WEATHER" />);
+
+    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
+    expect(weatherChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders tag chips even when no activeTag is set", () => {
+    render(<ApiCard api={mockApi} />);
+
+    const chips = screen.getAllByRole("button", { name: /Filter marketplace by tag/ });
+    expect(chips.length).toBe(3);
   });
 });

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -18,7 +18,8 @@ import RatingHistogram from "./RatingHistogram";
 import { useCompareStore, compareStore } from "../state/compareStore";
 import { usePinnedApis, pinnedApisStore } from "../state/pinnedApis";
 import Sparkline from "./Sparkline";
-import { TagIcon, ClockIcon, BoltIcon } from "./icons";
+import WhyApi from "./WhyApi";
+import { ClockIcon, BoltIcon } from "./icons";
 
 // ─── Skeleton ────────────────────────────────────────────────────────────────
 
@@ -662,22 +663,12 @@ export default function ApiCard({
         style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
       >
         {((api.tags as string[]) || []).slice(0, 4).map((t: string) => (
-          <span
+          <TagChip
             key={t}
-            style={{
-              fontSize: 12,
-              color: "var(--muted)",
-              background: "rgba(255,255,255,0.02)",
-              padding: "4px 8px",
-              borderRadius: 8,
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-            }}
-          >
-            <TagIcon size={16} />
-            {t}
-          </span>
+            tag={t}
+            active={activeTag?.toLowerCase() === t.toLowerCase()}
+            onClick={onTagClick}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary

Closes #360

Replaces plain `<span>` tags in `ApiCard` with the existing `TagChip` component to enable click-to-filter functionality on marketplace tag chips.

## Changes

- **`ApiCard.tsx`**: Replace inline-styled span tags with `<TagChip>` components using `onClick` and `active` props with case-insensitive matching
- **`ApiCard.tsx`**: Add missing `WhyApi` import (pre-existing bug)
- **`ApiCard.tsx`**: Remove unused `TagIcon` import
- **`ApiCard.test.tsx`**: Add 6 new tests covering tag rendering, click callbacks, active state, case insensitivity, and edge cases

## Testing
- 7/7 ApiCard tests pass
- Full test suite: 45/53 pass (all 8 failures are pre-existing and unrelated)