### PR TITLE
fix: ApiUsage skeleton parity

### DIFF
--- a/src/ApiUsage.skeleton.test.tsx
+++ b/src/ApiUsage.skeleton.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ApiUsageCallHistory } from './ApiUsage';
+
+const calls = Array.from({ length: 3 }, (_, index) => ({
+  id: String(index),
+  timestamp: new Date('2026-07-24T10:00:00Z'),
+  endpoint: `/api/v1/example/${index}`,
+  status: 'success' as const,
+  responseTime: 120,
+  cost: 0.001,
+}));
+
+function callHistory(isLoading: boolean) {
+  return (
+    <ApiUsageCallHistory
+      calls={calls}
+      expandedCall={null}
+      isLoading={isLoading}
+      onToggleExpand={() => {}}
+    />
+  );
+}
+
+describe('ApiUsage call history skeleton', () => {
+  afterEach(cleanup);
+
+  it('renders the same number of loading rows as loaded call records', () => {
+    const { container, rerender } = render(callHistory(true));
+
+    expect(container.querySelectorAll('.table-row')).toHaveLength(calls.length);
+
+    rerender(callHistory(false));
+
+    expect(container.querySelectorAll('.table-row')).toHaveLength(calls.length);
+  });
+
+  it('matches the six-column shape and action height of loaded rows', () => {
+    const { container } = render(callHistory(true));
+
+    container.querySelectorAll('.table-row').forEach(row => {
+      expect(row.querySelectorAll('.skeleton-cell-slot')).toHaveLength(6);
+      expect(row.querySelector('.skeleton-cell--endpoint')).toBeTruthy();
+      expect(row.querySelector('.skeleton-cell--action')).toBeTruthy();
+    });
+  });
+
+  it('announces loading and clears the busy state after content loads', () => {
+    const { container, rerender } = render(callHistory(true));
+    const table = container.querySelector('.call-history-table');
+
+    expect(table?.getAttribute('aria-busy')).toBe('true');
+    expect(table?.getAttribute('aria-describedby')).toBe('call-history-loading');
+    expect(screen.getByRole('status').textContent).toBe('Loading call history.');
+
+    rerender(callHistory(false));
+
+    expect(table?.getAttribute('aria-busy')).toBe('false');
+    expect(table?.getAttribute('aria-describedby')).toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -192,6 +192,64 @@ function formatTimestamp(date: Date) {
   }).format(date);
 }
 
+type CallHistoryTableProps = {
+  calls: CallRecord[];
+  expandedCall: string | null;
+  isLoading: boolean;
+  onToggleExpand: (id: string) => void;
+};
+
+export function ApiUsageCallHistory({
+  calls,
+  expandedCall,
+  isLoading,
+  onToggleExpand,
+}: CallHistoryTableProps) {
+  return (
+    <>
+      {isLoading && (
+        <p
+          id="call-history-loading"
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+        >
+          Loading call history.
+        </p>
+      )}
+      <div
+        className="call-history-table"
+        aria-busy={isLoading}
+        aria-describedby={isLoading ? 'call-history-loading' : undefined}
+      >
+        <div className="table-header">
+          <span>Timestamp</span>
+          <span>Endpoint</span>
+          <span>Status</span>
+          <span>Response Time</span>
+          <span>Cost</span>
+          <span>Actions</span>
+        </div>
+
+        {isLoading ? (
+          <SkeletonRow rows={calls.length} />
+        ) : calls.length === 0 ? (
+          <EmptyState message="No call records match the selected filter." />
+        ) : (
+          calls.map(call => (
+            <CallHistoryRow
+              key={call.id}
+              call={call}
+              expanded={expandedCall === call.id}
+              onToggleExpand={onToggleExpand}
+            />
+          ))
+        )}
+      </div>
+    </>
+  );
+}
+
 
 export default function ApiUsage() {
   const { trackFetch } = useFetchTracker();
@@ -754,31 +812,12 @@ export default function ApiUsage() {
           {filterResetMessage}
         </p>
 
-        <div className="call-history-table" aria-busy={isLoading}>
-           <div className="table-header">
-             <span>Timestamp</span>
-             <span>Endpoint</span>
-             <span>Status</span>
-             <span>Response Time</span>
-             <span>Cost</span>
-             <span>Actions</span>
-           </div>
-
-           {isTableLoading ? (
-             <SkeletonRow rows={5} />
-           ) : filteredCallHistory.length === 0 ? (
-             <EmptyState message="No call records match the selected filter." />
-           ) : (
-             filteredCallHistory.map(call => (
-               <CallHistoryRow
-                 key={call.id}
-                 call={call}
-                 expanded={expandedCall === call.id}
-                 onToggleExpand={id => setExpandedCall(expandedCall === id ? null : id)}
-               />
-             ))
-           )}
-         </div>
+        <ApiUsageCallHistory
+          calls={filteredCallHistory}
+          expandedCall={expandedCall}
+          isLoading={isTableLoading}
+          onToggleExpand={id => setExpandedCall(expandedCall === id ? null : id)}
+        />
       </div>
 
       {/* Integration Guide */}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment } from "react";
+import React, { CSSProperties } from "react";
 
 interface SkeletonProps {
   width?: string | number;
@@ -31,24 +31,30 @@ export default function Skeleton({
 }
 
 
-// Row variant for table loading
-export function SkeletonRow({ rows = 5 }: { rows?: number }) {
-  const rowSkeleton = (
-    <div className="table-row">
-      <Skeleton width="60%" height="16px" className="skeleton-cell" />
-      <Skeleton width="85%" height="16px" className="skeleton-cell" />
-      <Skeleton width="50%" height="16px" className="skeleton-cell" />
-      <Skeleton width="45%" height="16px" className="skeleton-cell" />
-      <Skeleton width="35%" height="16px" className="skeleton-cell" />
-      <Skeleton width="50%" height="16px" className="skeleton-cell" />
-    </div>
-  );
+const TABLE_CELL_VARIANTS = [
+  "timestamp",
+  "endpoint",
+  "status",
+  "response-time",
+  "cost",
+  "action",
+] as const;
+
+// Mirrors the six cells and responsive span wrappers in CallHistoryRow.
+export function SkeletonRow({ rows = 3 }: { rows?: number }) {
   return (
     <>
       {Array.from({ length: rows }).map((_, i) => (
-        <Fragment key={i}>{rowSkeleton}</Fragment>
+        <div className="table-row" aria-hidden="true" key={i}>
+          {TABLE_CELL_VARIANTS.map((variant) => (
+            <span className="skeleton-cell-slot" key={variant}>
+              <Skeleton
+                className={`skeleton-cell skeleton-cell--${variant}`}
+              />
+            </span>
+          ))}
+        </div>
       ))}
     </>
   );
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -2769,6 +2769,42 @@ code,
     border-bottom: none;
 }
 
+.skeleton-cell-slot {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+.skeleton-cell {
+    height: 16px;
+}
+
+.skeleton-cell--timestamp {
+    width: 60%;
+}
+
+.skeleton-cell--endpoint {
+    width: 85%;
+}
+
+.skeleton-cell--status {
+    width: 50%;
+}
+
+.skeleton-cell--response-time {
+    width: 45%;
+}
+
+.skeleton-cell--cost {
+    width: 35%;
+}
+
+.skeleton-cell--action {
+    width: 56px;
+    height: 48px;
+    border-radius: 6px;
+}
+
 .endpoint-cell {
     font-family: "Courier New", monospace;
     font-size: 0.875rem;


### PR DESCRIPTION
The Call History loading state now uses the same row count, six-cell structure, responsive wrappers, and action height as the loaded data. It also reports the actual table loading state through `aria-busy` and a polite status message.

Verified with `npx vitest run src/ApiUsage.skeleton.test.tsx src/components/Skeleton.test.tsx` (5/5 passed). The full suite is 598/623 passing, with the same 25 failures as clean upstream `main`. `npm run build` has the same 12 pre-existing parser errors in `App.tsx` and `ApiDetailPage.tsx`; the repository has no lint script. A browser capture was not possible because upstream `main` does not compile.

Closes #424