### PR TITLE
Feat: recently active rail

### DIFF
--- a/docs/RecentlyActiveRail.md
+++ b/docs/RecentlyActiveRail.md
@@ -1,0 +1,42 @@
+# RecentlyActiveRail Component
+
+`src/components/RecentlyActiveRail.tsx`
+
+The `RecentlyActiveRail` component provides a horizontally scrollable rail highlighting recently active APIs on the Marketplace page. This helps developers discover actively-maintained, high-demand APIs at a glance.
+
+---
+
+## Features
+
+- **Dynamic Sorting**: Automatically ranks APIs based on creation/usage timestamp (`createdAt`) with usage volume (`usageCount`) as a tiebreaker.
+- **Relative Time formatting**: Formats dates into compact relative timestamps (e.g. "today", "1d ago", "3d ago", "1mo ago").
+- **Horizontal Scroll & Snap**: Smooth horizontal scrolling with CSS scroll-snap for touch and mouse interactions.
+- **Accessible (WCAG 2.1 AA)**:
+  - Accessible region container with `aria-label="Recently active APIs"`.
+  - Native `<button>` elements for complete keyboard focusability and interaction.
+  - Informative screen reader labels describing API name, provider, and relative active time.
+- **Dark Mode Compatibility**: Uses standard CSS design variables (`var(--text-main)`, `var(--border-subtle)`, `var(--bg-highlight)`).
+
+---
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `apis` | `APIItem[]` | Required | Source list of APIs to rank and display |
+| `limit` | `number` | `8` | Maximum number of cards shown in the rail |
+| `onSelect` | `(api: APIItem) => void` | Optional | Callback when an API card is activated |
+
+---
+
+## Usage
+
+```tsx
+import RecentlyActiveRail from "../components/RecentlyActiveRail";
+
+<RecentlyActiveRail
+  apis={mockApis}
+  limit={8}
+  onSelect={(api) => navigate(`/marketplace/${api.id}`)}
+/>
+```

--- a/src/components/RecentlyActiveRail.test.tsx
+++ b/src/components/RecentlyActiveRail.test.tsx
@@ -42,6 +42,27 @@ describe("RecentlyActiveRail", () => {
     expect(buttons[2].textContent).toContain("Bravo");
   });
 
+  it("breaks ties with usageCount when dates match", () => {
+    const tieApis = [
+      makeApi({ id: "t1", name: "Tie Low", createdAt: "2026-06-01", usageCount: 5 }),
+      makeApi({ id: "t2", name: "Tie High", createdAt: "2026-06-01", usageCount: 500 }),
+    ];
+    render(<RecentlyActiveRail apis={tieApis} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0].textContent).toContain("Tie High");
+    expect(buttons[1].textContent).toContain("Tie Low");
+  });
+
+  it("handles missing or invalid createdAt gracefully", () => {
+    const fallbackApis = [
+      makeApi({ id: "f1", name: "No Date API", createdAt: undefined }),
+      makeApi({ id: "f2", name: "Invalid Date API", createdAt: "invalid-date" }),
+    ];
+    render(<RecentlyActiveRail apis={fallbackApis} />);
+    expect(screen.getByText("No Date API")).toBeTruthy();
+    expect(screen.getAllByText("recently").length).toBe(2);
+  });
+
   it("respects the limit prop", () => {
     render(<RecentlyActiveRail apis={apis} limit={2} />);
     expect(screen.getAllByRole("button")).toHaveLength(2);

--- a/src/components/RecentlyActiveRail.tsx
+++ b/src/components/RecentlyActiveRail.tsx
@@ -43,15 +43,18 @@ export default function RecentlyActiveRail({
 }: RecentlyActiveRailProps): JSX.Element | null {
   // Rank by most recent creation/usage, then by raw usage volume as a tiebreak.
   const items = useMemo(() => {
-    return apis
-      .slice()
+    const withTimestamps = apis.map(api => ({
+      api,
+      ts: Date.parse(api.createdAt ?? "1970-01-01")
+    }));
+
+    return withTimestamps
       .sort((a, b) => {
-        const da = Date.parse(a.createdAt ?? "1970-01-01");
-        const db = Date.parse(b.createdAt ?? "1970-01-01");
-        if (db !== da) return db - da;
-        return (b.usageCount ?? 0) - (a.usageCount ?? 0);
+        if (b.ts !== a.ts) return b.ts - a.ts;
+        return (b.api.usageCount ?? 0) - (a.api.usageCount ?? 0);
       })
-      .slice(0, Math.max(0, limit));
+      .slice(0, Math.max(0, limit))
+      .map(item => item.api);
   }, [apis, limit]);
 
   if (items.length === 0) return null;

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -20,6 +20,7 @@ import {
 } from "../utils/density";
 import CompareDrawer from "../components/CompareDrawer";
 import RecentlyActiveRail from "../components/RecentlyActiveRail";
+import { useCompareStore } from "../state/compareStore";
 
 export default function MarketplacePage(): JSX.Element {
   const { apis } = useCompareStore();


### PR DESCRIPTION
Closes #385

Adds a 'Recently active' rail on the Marketplace page for the GrantFox FWC26 campaign.

## Changes Included
- **New Component (`src/components/RecentlyActiveRail.tsx`)**:
  - Displays a horizontally scrollable rail of recent APIs.
  - Formats creation/activity into relative time labels (`today`, `1d ago`, `3d ago`, `1mo ago`).
  - Sorts APIs descending by `createdAt` date timestamp, with `usageCount` used as a tiebreaker.
  - Fully accessible (WCAG 2.1 AA) using native focusable `<button>` cards and informative `aria-label` descriptors.
- **Marketplace Page (`src/pages/MarketplacePage.tsx`)**:
  - Integrated `RecentlyActiveRail` above the filtered API results layout.
- **Unit Tests (`src/components/RecentlyActiveRail.test.tsx`)**:
  - 7 focused unit tests added covering rendering, sorting, tiebreaking, limit truncation, fallback date parsing, and click handlers.
- **Documentation (`docs/RecentlyActiveRail.md`)**:
  - Complete documentation detailing props, ranking logic, accessibility, and usage examples.

## Verification
- Ran Vitest suite: `npx vitest run src/components/RecentlyActiveRail.test.tsx` (7/7 tests passed).