### PR TITLE
feat: add pin-to-dashboard support for ApiCard and dashboard pinned API list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - Dashboard (usage stats, vault balance)
 - Screen-reader-friendly dashboard usage gauge with visible usage state and remaining allowance
 - Marketplace (browse and compare APIs)
+- Pinned APIs on the dashboard for fast access to saved marketplace APIs
 - Billing (USDC deposit, Stellar settlement, transaction tracking)
 - API Usage analytics view
 - 500 error page with retry flow

--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -3,6 +3,7 @@ import ApiCard from "./ApiCard";
 import { describe, it, expect, vi } from "vitest";
 import React from "react";
 import type { APIItem } from "../data/mockApis";
+import { pinnedApisStore } from "../state/pinnedApis";
 
 vi.mock("../state/collectionsStore", () => ({
   useCollections: () => ({
@@ -86,5 +87,19 @@ describe("ApiCard Accessibility and Context Layouts", () => {
 
     const chips = screen.getAllByRole("button", { name: /Filter marketplace by tag/ });
     expect(chips.length).toBe(3);
+  });
+
+  it("toggles pin state when the pin button is clicked", () => {
+    pinnedApisStore._reset();
+    render(<ApiCard api={mockApi} />);
+
+    const pinButton = screen.getByRole("button", { name: /Pin api-1 to dashboard/i });
+    expect(pinButton).toBeTruthy();
+    expect(pinButton.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(pinButton);
+
+    expect(pinButton.getAttribute("aria-pressed")).toBe("true");
+    expect(pinButton.getAttribute("aria-label")).toBe("Unpin api-1 from dashboard");
   });
 });

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -580,7 +580,7 @@ export default function ApiCard({
          aria-label={isCompared ? `Remove ${api.name} from comparison` : `Add ${api.name} to comparison`}
          aria-pressed={isCompared}
        >
-         {isCompared ? "Pinned" : "Pin"}
+         {isCompared ? "Compared" : "Compare"}
        </button>
 
 

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -149,6 +149,71 @@
   padding: 20px;
 }
 
+.dashboard-card--pinned {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dashboard-card__pinned-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.dashboard-card__pinned-count {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.dashboard-card__pinned-empty {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.dashboard-pinned-list {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-pinned-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+}
+
+.dashboard-pinned-item__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.dashboard-pinned-item__content strong {
+  font-size: 0.95rem;
+}
+
+.dashboard-pinned-item__content span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.dashboard-pinned-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .activity-list {
   list-style: none;
   margin: 0;

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -5,11 +5,14 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Dashboard from './Dashboard';
 import { LOADING_DELAY_MS } from '../config/constants';
+import { pinnedApisStore } from '../state/pinnedApis';
 
 describe('Dashboard', () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    pinnedApisStore._reset();
+    window.localStorage.removeItem('callora_pinned_apis');
   });
 
   it('renders the accessible usage gauge from recent usage activity and vault balance', async () => {
@@ -33,5 +36,30 @@ describe('Dashboard', () => {
     expect(screen.getByRole('progressbar').getAttribute('aria-valuetext')).toBe(
       'Within limit: 12.5 of 50 USDC used, 37.5 USDC remaining, 25% used.',
     );
+  });
+
+  it('renders a pinned APIs section when APIs are pinned', () => {
+    pinnedApisStore.pin('weather-001');
+
+    render(
+      <MemoryRouter>
+        <Dashboard vaultBalance={100} walletBalance={20} openDeposit={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Pinned APIs')).toBeTruthy();
+    expect(screen.getByText('WeatherSim API')).toBeTruthy();
+    expect(screen.getByText('1 pinned')).toBeTruthy();
+  });
+
+  it('shows the pinned API empty state when nothing is pinned', () => {
+    render(
+      <MemoryRouter>
+        <Dashboard vaultBalance={100} walletBalance={20} openDeposit={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Pinned APIs')).toBeTruthy();
+    expect(screen.getByText('Pin APIs from the marketplace to keep them handy on your dashboard.')).toBeTruthy();
   });
 });

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import './Dashboard.css';
 import LowBalanceBanner from './LowBalanceBanner';
 import { useNavigate } from 'react-router-dom';
 import Skeleton from '../components/Skeleton';
 import EmptyState from '../components/EmptyState';
 import UsageGauge from '../components/UsageGauge';
-import { formatUsdc } from '../utils/format';
+import { formatUsdc, formatPrice } from '../utils/format';
 import { LOADING_DELAY_MS } from '../config/constants';
+import { usePinnedApis, pinnedApisStore } from '../state/pinnedApis';
+import MOCK_APIS from '../data/mockApis';
 
 // Props needed from the App state
 interface DashboardProps {
@@ -41,6 +43,11 @@ export default function Dashboard({ vaultBalance, walletBalance, openDeposit }: 
 
   const isLoading = activity === null;
   const totalUsage = activity?.reduce((sum, item) => (item.type === 'usage' ? sum + item.amount : sum), 0) ?? 0;
+  const pinnedApiIds = usePinnedApis();
+  const pinnedApis = useMemo(
+    () => MOCK_APIS.filter((api) => pinnedApiIds.has(api.id)),
+    [pinnedApiIds],
+  );
 
   return (
     <>
@@ -69,6 +76,45 @@ export default function Dashboard({ vaultBalance, walletBalance, openDeposit }: 
         <button className="primary-button no-print" onClick={openDeposit}>Deposit</button>
         <button className="secondary-button" onClick={() => navigate('/marketplace')}>Browse APIs</button>
         <button className="secondary-button" onClick={() => navigate('/api-usage')}>View Usage</button>
+      </div>
+
+      <div className="dashboard-card dashboard-card--pinned">
+        <div className="dashboard-card__pinned-heading">
+          <h3 className="eyebrow">Pinned APIs</h3>
+          {pinnedApis.length > 0 && (
+            <span className="dashboard-card__pinned-count">
+              {pinnedApis.length} pinned
+            </span>
+          )}
+        </div>
+
+        {pinnedApis.length === 0 ? (
+          <p className="dashboard-card__pinned-empty">
+            Pin APIs from the marketplace to keep them handy on your dashboard.
+          </p>
+        ) : (
+          <div className="dashboard-pinned-list">
+            {pinnedApis.map((api) => (
+              <div key={api.id} className="dashboard-pinned-item">
+                <div className="dashboard-pinned-item__content">
+                  <strong>{api.name}</strong>
+                  <span>{api.provider?.name}</span>
+                </div>
+                <div className="dashboard-pinned-item__meta">
+                  <span>{`$${formatPrice(api.pricePerCall ?? api.pricePerRequest)} / call`}</span>
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    onClick={() => pinnedApisStore.unpin(api.id)}
+                    aria-label={`Unpin ${api.name} from dashboard`}
+                  >
+                    Unpin
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Recent Activity */}


### PR DESCRIPTION
closes #371

This PR adds a dashboard pinning experience for marketplace APIs by introducing a pin button on `ApiCard` and a pinned APIs panel on the dashboard. The change preserves existing compare flows, stores pinned API IDs in localStorage, and keeps the pin state synchronized across components.

Highlights:
- Added `PinButton` interactions on `ApiCard` for pin/unpin actions
- Render pinned APIs in `Dashboard` with quick unpin support
- Added focused coverage for pin toggling and dashboard pinned display
- Updated README to document the new pinned dashboard feature

Tests:
- `npm test -- --run src/components/ApiCard.test.tsx src/components/Dashboard.test.tsx src/state/pinnedApis.test.ts`
