### PR TITLE
feat: default code sample language

### DIFF
--- a/docs/default-code-language-description.md
+++ b/docs/default-code-language-description.md
@@ -1,0 +1,50 @@
+# Add default code sample language pref
+
+## Summary
+
+Adds a dedicated `src/state/userPrefs.ts` module that pins the user's preferred code sample
+language and applies it as the default across every `CodeExample` instance on the site, so
+picking a language once (e.g. Python) "sticks" the next time a code sample is shown — even for
+a different endpoint or a fresh page load.
+
+## Changes
+
+### `src/state/userPrefs.ts` (new)
+- `getDefaultCodeLanguage(): string | null` — reads the pinned language from localStorage.
+- `setDefaultCodeLanguage(language: string): void` — persists the pinned language.
+- SSR-safe (`typeof window` guard) and fails silently on parse errors / unavailable storage,
+  matching the pattern used by `usePersistedState` and `src/state/uiPrefs.ts`.
+- Storage key: `callora:codeExample:language` (unchanged from the previous implementation, so
+  existing users' preferences carry over without migration).
+
+### `src/components/CodeExample.tsx`
+- Replaced the generic `usePersistedState` call with `getDefaultCodeLanguage` /
+  `setDefaultCodeLanguage`, so the default-language behavior has one documented, testable,
+  directly-importable API instead of being embedded inline in the component.
+- Resolution order on mount: pinned preference (if valid for this snippet set) → this instance's
+  own `defaultLanguage` prop → first available language.
+- No change to component props or visible behavior.
+
+### Test Files
+- `src/state/userPrefs.test.ts` (new) — covers get/set, malformed JSON, and overwrite behavior.
+- `src/components/CodeExample.test.tsx` — unchanged, still passing (19/19), confirming the
+  refactor preserved existing behavior (persistence on selection, restoration on remount,
+  fallback when the pinned language isn't available in a given snippet set).
+
+## API/Visible Changes
+
+No breaking changes. `CodeExample`'s props are unchanged. The only new public API is
+`src/state/userPrefs.ts`'s two exported functions.
+
+## Accessibility
+
+No accessibility-relevant changes — tab roving/ARIA behavior in `CodeExample` is untouched.
+
+## Test Output
+
+```
+✓ src/state/userPrefs.test.ts (6 tests)
+✓ src/components/CodeExample.test.tsx (19 tests)
+```
+
+closes #398

--- a/src/components/CodeExample.tsx
+++ b/src/components/CodeExample.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Icons } from "../utils/icons";
-import { usePersistedState } from "../hooks/usePersistedState";
+import { getDefaultCodeLanguage, setDefaultCodeLanguage } from "../state/userPrefs";
 
 /**
  * CodeExample component with tabbed navigation for multiple code snippets.
- * 
+ *
  * Features:
  * - Tabbed navigation for multiple languages with roving tabindex
- * - Language persistence via usePersistedState hook
+ * - Default language pinned via userPrefs, shared across all CodeExample instances
  * - Copy-to-clipboard with visual feedback
  * - Full WCAG 2.1 AA accessibility
  * - Dark mode support via CSS custom properties
@@ -21,22 +21,29 @@ type CodeExampleProps = {
   defaultLanguage?: string;
 };
 
-const STORAGE_KEY = "callora:codeExample:language";
-
 export default function CodeExample({
   snippets,
   defaultLanguage,
 }: CodeExampleProps) {
   // Extract available languages from the snippets keys
   const languages = Object.keys(snippets);
-  
-  // Use persisted state for language selection
-  const [activeLanguage, setActiveLanguage] = usePersistedState<string>(
-    STORAGE_KEY,
-    defaultLanguage && defaultLanguage in snippets
+
+  // Pin the user's preferred language (if set and available here), otherwise
+  // fall back to this example's own defaultLanguage prop, then the first language.
+  const [activeLanguage, setActiveLanguageState] = useState<string>(() => {
+    const pinned = getDefaultCodeLanguage();
+    if (pinned && pinned in snippets) {
+      return pinned;
+    }
+    return defaultLanguage && defaultLanguage in snippets
       ? defaultLanguage
-      : languages[0] || ""
-  );
+      : languages[0] || "";
+  });
+
+  const setActiveLanguage = useCallback((language: string) => {
+    setActiveLanguageState(language);
+    setDefaultCodeLanguage(language);
+  }, []);
 
   // Validate persisted language is still in current languages list
   const resolvedLanguage = languages.includes(activeLanguage)

--- a/src/state/userPrefs.test.ts
+++ b/src/state/userPrefs.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDefaultCodeLanguage, setDefaultCodeLanguage } from './userPrefs';
+
+const STORAGE_KEY = 'callora:codeExample:language';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('userPrefs - default code sample language', () => {
+  describe('getDefaultCodeLanguage', () => {
+    it('returns null when no language is pinned', () => {
+      expect(getDefaultCodeLanguage()).toBeNull();
+    });
+
+    it('returns the pinned language when stored', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify('python'));
+      expect(getDefaultCodeLanguage()).toBe('python');
+    });
+
+    it('returns null when stored value is malformed JSON', () => {
+      localStorage.setItem(STORAGE_KEY, '{not valid json');
+      expect(getDefaultCodeLanguage()).toBeNull();
+    });
+  });
+
+  describe('setDefaultCodeLanguage', () => {
+    it('persists the language under the shared storage key', () => {
+      setDefaultCodeLanguage('javascript');
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify('javascript'));
+    });
+
+    it('overwrites a previously pinned language', () => {
+      setDefaultCodeLanguage('python');
+      setDefaultCodeLanguage('bash');
+      expect(getDefaultCodeLanguage()).toBe('bash');
+    });
+
+    it('round-trips through getDefaultCodeLanguage', () => {
+      setDefaultCodeLanguage('typescript');
+      expect(getDefaultCodeLanguage()).toBe('typescript');
+    });
+  });
+});

--- a/src/state/userPrefs.ts
+++ b/src/state/userPrefs.ts
@@ -1,0 +1,33 @@
+// src/state/userPrefs.ts
+
+// Default code sample language, shared across all CodeExample instances site-wide.
+const DEFAULT_CODE_LANGUAGE_KEY = "callora:codeExample:language";
+
+export function getDefaultCodeLanguage(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(DEFAULT_CODE_LANGUAGE_KEY);
+    return stored !== null ? (JSON.parse(stored) as string) : null;
+  } catch {
+    // Silently fail if JSON parse fails or localStorage is unavailable
+    return null;
+  }
+}
+
+export function setDefaultCodeLanguage(language: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      DEFAULT_CODE_LANGUAGE_KEY,
+      JSON.stringify(language),
+    );
+  } catch {
+    // Silently fail if localStorage is unavailable (private mode, quota exceeded, etc.)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/state/userPrefs.ts` with `getDefaultCodeLanguage()` / `setDefaultCodeLanguage()`, extracting the code-sample language persistence logic out of `CodeExample.tsx` into a dedicated, directly-testable module (matching the pattern already established by `src/state/uiPrefs.ts`).
- `CodeExample.tsx` now resolves its active language as: pinned preference (if valid for this snippet set) → this instance's own `defaultLanguage` prop → first available language. Selecting a language pins it as the default across every `CodeExample` on the site.
- Storage key (`callora:codeExample:language`) is unchanged, so any previously pinned language carries over with no migration needed.
- No breaking changes to `CodeExample`'s props or visible behavior.

## Test plan
- [x] `npx vitest run src/state/userPrefs.test.ts` — 6/6 passed (new)
- [x] `npx vitest run src/components/CodeExample.test.tsx` — 19/19 passed (unchanged, confirms the refactor preserved existing behavior)
- [x] `npx vitest run` (full suite) — no new failures introduced; all failures present are pre-existing on `main` and unrelated to this change (Breadcrumb, ExternalLink, FiltersBottomSheet, MarketplacePage, ThemePlayground, schema-validate)
- [x] `npx tsc -b` — no new type errors

## Docs
- Added `docs/default-code-language-description.md` describing the new API and behavior.

closes #398