### PR TITLE
Add pattern-based status badges for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - Theme playground for previewing primary/accent/surface tokens live
 - Dev proxy to backend at `http://localhost:3000` for `/api`
 - **Global Command Palette**: Instantly jump to views, search APIs by name, cycle/toggle light & dark themes, or trigger vault deposits. Use `Cmd+K` on macOS or `Ctrl+K` on Windows/Linux to open.
+- **Pattern-based status badges**: Status indicators now use distinct textures in addition to color so they remain understandable for color-blind users and in grayscale displays.
 
 ## Keyboard shortcuts
 

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -101,4 +101,12 @@ describe('StatusBadge', () => {
     const dot = badge.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();
   });
+
+  it('exposes the pattern semantics for non-color status cues', () => {
+    render(<StatusBadge status="error" />);
+    const badge = screen.getByRole('img', { name: 'Error' }) as HTMLElement;
+    expect(badge.getAttribute('data-status')).toBe('error');
+    expect(badge.getAttribute('data-pattern')).toBe('stripes');
+    expect(badge.getAttribute('aria-description')).toContain('diagonal stripes');
+  });
 });

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -39,6 +39,26 @@ const DEFAULT_LABELS: Record<StatusVariant, string> = {
   pending: 'Pending',
 };
 
+const PATTERN_DESCRIPTIONS: Record<StatusVariant, string> = {
+  success: 'solid baseline',
+  operational: 'solid baseline',
+  error: 'diagonal stripes',
+  down: 'diagonal stripes',
+  warning: 'opposite diagonal stripes',
+  degraded: 'opposite diagonal stripes',
+  pending: 'dot pattern',
+};
+
+const PATTERN_KEYS: Record<StatusVariant, string> = {
+  success: 'baseline',
+  operational: 'baseline',
+  error: 'stripes',
+  down: 'stripes',
+  warning: 'opposite-stripes',
+  degraded: 'opposite-stripes',
+  pending: 'dots',
+};
+
 /** Small circle indicator rendered before the text label. */
 function Dot({ status }: { status: StatusVariant }) {
   return (
@@ -65,11 +85,15 @@ type Props = {
 
 export function StatusBadge({ status, label, className }: Props) {
   const visibleLabel = label ?? DEFAULT_LABELS[status];
+  const patternDescription = PATTERN_DESCRIPTIONS[status];
+  const patternKey = PATTERN_KEYS[status];
 
   return (
     <span
       // Pattern class from patterns.css provides the texture overlay
       className={[`sb-pattern-${status}`, className].filter(Boolean).join(' ')}
+      data-status={status}
+      data-pattern={patternKey}
       style={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -91,6 +115,7 @@ export function StatusBadge({ status, label, className }: Props) {
       // role="status" would be too assertive for a static badge.
       role="img"
       aria-label={visibleLabel}
+      aria-description={`Pattern-based status badge: ${visibleLabel} with ${patternDescription}`}
     >
       <Dot status={status} />
       {visibleLabel}

--- a/src/pages/ThemePlayground.tsx
+++ b/src/pages/ThemePlayground.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
+import StatusBadge from "../components/StatusBadge";
 import TokenEditor from "../components/TokenEditor";
 
 const DEFAULT_TOKENS = {
@@ -118,6 +119,18 @@ export default function ThemePlayground() {
               Use this sandbox to tune a new visual direction while preserving
               accessible contrast.
             </p>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "0.5rem",
+                marginBottom: "1rem",
+              }}
+            >
+              <StatusBadge status="operational" label="Live" />
+              <StatusBadge status="warning" label="Needs review" />
+              <StatusBadge status="error" label="Blocked" />
+            </div>
             <div className="theme-playground__actions-inline">
               <button
                 className="primary-button"


### PR DESCRIPTION
Improves status badges so they remain understandable without relying on color alone by exposing explicit pattern semantics and descriptive ARIA text.
Adds regression tests for the new non-color cues.
Shows the updated badges in the GrantFox theme playground for visible review.
To finish the remote handoff
If you want to push and open the PR from your machine, run:

Closes #365