### PR TITLE
feat: filters collapse persistence

### DIFF
--- a/docs/filters-collapse-description.md
+++ b/docs/filters-collapse-description.md
@@ -86,3 +86,23 @@ These do not affect the functionality of the changes in this PR.
 PR: https://github.com/CalloraOrg/Callora-Frontend/pull/337
 
 closes #254
+
+## Regression fix (2026-07-24)
+
+A merge conflict in a later PR dropped part of this feature from `FiltersSidebar.tsx`: the
+`ChevronIcon`/`usePersistedState` imports and the entire "Price range" section were lost, and the
+"Popularity" section was left outside of `FilterGroup` (so it no longer collapsed or persisted its
+state). The matching `.filter-group__header`, `.filter-group__chevron`, and `.filter-group__panel`
+styles were also dropped from `src/index.css`.
+
+This fix restores:
+- The "Price range" section wrapped in `FilterGroup` (`storageKey="price"`), including the
+  min/max validation error.
+- The "Popularity" section wrapped in `FilterGroup` (`storageKey="popularity"`) so it collapses
+  and persists like Categories and Price range.
+- The missing imports and collapsible-section CSS.
+
+The "Favorites" section intentionally remains a plain, non-collapsible `fieldset` — it was never
+part of the original collapsible set.
+
+closes #369

--- a/src/components/FiltersSidebar.tsx
+++ b/src/components/FiltersSidebar.tsx
@@ -1,5 +1,7 @@
-import { WarningIcon } from "./icons";
+import type { ReactNode } from "react";
+import { WarningIcon, ChevronIcon } from "./icons";
 import Dropdown from "./Dropdown";
+import { usePersistedState } from "../hooks/usePersistedState";
 
 const POPULARITY_OPTIONS = [
   { value: "any", label: "Any" },
@@ -20,7 +22,7 @@ export const ALL_CATEGORIES = [
 interface FilterGroupProps {
   title: string;
   storageKey: "categories" | "price" | "popularity";
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 function FilterGroup({ title, storageKey, children }: FilterGroupProps) {
@@ -109,22 +111,70 @@ export default function FiltersSidebar({
         </div>
       </FilterGroup>
 
-      <div style={{ marginBottom: 12 }}>
-          <fieldset className="filter-group">
-            <legend className="filter-legend">Popularity</legend>
-            <div className="filter-popularity" style={{ marginTop: 8 }}>
-              <Dropdown<PopularityValue>
-                id="filters-popularity"
-                value={popularity as PopularityValue}
-                options={POPULARITY_OPTIONS as unknown as { value: PopularityValue; label: string }[]}
-                onChange={(v) => setPopularity(v)}
-                label="Filter by popularity"
-                visibleLabel={null}
-                className="filter-dropdown"
-              />
-            </div>
-          </fieldset>
-      </div>
+      <FilterGroup title="Price range" storageKey="price">
+        <div className="filter-price" style={{ display: "flex", gap: 8 }}>
+          <input
+            id="min-price-input"
+            type="number"
+            min="0"
+            className={`filter-input ${minPrice !== null && maxPrice !== null && minPrice > maxPrice ? 'filter-input--invalid' : ''}`}
+            placeholder="min"
+            value={minPrice ?? ""}
+            onChange={(e) => {
+              const val = e.target.value === "" ? null : Math.max(0, Number(e.target.value));
+              setMinPrice(val);
+            }}
+            aria-invalid={minPrice !== null && maxPrice !== null && minPrice > maxPrice}
+            aria-describedby={minPrice !== null && maxPrice !== null && minPrice > maxPrice ? "price-range-error" : undefined}
+            style={{ width: "100%" }}
+          />
+          <input
+            id="max-price-input"
+            type="number"
+            min="0"
+            className={`filter-input ${minPrice !== null && maxPrice !== null && minPrice > maxPrice ? 'filter-input--invalid' : ''}`}
+            placeholder="max"
+            value={maxPrice ?? ""}
+            onChange={(e) => {
+              const val = e.target.value === "" ? null : Math.max(0, Number(e.target.value));
+              setMaxPrice(val);
+            }}
+            aria-invalid={minPrice !== null && maxPrice !== null && minPrice > maxPrice}
+            aria-describedby={minPrice !== null && maxPrice !== null && minPrice > maxPrice ? "price-range-error" : undefined}
+            style={{ width: "100%" }}
+          />
+        </div>
+        {minPrice !== null && maxPrice !== null && minPrice > maxPrice && (
+          <div
+            id="price-range-error"
+            style={{
+              color: "var(--danger)",
+              fontSize: "0.8rem",
+              marginTop: 6,
+              display: "flex",
+              alignItems: "center",
+              gap: 4
+            }}
+            role="alert"
+          >
+            <WarningIcon size={16} /> Min price cannot exceed max price.
+          </div>
+        )}
+      </FilterGroup>
+
+      <FilterGroup title="Popularity" storageKey="popularity">
+        <div className="filter-popularity">
+          <Dropdown<PopularityValue>
+            id="filters-popularity"
+            value={popularity as PopularityValue}
+            options={POPULARITY_OPTIONS as unknown as { value: PopularityValue; label: string }[]}
+            onChange={(v) => setPopularity(v)}
+            label="Filter by popularity"
+            visibleLabel={null}
+            className="filter-dropdown"
+          />
+        </div>
+      </FilterGroup>
 
       <div style={{ marginBottom: 12 }}>
           <fieldset className="filter-group">

--- a/src/index.css
+++ b/src/index.css
@@ -4217,6 +4217,61 @@ code,
   cursor: pointer;
 }
 
+/* ─── Filter Group Collapsible Styles ─────────────────────────────────────────── */
+.filter-group__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 180ms ease, border-color 180ms ease;
+}
+
+.filter-group__header:hover,
+.filter-group__header:focus-visible {
+  background: var(--line);
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.filter-group__chevron {
+  transition: transform 180ms ease;
+}
+
+.filter-group__chevron--collapsed {
+  transform: rotate(180deg);
+}
+
+.filter-group__panel {
+  padding: 8px 16px 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filter-group__header,
+  .filter-group__chevron {
+    transition: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .filter-group__header {
+    padding: 10px 14px;
+    font-size: 0.9rem;
+  }
+
+  .filter-group__panel {
+    padding: 6px 14px 0;
+  }
+}
+
 /* Button Spinner & Loading States */
 @keyframes spin {
   to {


### PR DESCRIPTION
## Summary
- Restores the "Price range" `FilterGroup` and the "Popularity" `FilterGroup` wrapper in `FiltersSidebar.tsx`, along with the `ChevronIcon` / `usePersistedState` imports, which were dropped in a prior merge.
- Restores the matching `.filter-group__header`, `.filter-group__chevron`, and `.filter-group__panel` styles in `src/index.css` (including reduced-motion and responsive rules).
- All three sections — Categories, Price range, Popularity — now collapse/expand independently and persist state to localStorage under `callora.filters.<section>.collapsed`. "Favorites" intentionally stays a plain, non-collapsible fieldset (it was never part of the collapsible set).

## Accessibility (WCAG 2.1 AA)
- `aria-expanded` / `aria-controls` on each section header.
- `hidden` attribute removes collapsed panels from the accessibility tree.
- Focus-visible outline uses `var(--accent)`.
- `prefers-reduced-motion` respected for chevron/header transitions.

## Test plan
- [x] `npx vitest run src/components/FiltersSidebar.test.tsx` — 16/16 passed
- [x] `npx vitest run` (full suite) — no new failures; 531/556 passing, same 25 pre-existing failures on `main` (MarketplacePage `useCompareStore`, ThemePlayground chai matcher, schema-validate) unrelated to this change
- [x] `npx tsc -b` — no new type errors introduced (pre-existing unrelated errors in `App.tsx` / `ApiDetailPage.tsx` untouched by this PR)

## Docs
- Updated `docs/filters-collapse-description.md` with a "Regression fix" section explaining what was lost and restored.

closes #369