### PR TITLE
feat: design-system docs

### DIFF
--- a/src/pages/DesignSystemDocs.test.tsx
+++ b/src/pages/DesignSystemDocs.test.tsx
@@ -1,44 +1,393 @@
 // @vitest-environment jsdom
+/**
+ * Tests for DesignSystemDocs (src/pages/DesignSystemDocs.tsx).
+ *
+ * Coverage scope:
+ *   - Page heading and meta title.
+ *   - Tab navigation (Components, Colours, Typography, Tokens, Utilities).
+ *   - Component accordion: default open state, expand-all, collapse-all, individual toggle.
+ *   - Search: filter by name, token, and description; empty-state; clear search.
+ *   - Aria-live announcement of search results.
+ *   - Usage snippet copy button label.
+ *   - Colour palette, typography, token, and utility panels rendered.
+ *   - No accessibility regressions: aria-expanded, aria-controls, aria-selected.
+ */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import DesignSystemDocs from "./DesignSystemDocs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Navigate to a named tab. */
+function clickTab(name: string) {
+  fireEvent.click(screen.getByRole("tab", { name }));
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
 
 describe("DesignSystemDocs", () => {
   afterEach(() => {
     cleanup();
   });
 
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
   it("renders the page heading", () => {
     render(<DesignSystemDocs />);
-    expect(screen.getByRole("heading", { name: "Design System" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Design System", level: 1 })).toBeTruthy();
   });
 
-  it("shows the first component expanded by default and the rest collapsed", () => {
+  it("renders the eyebrow label 'Internal reference'", () => {
     render(<DesignSystemDocs />);
-    // First component section (Primary Button) is open by default
-    expect(screen.getByText("Live example")).toBeTruthy();
-    // Verify the collapse/expand toggle buttons are present
-    const expandAllBtn = screen.getByRole("button", { name: "Expand all" });
-    expect(expandAllBtn).toBeTruthy();
+    // There may be multiple eyebrow elements on the page; assert at least one exists
+    const labels = screen.getAllByText("Internal reference");
+    expect(labels.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("collapses all sections when 'Collapse all' is clicked", () => {
+  it("renders all five tabs", () => {
+    render(<DesignSystemDocs />);
+    const tabNames = ["Components", "Colours", "Typography", "Tokens", "Utilities"];
+    for (const name of tabNames) {
+      expect(screen.getByRole("tab", { name })).toBeTruthy();
+    }
+  });
+
+  // ── Tab navigation ────────────────────────────────────────────────────────
+
+  it("shows the Components panel by default", () => {
+    render(<DesignSystemDocs />);
+    const tab = screen.getByRole("tab", { name: "Components" });
+    expect(tab.getAttribute("aria-selected")).toBe("true");
+    // The accordion h2 for "Primary Button" must exist (level-2 heading in the component panel)
+    expect(
+      screen.getAllByRole("heading", { name: "Primary Button" }).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("switches to the Colours panel when the Colours tab is clicked", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Colours");
+    const colTab = screen.getByRole("tab", { name: "Colours" });
+    expect(colTab.getAttribute("aria-selected")).toBe("true");
+    // Colour palette heading
+    expect(screen.getByRole("heading", { name: "Colour Tokens" })).toBeTruthy();
+  });
+
+  it("switches to the Typography panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Typography");
+    expect(screen.getByRole("heading", { name: "Typography Scale" })).toBeTruthy();
+  });
+
+  it("switches to the Tokens panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Tokens");
+    expect(screen.getByRole("heading", { name: "Spacing & Radius Tokens" })).toBeTruthy();
+  });
+
+  it("switches to the Utilities panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Utilities");
+    expect(screen.getByRole("heading", { name: "CSS Utility Classes" })).toBeTruthy();
+  });
+
+  it("marks exactly one tab as selected at a time", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Colours");
+    const tabs = screen.getAllByRole("tab");
+    const selected = tabs.filter((t) => t.getAttribute("aria-selected") === "true");
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toBe("Colours");
+  });
+
+  // ── Component accordion ───────────────────────────────────────────────────
+
+  it("opens the first component (Primary Button) by default", () => {
+    render(<DesignSystemDocs />);
+    // The live example section inside the first accordion
+    expect(screen.getAllByText("Live example").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("collapses all accordions when 'Collapse all' is clicked", () => {
     render(<DesignSystemDocs />);
     fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
-    // All component headers remain but no prop tables are shown
     expect(screen.queryAllByText("Live example")).toHaveLength(0);
   });
 
-  it("expands all sections when 'Expand all' is clicked", () => {
+  it("expands all accordions when 'Expand all' is clicked", () => {
+    render(<DesignSystemDocs />);
+    // Collapse first, then expand
+    fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
+    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    // All COMPONENT_DOCS entries should have a 'Live example' label visible
+    const labels = screen.queryAllByText("Live example");
+    expect(labels.length).toBeGreaterThan(1);
+  });
+
+  it("toggles a single accordion open and closed", () => {
+    render(<DesignSystemDocs />);
+    // Collapse everything first for a clean slate
+    fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
+    expect(screen.queryAllByText("Live example")).toHaveLength(0);
+
+    // Click the "Secondary Button" accordion trigger
+    const trigger = screen.getByRole("button", { name: "Secondary Button" });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryAllByText("Live example").length).toBeGreaterThanOrEqual(1);
+
+    // Click again to collapse
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryAllByText("Live example")).toHaveLength(0);
+  });
+
+  it("sets aria-expanded correctly on each accordion trigger", () => {
+    render(<DesignSystemDocs />);
+    fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
+    const trigger = screen.getByRole("button", { name: "Primary Button" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("links each accordion trigger to its body via aria-controls", () => {
+    render(<DesignSystemDocs />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    // Every trigger must have an aria-controls referencing an element in the DOM
+    const triggers = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-expanded") !== null);
+    for (const trigger of triggers) {
+      const controlsId = trigger.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+      expect(document.getElementById(controlsId!)).toBeTruthy();
+    }
+  });
+
+  // ── Search ────────────────────────────────────────────────────────────────
+
+  it("filters components by name when the user types in the search box", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "Primary Button" } });
+    // Only primary-button section should be shown
+    expect(screen.getByRole("heading", { name: "Primary Button", level: 2 })).toBeTruthy();
+    // Secondary Button should no longer be in the DOM
+    expect(screen.queryByRole("heading", { name: "Secondary Button", level: 2 })).toBeNull();
+  });
+
+  it("filters components by design token name", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    // "--danger" is used by Status Chip and Danger Button
+    fireEvent.change(search, { target: { value: "--danger" } });
+    // At least the danger-button should appear
+    const headings = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => h.textContent ?? "");
+    expect(headings.some((h) => h.includes("Danger"))).toBe(true);
+    // Primary button (no --danger token) should not appear
+    expect(headings.some((h) => h === "Primary Button")).toBe(false);
+  });
+
+  it("filters components by description keyword", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "shimmer" } });
+    // Skeleton uses "shimmer" in its description
+    expect(screen.getByRole("heading", { name: "Skeleton", level: 2 })).toBeTruthy();
+  });
+
+  it("shows empty-state message when no components match the search", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "xyznonexistent" } });
+    expect(screen.getByText(/No components match/i)).toBeTruthy();
+  });
+
+  it("restores all components when the clear-search button is clicked", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "nonexistent" } });
+    expect(screen.queryByRole("heading", { name: "Primary Button", level: 2 })).toBeNull();
+
+    // There are two "Clear search" targets: the ✕ inline button (aria-label) and the
+    // empty-state "Clear search" text button. Click the first one available.
+    const clearBtns = screen.getAllByRole("button", { name: /Clear search/i });
+    fireEvent.click(clearBtns[0]);
+    expect(screen.getByRole("heading", { name: "Primary Button", level: 2 })).toBeTruthy();
+  });
+
+  it("clears the search field when the X button inside the input is clicked", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "skeleton" } });
+
+    const clearBtn = screen.getByRole("button", { name: "Clear search" });
+    fireEvent.click(clearBtn);
+
+    expect((search as HTMLInputElement).value).toBe("");
+  });
+
+  it("auto-expands all accordions when a search query is entered", () => {
     render(<DesignSystemDocs />);
     // Collapse everything first
     fireEvent.click(screen.getByRole("button", { name: "Collapse all" }));
     expect(screen.queryAllByText("Live example")).toHaveLength(0);
-    // Then expand all
-    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
-    // Every component section should now show a "Live example" label
-    const liveExampleLabels = screen.queryAllByText("Live example");
-    expect(liveExampleLabels.length).toBeGreaterThan(1);
+
+    // Type a query that matches multiple components
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "button" } });
+    // Matching entries should be expanded
+    expect(screen.queryAllByText("Live example").length).toBeGreaterThan(0);
   });
+
+  // ── Aria-live search result announcement ──────────────────────────────────
+
+  it("announces search result count via aria-live region", () => {
+    render(<DesignSystemDocs />);
+    const search = screen.getByRole("searchbox", { name: "Filter components" });
+    fireEvent.change(search, { target: { value: "skeleton" } });
+    // The sr-only live region should contain the count
+    const liveRegion = document.querySelector("[aria-live='polite']");
+    expect(liveRegion).toBeTruthy();
+    expect(liveRegion?.textContent).toMatch(/1 component found/i);
+  });
+
+  // ── Copy button ───────────────────────────────────────────────────────────
+
+  it("renders copy buttons for usage snippets when a component is expanded", () => {
+    render(<DesignSystemDocs />);
+    // Expand all to surface all usage sections
+    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    // Copy buttons should be present
+    const copyBtns = screen.getAllByRole("button", { name: /Copy usage snippet/i });
+    expect(copyBtns.length).toBeGreaterThan(0);
+  });
+
+  it("renders the copy button with 'Copy' label initially", () => {
+    render(<DesignSystemDocs />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    const copyBtns = screen.getAllByRole("button", { name: /Copy usage snippet/i });
+    // First button should show "Copy" as text
+    expect(copyBtns[0].textContent).toBe("Copy");
+  });
+
+  // ── Colour palette panel ──────────────────────────────────────────────────
+
+  it("renders colour group labels in the Colours panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Colours");
+    const groupLabels = ["Background", "Text", "Brand & Actions", "Semantic", "Borders"];
+    for (const label of groupLabels) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("renders individual token names in the colour palette", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Colours");
+    // Scope to the colours panel to avoid collision with token chips in open accordions
+    const panel = document.getElementById("panel-colours")!;
+    expect(within(panel).getByText("--page-bg")).toBeTruthy();
+    // --accent and --danger may appear in multiple panels; at least one per panel is fine
+    expect(within(panel).getAllByText("--accent").length).toBeGreaterThanOrEqual(1);
+    expect(within(panel).getAllByText("--danger").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Typography panel ──────────────────────────────────────────────────────
+
+  it("renders typography specimen labels in the Typography panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Typography");
+    expect(screen.getByText("H1")).toBeTruthy();
+    expect(screen.getByText("Eyebrow label")).toBeTruthy();
+    expect(screen.getByText("Helper text")).toBeTruthy();
+  });
+
+  // ── Tokens panel ─────────────────────────────────────────────────────────
+
+  it("renders spacing token names in the Tokens panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Tokens");
+    expect(screen.getByText("--radius-xl")).toBeTruthy();
+    expect(screen.getByText("--radius-lg")).toBeTruthy();
+    expect(screen.getByText("--transition-speed")).toBeTruthy();
+  });
+
+  // ── Utilities panel ───────────────────────────────────────────────────────
+
+  it("renders CSS utility class names in the Utilities panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Utilities");
+    // Spot-check a few expected classes
+    expect(screen.getByText(".primary-button")).toBeTruthy();
+    expect(screen.getByText(".surface")).toBeTruthy();
+    expect(screen.getByText(".sr-only")).toBeTruthy();
+  });
+
+  it("renders utility category headings in the Utilities panel", () => {
+    render(<DesignSystemDocs />);
+    clickTab("Utilities");
+    // Scope to the utilities panel to avoid collision with the tab button named "Typography"
+    const panel = document.getElementById("panel-utilities")!;
+    expect(within(panel).getByText("Buttons")).toBeTruthy();
+    expect(within(panel).getByText("Layout")).toBeTruthy();
+    expect(within(panel).getByText("Typography")).toBeTruthy();
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  it("each tab has role=tab and the panel has role=tabpanel", () => {
+    render(<DesignSystemDocs />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.length).toBe(5);
+    // Active panel should have role tabpanel
+    const panel = screen.getByRole("tabpanel", { hidden: false });
+    expect(panel).toBeTruthy();
+  });
+
+  it("each tab panel is linked to its tab via aria-labelledby", () => {
+    render(<DesignSystemDocs />);
+    for (const tab of TABS_TEST_DATA) {
+      clickTab(tab.label);
+      const panel = document.getElementById(`panel-${tab.id}`)!;
+      expect(panel).toBeTruthy();
+      expect(panel.getAttribute("aria-labelledby")).toBe(`tab-${tab.id}`);
+    }
+  });
+
+  it("search input has role=searchbox and is inside a search landmark", () => {
+    render(<DesignSystemDocs />);
+    const searchLandmark = screen.getByRole("search");
+    const input = within(searchLandmark).getByRole("searchbox");
+    expect(input).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants used in tests (mirrors TABS from the component)
+// ---------------------------------------------------------------------------
+const TABS_TEST_DATA = [
+  { id: "components", label: "Components" },
+  { id: "colours", label: "Colours" },
+  { id: "typography", label: "Typography" },
+  { id: "tokens", label: "Tokens" },
+  { id: "utilities", label: "Utilities" },
+] as const;
+
+// Suppress "useId requires a unique id" warnings in jsdom
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  let counter = 0;
+  return {
+    ...actual,
+    useId: () => `:r${counter++}:`,
+  };
 });

--- a/src/pages/DesignSystemDocs.tsx
+++ b/src/pages/DesignSystemDocs.tsx
@@ -2,53 +2,250 @@
  * DesignSystemDocs – internal /design-system/docs page.
  *
  * Lists every documented UI component with a live example, usage notes, and
- * the design tokens it consumes. Intended for contributors and designers so
- * the entire component library is discoverable in one place.
+ * the design tokens it consumes. Also surfaces the full colour-token palette,
+ * typography scale, spacing scale, border-radius tokens, and CSS utility
+ * classes. Intended for contributors and designers so the entire component
+ * library is discoverable in one place.
+ *
+ * Accessibility: WCAG 2.1 AA.
+ *   - Keyboard navigable (Tab, Enter, Escape).
+ *   - `aria-expanded` / `aria-controls` on every accordion.
+ *   - Search results announced via aria-live.
+ *   - Focus-visible ring via the global @layer focus rule.
+ *   - No colour-only information; text labels always accompany swatches.
+ *
+ * Dark-mode: all colour values come from design tokens so the page
+ * automatically adapts when `data-theme` changes.
  */
 
-import { useState } from "react";
+import { useState, useId, useMemo } from "react";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
+/** A single prop entry shown in the props table. */
 interface PropDoc {
   name: string;
   type: string;
+  required?: boolean;
+  defaultValue?: string;
   description: string;
 }
 
+/** A documented component entry in the catalogue. */
 interface ComponentDoc {
   id: string;
+  /** Display name shown in the accordion header and table of contents. */
   name: string;
+  /** Short description of the component's purpose. */
   description: string;
+  /** Design tokens consumed by this component. */
   tokens: string[];
+  /** Props accepted by the component. */
   props: PropDoc[];
-  /** Inline render of a live example */
+  /** Optional usage code snippet (plain text). */
+  usageSnippet?: string;
+  /** Inline render of a live example. */
   example: () => JSX.Element;
 }
+
+/** A colour-token row shown in the palette section. */
+interface ColourToken {
+  token: string;
+  /** Raw value shown in the swatch; uses a CSS var() reference so it adapts
+   *  to the active theme at render time. */
+  cssVar: string;
+  description: string;
+}
+
+/** A named group of colour tokens (e.g. "Background", "Text"). */
+interface ColourGroup {
+  label: string;
+  tokens: ColourToken[];
+}
+
+// ---------------------------------------------------------------------------
+// Colour token catalogue
+// ---------------------------------------------------------------------------
+
+const COLOUR_GROUPS: ColourGroup[] = [
+  {
+    label: "Background",
+    tokens: [
+      { token: "--page-bg", cssVar: "var(--page-bg)", description: "Main page background" },
+      { token: "--surface", cssVar: "var(--surface)", description: "Card / panel background" },
+      { token: "--surface-strong", cssVar: "var(--surface-strong)", description: "High-opacity surfaces (modals, overlays)" },
+      { token: "--surface-soft", cssVar: "var(--surface-soft)", description: "Subtle backgrounds (hover states, inputs)" },
+    ],
+  },
+  {
+    label: "Text",
+    tokens: [
+      { token: "--text", cssVar: "var(--text)", description: "Primary text" },
+      { token: "--muted", cssVar: "var(--muted)", description: "Secondary text and labels" },
+    ],
+  },
+  {
+    label: "Brand & Actions",
+    tokens: [
+      { token: "--accent", cssVar: "var(--accent)", description: "Primary brand colour — links, active states" },
+      { token: "--accent-strong", cssVar: "var(--accent-strong)", description: "Success states, highlights, CTAs" },
+    ],
+  },
+  {
+    label: "Semantic",
+    tokens: [
+      { token: "--danger", cssVar: "var(--danger)", description: "Error states, destructive actions" },
+      { token: "--success", cssVar: "var(--success)", description: "Success messages, confirmations" },
+      { token: "--warning", cssVar: "var(--warning)", description: "Warning states" },
+    ],
+  },
+  {
+    label: "Borders",
+    tokens: [
+      { token: "--line", cssVar: "var(--line)", description: "Standard borders and dividers" },
+      { token: "--line-strong", cssVar: "var(--line-strong)", description: "Emphasised borders" },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Typography specimens
+// ---------------------------------------------------------------------------
+
+interface TypeSpecimen {
+  label: string;
+  element: keyof JSX.IntrinsicElements;
+  className?: string;
+  sampleText: string;
+  notes: string;
+}
+
+const TYPE_SCALE: TypeSpecimen[] = [
+  {
+    label: "Brand heading",
+    element: "p",
+    className: "brand",
+    sampleText: "Callora — Programmable API Access",
+    notes: "`.brand` class — used for hero-level headings only.",
+  },
+  {
+    label: "H1",
+    element: "h1",
+    sampleText: "Design System",
+    notes: "One `<h1>` per page. Inherits `--font-family`.",
+  },
+  {
+    label: "H2",
+    element: "h2",
+    sampleText: "Component Reference",
+    notes: "Section headings inside a page.",
+  },
+  {
+    label: "H3",
+    element: "h3",
+    sampleText: "Primary Button",
+    notes: "Card titles and sub-section headings.",
+  },
+  {
+    label: "Body",
+    element: "p",
+    sampleText:
+      "All text defaults to `var(--text)`. Secondary copy uses `var(--muted)` to establish visual hierarchy.",
+    notes: "Default paragraph; inherits font from `:root`.",
+  },
+  {
+    label: "Eyebrow label",
+    element: "p",
+    className: "eyebrow",
+    sampleText: "Internal reference",
+    notes: "`.eyebrow` class — uppercase, letter-spaced, accent colour.",
+  },
+  {
+    label: "Helper text",
+    element: "p",
+    className: "helper-text",
+    sampleText: "Muted supplementary information shown below form fields.",
+    notes: "`.helper-text` class — `var(--muted)` colour.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Spacing & radius token tables
+// ---------------------------------------------------------------------------
+
+const SPACING_TOKENS = [
+  { token: "--radius-xl", value: "28px", usage: "Extra-large — cards, modals" },
+  { token: "--radius-lg", value: "20px", usage: "Large — sections, panels" },
+  { token: "--radius-md", value: "16px", usage: "Medium — buttons, inputs" },
+  { token: "--transition-speed", value: "240ms", usage: "Standard animation duration" },
+];
+
+// ---------------------------------------------------------------------------
+// CSS utility classes reference
+// ---------------------------------------------------------------------------
+
+interface UtilityClass {
+  name: string;
+  description: string;
+  category: "button" | "layout" | "typography" | "state" | "link";
+}
+
+const UTILITY_CLASSES: UtilityClass[] = [
+  // Buttons
+  { name: ".primary-button", description: "Primary action — gradient background, used at most once per view.", category: "button" },
+  { name: ".secondary-button", description: "Secondary / cancel action — ghost style with border.", category: "button" },
+  { name: ".ghost-button", description: "Minimal button with hover effect; used for low-emphasis actions.", category: "button" },
+  { name: ".close-button", description: "Dismiss / close action button.", category: "button" },
+  { name: ".danger-button", description: "Destructive action — uses `--danger` token.", category: "button" },
+  // Layout
+  { name: ".surface", description: "Elevated container: border, radius, shadow, backdrop blur.", category: "layout" },
+  { name: ".app-shell", description: "Main application container with consistent padding.", category: "layout" },
+  { name: ".hero-grid", description: "Two-column hero layout for landing sections.", category: "layout" },
+  { name: ".modal-grid", description: "Two-column modal layout.", category: "layout" },
+  // Typography
+  { name: ".brand", description: "Large hero-level brand heading.", category: "typography" },
+  { name: ".eyebrow", description: "Small uppercase label used above headings.", category: "typography" },
+  { name: ".helper-text", description: "Secondary / muted text below form fields.", category: "typography" },
+  // Links
+  { name: ".link-body", description: "Inline body-text links with 1 px underline and `--visited` state.", category: "link" },
+  { name: ".link-nav", description: "Structural navigation links — no underline, hover/focus states included.", category: "link" },
+  // State
+  { name: ".not-found", description: "404 page container.", category: "state" },
+  { name: ".server-error", description: "Server-error page container.", category: "state" },
+  { name: ".placeholder-card", description: "Generic placeholder / empty-state container.", category: "state" },
+  { name: ".sr-only", description: "Visually hidden, still available to screen readers (WCAG 2.1 AA).", category: "state" },
+];
 
 // ---------------------------------------------------------------------------
 // Component catalogue
 // ---------------------------------------------------------------------------
 
 const COMPONENT_DOCS: ComponentDoc[] = [
+  // ── Buttons ─────────────────────────────────────────────────────────────
   {
     id: "button-primary",
     name: "Primary Button",
     description:
-      "The main call-to-action button. Uses --theme-primary and should be used sparingly – once per view.",
-    tokens: ["--theme-primary", "--radius-md", "--space-3"],
+      "The main call-to-action button. Uses `.primary-button` and should be used sparingly — once per view. It receives a gradient background from the design token layer.",
+    tokens: ["--accent", "--radius-md"],
     props: [
       { name: "onClick", type: "() => void", description: "Click handler." },
-      { name: "disabled", type: "boolean", description: "Disables interaction and reduces opacity." },
-      { name: "children", type: "ReactNode", description: "Button label." },
+      { name: "disabled", type: "boolean", defaultValue: "false", description: "Disables interaction and reduces opacity." },
+      { name: "children", type: "ReactNode", required: true, description: "Button label." },
     ],
+    usageSnippet: '<button className="primary-button" type="button">\n  Approve Transaction\n</button>',
     example: () => (
-      <button className="primary-button" type="button">
-        Approve Transaction
-      </button>
+      <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
+        <button className="primary-button" type="button">
+          Approve Transaction
+        </button>
+        <button className="primary-button" type="button" disabled>
+          Disabled
+        </button>
+      </div>
     ),
   },
   {
@@ -56,82 +253,123 @@ const COMPONENT_DOCS: ComponentDoc[] = [
     name: "Secondary Button",
     description:
       "Ghost-style button for secondary or cancel actions. Never used as the sole action on a page.",
-    tokens: ["--color-border", "--radius-md", "--space-3"],
+    tokens: ["--line", "--radius-md", "--text"],
     props: [
       { name: "onClick", type: "() => void", description: "Click handler." },
-      { name: "disabled", type: "boolean", description: "Disables interaction." },
-      { name: "children", type: "ReactNode", description: "Button label." },
+      { name: "disabled", type: "boolean", defaultValue: "false", description: "Disables interaction." },
+      { name: "children", type: "ReactNode", required: true, description: "Button label." },
     ],
+    usageSnippet: '<button className="secondary-button" type="button">\n  Cancel\n</button>',
     example: () => (
-      <button className="secondary-button" type="button">
-        Cancel
-      </button>
-    ),
-  },
-  {
-    id: "surface-card",
-    name: "Surface Card",
-    description:
-      "Elevated container used for dashboard tiles, vault balance cards, and info panels.",
-    tokens: ["--color-surface", "--color-surface-raised", "--radius-lg", "--shadow-md"],
-    props: [
-      { name: "children", type: "ReactNode", description: "Card body content." },
-      { name: "className", type: "string", description: "Additional CSS classes." },
-    ],
-    example: () => (
-      <article className="surface" style={{ padding: "1rem", borderRadius: "var(--radius-lg, 8px)" }}>
-        <span className="eyebrow">Vault balance</span>
-        <strong style={{ display: "block", marginTop: "0.25rem" }}>284.62 USDC</strong>
-      </article>
-    ),
-  },
-  {
-    id: "eyebrow",
-    name: "Eyebrow Label",
-    description:
-      "Small uppercase label used above headings to establish section context.",
-    tokens: ["--color-accent", "--font-size-xs", "--letter-spacing-wide"],
-    props: [
-      { name: "children", type: "ReactNode", description: "Label text." },
-    ],
-    example: () => <p className="eyebrow">Core capabilities</p>,
-  },
-  {
-    id: "status-chip",
-    name: "Status Chip",
-    description:
-      "Inline badge that surfaces transaction or system state at a glance.",
-    tokens: ["--color-success", "--color-error", "--color-warn", "--radius-full"],
-    props: [
-      {
-        name: "status",
-        type: "'input' | 'approving' | 'pending' | 'confirmed' | 'failed'",
-        description: "Controls colour and label.",
-      },
-    ],
-    example: () => (
-      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
-        {(["input", "approving", "pending", "confirmed", "failed"] as const).map(
-          (s) => (
-            <span key={s} className={`status-chip ${s}`}>
-              {s}
-            </span>
-          ),
-        )}
+      <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
+        <button className="secondary-button" type="button">
+          Cancel
+        </button>
+        <button className="secondary-button" type="button" disabled>
+          Disabled
+        </button>
       </div>
     ),
   },
   {
+    id: "button-danger",
+    name: "Danger Button",
+    description:
+      "Destructive action button. Uses `.danger-button` and the `--danger` token. Must be accompanied by a confirmation step for irreversible actions.",
+    tokens: ["--danger", "--radius-md"],
+    props: [
+      { name: "onClick", type: "() => void", description: "Click handler." },
+      { name: "children", type: "ReactNode", required: true, description: "Button label." },
+    ],
+    usageSnippet: '<button className="danger-button" type="button">\n  Delete API Key\n</button>',
+    example: () => (
+      <button className="danger-button" type="button">
+        Delete API Key
+      </button>
+    ),
+  },
+  // ── Surfaces & Layout ────────────────────────────────────────────────────
+  {
+    id: "surface-card",
+    name: "Surface Card",
+    description:
+      "Elevated container used for dashboard tiles, vault balance cards, and info panels. Applies `--surface`, `--line`, `--radius-lg`, and backdrop blur.",
+    tokens: ["--surface", "--line", "--radius-lg", "--shadow"],
+    props: [
+      { name: "children", type: "ReactNode", required: true, description: "Card body content." },
+      { name: "className", type: "string", description: "Additional CSS classes." },
+    ],
+    usageSnippet: '<article className="surface" style={{ padding: "1rem" }}>\n  <span className="eyebrow">Vault balance</span>\n  <strong>284.62 USDC</strong>\n</article>',
+    example: () => (
+      <article className="surface" style={{ padding: "1rem", borderRadius: "var(--radius-lg, 20px)", maxWidth: 320 }}>
+        <span className="eyebrow">Vault balance</span>
+        <strong style={{ display: "block", marginTop: "0.25rem", fontSize: "1.5rem" }}>
+          284.62 USDC
+        </strong>
+        <p className="helper-text" style={{ marginTop: "0.5rem" }}>
+          Last updated just now
+        </p>
+      </article>
+    ),
+  },
+  // ── Typography ───────────────────────────────────────────────────────────
+  {
+    id: "eyebrow",
+    name: "Eyebrow Label",
+    description:
+      "Small uppercase label used above headings to establish section context. Uses the `.eyebrow` class.",
+    tokens: ["--accent", "--muted"],
+    props: [
+      { name: "children", type: "ReactNode", required: true, description: "Label text." },
+    ],
+    usageSnippet: '<p className="eyebrow">Core capabilities</p>',
+    example: () => (
+      <div>
+        <p className="eyebrow">Core capabilities</p>
+        <h2 style={{ margin: "0.25rem 0 0" }}>Why teams choose Callora</h2>
+      </div>
+    ),
+  },
+  // ── Badges & Status ──────────────────────────────────────────────────────
+  {
+    id: "status-chip",
+    name: "Status Chip",
+    description:
+      "Inline badge that surfaces transaction or system state at a glance. Colour is token-driven; text always carries the label so colour is never the sole indicator.",
+    tokens: ["--success", "--danger", "--warning", "--radius-full"],
+    props: [
+      {
+        name: "status",
+        type: "'input' | 'approving' | 'pending' | 'confirmed' | 'failed'",
+        required: true,
+        description: "Controls colour and label.",
+      },
+    ],
+    usageSnippet: '<span className="status-chip confirmed">confirmed</span>',
+    example: () => (
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+        {(["input", "approving", "pending", "confirmed", "failed"] as const).map((s) => (
+          <span key={s} className={`status-chip ${s}`}>
+            {s}
+          </span>
+        ))}
+      </div>
+    ),
+  },
+  // ── Navigation & Accessibility ───────────────────────────────────────────
+  {
     id: "skip-link",
     name: "Skip Link",
     description:
-      "Visually hidden anchor that becomes visible on focus, allowing keyboard users to bypass the navigation and jump straight to main content. Required for WCAG 2.1 AA compliance.",
-    tokens: ["--color-surface", "--theme-primary", "--z-skip-link"],
+      "Visually hidden anchor that becomes visible on focus, allowing keyboard users to bypass the navigation and jump straight to main content. Required for WCAG 2.1 AA compliance. Rendered in `App.tsx` as the very first child of `<body>`.",
+    tokens: ["--text", "--page-bg", "--accent"],
     props: [
-      { name: "href", type: "string", description: "Target element id, e.g. #main-content." },
-      { name: "children", type: "ReactNode", description: "Link text shown on focus." },
+      { name: "href", type: "string", required: true, description: "Target element id, e.g. #main-content." },
+      { name: "children", type: "ReactNode", required: true, description: "Link text shown on focus." },
     ],
+    usageSnippet: '<a href="#main-content" className="skip-link">\n  Skip to main content\n</a>',
     example: () => (
+      /* Force static positioning so it is always visible in the demo */
       <a
         href="#main-content"
         className="skip-link"
@@ -141,61 +379,237 @@ const COMPONENT_DOCS: ComponentDoc[] = [
       </a>
     ),
   },
+  // ── Form Controls ────────────────────────────────────────────────────────
+  {
+    id: "search-bar",
+    name: "SearchBar",
+    description:
+      "Search input with a clear button and keyboard shortcuts. Supports Escape to clear and Enter to trigger the search callback.",
+    tokens: ["--surface-soft", "--line", "--accent", "--text", "--muted"],
+    props: [
+      { name: "value", type: "string", required: true, description: "Current search value." },
+      { name: "onChange", type: "(v: string) => void", required: true, description: "Update callback." },
+      { name: "placeholder", type: "string", defaultValue: '"Search APIs, providers, tags..."', description: "Input placeholder." },
+      { name: "onSearch", type: "() => void", description: "Called when the user presses Enter." },
+    ],
+    usageSnippet: '<SearchBar value={q} onChange={setQ} onSearch={handleSearch} />',
+    example: () => {
+      /* Local state not available in static example — render a static mockup */
+      return (
+        <div
+          role="search"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            padding: "0.5rem 0.75rem",
+            borderRadius: "8px",
+            background: "var(--surface-soft, rgba(255,255,255,0.04))",
+            border: "1px solid var(--line, rgba(169,184,255,0.16))",
+            maxWidth: 340,
+          }}
+        >
+          {/* Simple search icon inline so we avoid importing a component */}
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.35-4.35" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Search APIs, providers, tags…"
+            aria-label="Search APIs"
+            style={{
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              color: "var(--text)",
+              width: "100%",
+            }}
+          />
+        </div>
+      );
+    },
+  },
+  // ── Feedback & Loading ───────────────────────────────────────────────────
+  {
+    id: "skeleton",
+    name: "Skeleton",
+    description:
+      "Loading placeholder with a shimmer animation. Renders an element of configurable size and radius; the parent is responsible for setting `aria-busy` / `aria-label` context.",
+    tokens: ["--surface-soft", "--line"],
+    props: [
+      { name: "width", type: "string | number", description: "Skeleton width." },
+      { name: "height", type: "string | number", description: "Skeleton height." },
+      { name: "borderRadius", type: "string | number", description: "Border radius." },
+      { name: "style", type: "CSSProperties", description: "Additional inline styles." },
+      { name: "className", type: "string", description: "Additional CSS classes." },
+    ],
+    usageSnippet: '<Skeleton width={200} height={20} borderRadius={4} />',
+    example: () => (
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }} aria-label="Loading content" aria-busy="true">
+        <div className="skeleton" style={{ width: 200, height: 16, borderRadius: 4 }} />
+        <div className="skeleton" style={{ width: 280, height: 16, borderRadius: 4 }} />
+        <div className="skeleton" style={{ width: 140, height: 16, borderRadius: 4 }} />
+        <div className="skeleton" style={{ width: 80, height: 32, borderRadius: 8, marginTop: "0.5rem" }} />
+      </div>
+    ),
+  },
+  {
+    id: "empty-state",
+    name: "EmptyState",
+    description:
+      "Displayed when no results are found (e.g. empty search results). Provides a heading and an optional sub-message.",
+    tokens: ["--surface", "--text", "--muted"],
+    props: [
+      { name: "title", type: "string", defaultValue: '"No APIs found"', description: "Heading text." },
+      { name: "message", type: "string", defaultValue: '"Try adjusting your filters"', description: "Subtitle text." },
+    ],
+    usageSnippet: '<EmptyState title="No results found" message="Try different search terms" />',
+    example: () => (
+      <div style={{ textAlign: "center", padding: "2rem 1rem" }}>
+        <p style={{ fontSize: "2.5rem", marginBottom: "0.5rem" }}>🔍</p>
+        <h3 style={{ margin: 0 }}>No APIs found</h3>
+        <p className="helper-text" style={{ marginTop: "0.5rem" }}>
+          Try adjusting your filters
+        </p>
+      </div>
+    ),
+  },
+  // ── Error States ─────────────────────────────────────────────────────────
+  {
+    id: "server-error",
+    name: "ServerError",
+    description:
+      "Server-error display with retry functionality. Uses `role=\"alert\"` so the message is announced immediately by screen readers. The retry button receives `aria-busy` during an in-flight retry.",
+    tokens: ["--danger", "--surface", "--accent"],
+    props: [
+      { name: "onRetry", type: "() => void | Promise<void>", description: "Retry callback (optional)." },
+      { name: "requestId", type: "string", description: "Request ID shown masked for support." },
+      { name: "title", type: "string", defaultValue: '"Something went wrong on our end"', description: "Error heading." },
+      { name: "description", type: "string", description: "Error message." },
+    ],
+    usageSnippet: '<ServerError onRetry={refetch} requestId="req_abc123" />',
+    example: () => (
+      <div
+        role="alert"
+        style={{
+          textAlign: "center",
+          padding: "1.5rem",
+          borderRadius: "var(--radius-lg, 20px)",
+          background: "var(--surface-soft, rgba(255,255,255,0.04))",
+        }}
+      >
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: "50%",
+            background: "rgba(255,125,141,0.12)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            margin: "0 auto 0.75rem",
+          }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--danger, #ff7d8d)" strokeWidth="1.6" aria-hidden="true">
+            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+        </div>
+        <h3 style={{ margin: "0 0 0.5rem" }}>Something went wrong</h3>
+        <p className="helper-text" style={{ margin: "0 0 1rem" }}>
+          An unexpected error occurred. Please try again.
+        </p>
+        <button className="primary-button" type="button">
+          Retry
+        </button>
+      </div>
+    ),
+  },
 ];
 
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
+/** Renders a table of prop definitions for a component. */
 function PropTable({ props }: { props: PropDoc[] }) {
   return (
-    <table
-      style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.85rem" }}
-      aria-label="Component props"
-    >
-      <thead>
-        <tr>
-          {["Prop", "Type", "Description"].map((h) => (
-            <th
-              key={h}
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.85rem", minWidth: 480 }}
+        aria-label="Component props"
+      >
+        <thead>
+          <tr>
+            {["Prop", "Type", "Required", "Default", "Description"].map((h) => (
+              <th
+                key={h}
+                style={{
+                  textAlign: "left",
+                  padding: "0.45rem 0.65rem",
+                  borderBottom: "1px solid var(--line, #334155)",
+                  color: "var(--muted)",
+                  fontWeight: 600,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {props.map((p, i) => (
+            <tr
+              key={p.name}
               style={{
-                textAlign: "left",
-                padding: "0.4rem 0.6rem",
-                borderBottom: "1px solid var(--color-border, #334155)",
+                background: i % 2 === 0 ? "transparent" : "var(--surface-soft, rgba(255,255,255,0.02))",
               }}
             >
-              {h}
-            </th>
+              <td style={{ padding: "0.45rem 0.65rem", fontFamily: "monospace", whiteSpace: "nowrap", color: "var(--accent)" }}>
+                {p.name}
+              </td>
+              <td style={{ padding: "0.45rem 0.65rem", fontFamily: "monospace", color: "var(--accent-strong)", whiteSpace: "nowrap" }}>
+                {p.type}
+              </td>
+              <td style={{ padding: "0.45rem 0.65rem", textAlign: "center" }}>
+                {p.required ? (
+                  <span aria-label="required" style={{ color: "var(--danger)" }}>✓</span>
+                ) : (
+                  <span aria-label="optional" style={{ color: "var(--muted)" }}>—</span>
+                )}
+              </td>
+              <td style={{ padding: "0.45rem 0.65rem", fontFamily: "monospace", color: "var(--muted)" }}>
+                {p.defaultValue ?? "—"}
+              </td>
+              <td style={{ padding: "0.45rem 0.65rem" }}>{p.description}</td>
+            </tr>
           ))}
-        </tr>
-      </thead>
-      <tbody>
-        {props.map((p) => (
-          <tr key={p.name}>
-            <td style={{ padding: "0.4rem 0.6rem", fontFamily: "monospace" }}>{p.name}</td>
-            <td style={{ padding: "0.4rem 0.6rem", fontFamily: "monospace", color: "var(--color-accent, #1ed6a4)" }}>
-              {p.type}
-            </td>
-            <td style={{ padding: "0.4rem 0.6rem" }}>{p.description}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   );
 }
 
+/** Renders a chip list of design tokens consumed by a component. */
 function TokenList({ tokens }: { tokens: string[] }) {
   return (
-    <ul style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", listStyle: "none", padding: 0, margin: 0 }}>
+    <ul
+      style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", listStyle: "none", padding: 0, margin: 0 }}
+      aria-label="Design tokens used"
+    >
       {tokens.map((t) => (
         <li
           key={t}
           style={{
-            background: "var(--color-surface-raised, #1e293b)",
-            borderRadius: "var(--radius-sm, 4px)",
-            padding: "0.15rem 0.5rem",
+            background: "var(--surface-soft, #1e293b)",
+            border: "1px solid var(--line)",
+            borderRadius: "var(--radius-md, 16px)",
+            padding: "0.15rem 0.6rem",
             fontFamily: "monospace",
-            fontSize: "0.8rem",
+            fontSize: "0.78rem",
           }}
         >
           {t}
@@ -205,25 +619,87 @@ function TokenList({ tokens }: { tokens: string[] }) {
   );
 }
 
+/** Renders the usage code snippet with copy-to-clipboard support. */
+function UsageSnippet({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        background: "var(--surface-soft, rgba(0,0,0,0.3))",
+        borderRadius: "var(--radius-md, 16px)",
+        border: "1px solid var(--line)",
+        overflow: "hidden",
+      }}
+    >
+      <pre
+        style={{
+          margin: 0,
+          padding: "0.85rem 1rem",
+          fontFamily: "monospace",
+          fontSize: "0.8rem",
+          overflowX: "auto",
+          lineHeight: 1.6,
+        }}
+      >
+        <code>{code}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Code copied" : "Copy usage snippet"}
+        style={{
+          position: "absolute",
+          top: "0.5rem",
+          right: "0.5rem",
+          background: "var(--surface)",
+          border: "1px solid var(--line)",
+          borderRadius: "var(--radius-md, 16px)",
+          padding: "0.2rem 0.55rem",
+          fontSize: "0.75rem",
+          cursor: "pointer",
+          color: "var(--muted)",
+        }}
+      >
+        {copied ? "✓ Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
 interface ComponentSectionProps {
   doc: ComponentDoc;
   isOpen: boolean;
   onToggle: () => void;
 }
 
+/** Accordion card for a single component entry. */
 function ComponentSection({ doc, isOpen, onToggle }: ComponentSectionProps) {
+  // Unique IDs for aria-controls / aria-labelledby
+  const headingId = `doc-heading-${doc.id}`;
+  const bodyId = `doc-body-${doc.id}`;
+
   return (
     <article
       className="surface"
-      style={{ marginBottom: "1.5rem", borderRadius: "var(--radius-lg, 8px)", overflow: "hidden" }}
-      aria-labelledby={`doc-heading-${doc.id}`}
+      style={{ marginBottom: "1rem", borderRadius: "var(--radius-lg, 20px)", overflow: "hidden" }}
+      aria-labelledby={headingId}
     >
-      {/* Header row – always visible */}
+      {/* Accordion trigger — always visible */}
       <button
         type="button"
+        id={`trigger-${doc.id}`}
         onClick={onToggle}
         aria-expanded={isOpen}
-        aria-controls={`doc-body-${doc.id}`}
+        aria-controls={bodyId}
         style={{
           display: "flex",
           alignItems: "center",
@@ -234,42 +710,61 @@ function ComponentSection({ doc, isOpen, onToggle }: ComponentSectionProps) {
           border: "none",
           cursor: "pointer",
           textAlign: "left",
+          gap: "0.5rem",
         }}
       >
-        <h2 id={`doc-heading-${doc.id}`} style={{ margin: 0, fontSize: "1.1rem" }}>
+        <h2 id={headingId} style={{ margin: 0, fontSize: "1rem", fontWeight: 600 }}>
           {doc.name}
         </h2>
-        <span aria-hidden="true" style={{ fontSize: "0.9rem", opacity: 0.6 }}>
-          {isOpen ? "▲ collapse" : "▼ expand"}
+        <span
+          aria-hidden="true"
+          style={{
+            fontSize: "0.8rem",
+            color: "var(--muted)",
+            flexShrink: 0,
+            transition: "transform 240ms",
+            display: "inline-block",
+            transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+        >
+          ▾
         </span>
       </button>
 
       {/* Collapsible body */}
       {isOpen && (
-        <div
-          id={`doc-body-${doc.id}`}
-          style={{ padding: "0 1.25rem 1.25rem" }}
-        >
-          <p style={{ marginTop: 0 }}>{doc.description}</p>
+        <div id={bodyId} role="region" aria-labelledby={headingId} style={{ padding: "0 1.25rem 1.25rem" }}>
+          <p style={{ marginTop: 0, color: "var(--muted)", lineHeight: 1.6 }}>{doc.description}</p>
 
           {/* Live example */}
-          <section aria-label="Live example" style={{ marginBottom: "1rem" }}>
+          <section aria-label="Live example" style={{ marginBottom: "1.25rem" }}>
             <p className="eyebrow" style={{ marginBottom: "0.5rem" }}>
               Live example
             </p>
             <div
               style={{
-                padding: "1rem",
-                background: "var(--color-surface-raised, #1e293b)",
-                borderRadius: "var(--radius-md, 6px)",
+                padding: "1.25rem",
+                background: "var(--surface-soft, rgba(255,255,255,0.04))",
+                borderRadius: "var(--radius-md, 16px)",
+                border: "1px solid var(--line)",
               }}
             >
               <doc.example />
             </div>
           </section>
 
+          {/* Usage snippet */}
+          {doc.usageSnippet && (
+            <section aria-label="Usage snippet" style={{ marginBottom: "1.25rem" }}>
+              <p className="eyebrow" style={{ marginBottom: "0.5rem" }}>
+                Usage
+              </p>
+              <UsageSnippet code={doc.usageSnippet} />
+            </section>
+          )}
+
           {/* Design tokens */}
-          <section aria-label="Design tokens" style={{ marginBottom: "1rem" }}>
+          <section aria-label="Design tokens" style={{ marginBottom: "1.25rem" }}>
             <p className="eyebrow" style={{ marginBottom: "0.5rem" }}>
               Design tokens
             </p>
@@ -277,12 +772,14 @@ function ComponentSection({ doc, isOpen, onToggle }: ComponentSectionProps) {
           </section>
 
           {/* Props table */}
-          <section aria-label="Props">
-            <p className="eyebrow" style={{ marginBottom: "0.5rem" }}>
-              Props
-            </p>
-            <PropTable props={doc.props} />
-          </section>
+          {doc.props.length > 0 && (
+            <section aria-label="Props table">
+              <p className="eyebrow" style={{ marginBottom: "0.5rem" }}>
+                Props
+              </p>
+              <PropTable props={doc.props} />
+            </section>
+          )}
         </div>
       )}
     </article>
@@ -290,19 +787,356 @@ function ComponentSection({ doc, isOpen, onToggle }: ComponentSectionProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Colour palette section
+// ---------------------------------------------------------------------------
+
+function ColourPalette() {
+  return (
+    <section aria-labelledby="colour-palette-heading" style={{ marginBottom: "2.5rem" }}>
+      <h2 id="colour-palette-heading" style={{ marginBottom: "0.25rem" }}>
+        Colour Tokens
+      </h2>
+      <p style={{ color: "var(--muted)", marginTop: 0, marginBottom: "1.25rem" }}>
+        All colour values are CSS custom properties defined in{" "}
+        <code style={{ fontFamily: "monospace" }}>src/index.css</code>. They automatically adapt
+        between light and dark themes.
+      </p>
+
+      {COLOUR_GROUPS.map((group) => (
+        <div key={group.label} style={{ marginBottom: "1.5rem" }}>
+          <p className="eyebrow" style={{ marginBottom: "0.75rem" }}>
+            {group.label}
+          </p>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+              gap: "0.75rem",
+            }}
+          >
+            {group.tokens.map((t) => (
+              <div
+                key={t.token}
+                className="surface"
+                style={{
+                  borderRadius: "var(--radius-md, 16px)",
+                  overflow: "hidden",
+                  padding: 0,
+                }}
+              >
+                {/* Colour swatch */}
+                <div
+                  aria-hidden="true"
+                  style={{
+                    height: 56,
+                    background: t.cssVar,
+                    border: "1px solid var(--line)",
+                    borderRadius: "var(--radius-md, 16px) var(--radius-md, 16px) 0 0",
+                  }}
+                />
+                <div style={{ padding: "0.6rem 0.75rem" }}>
+                  <p
+                    style={{
+                      margin: 0,
+                      fontFamily: "monospace",
+                      fontSize: "0.78rem",
+                      color: "var(--accent)",
+                    }}
+                  >
+                    {t.token}
+                  </p>
+                  <p
+                    style={{
+                      margin: "0.2rem 0 0",
+                      fontSize: "0.78rem",
+                      color: "var(--muted)",
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {t.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Typography section
+// ---------------------------------------------------------------------------
+
+function TypographyScale() {
+  return (
+    <section aria-labelledby="typography-heading" style={{ marginBottom: "2.5rem" }}>
+      <h2 id="typography-heading" style={{ marginBottom: "0.25rem" }}>
+        Typography Scale
+      </h2>
+      <p style={{ color: "var(--muted)", marginTop: 0, marginBottom: "1.25rem" }}>
+        All type uses{" "}
+        <code style={{ fontFamily: "monospace" }}>var(--font-family)</code> ={" "}
+        <em>"Space Grotesk", "Segoe UI", sans-serif</em>.
+      </p>
+
+      <div
+        className="surface"
+        style={{ borderRadius: "var(--radius-lg, 20px)", overflow: "hidden" }}
+      >
+        {TYPE_SCALE.map((specimen, i) => {
+          const Tag = specimen.element as keyof JSX.IntrinsicElements;
+          return (
+            <div
+              key={specimen.label}
+              style={{
+                padding: "1rem 1.25rem",
+                borderBottom:
+                  i < TYPE_SCALE.length - 1 ? "1px solid var(--line)" : undefined,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  gap: "1rem",
+                  flexWrap: "wrap",
+                }}
+              >
+                <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+                  {/* Render the specimen using the correct element */}
+                  <Tag
+                    className={specimen.className}
+                    style={{
+                      margin: 0,
+                      // Prevent h1/h2 etc. from towering too tall
+                      fontSize: specimen.element === "h1" ? "clamp(1.4rem, 3vw, 2rem)" : undefined,
+                    }}
+                  >
+                    {specimen.sampleText}
+                  </Tag>
+                </div>
+                <div style={{ flexShrink: 0, maxWidth: 280 }}>
+                  <p className="eyebrow" style={{ marginBottom: "0.2rem" }}>
+                    {specimen.label}
+                  </p>
+                  <p
+                    style={{
+                      margin: 0,
+                      fontSize: "0.8rem",
+                      color: "var(--muted)",
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    {specimen.notes}
+                  </p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Spacing / tokens reference table
+// ---------------------------------------------------------------------------
+
+function SpacingReference() {
+  return (
+    <section aria-labelledby="spacing-heading" style={{ marginBottom: "2.5rem" }}>
+      <h2 id="spacing-heading" style={{ marginBottom: "0.25rem" }}>
+        Spacing & Radius Tokens
+      </h2>
+      <p style={{ color: "var(--muted)", marginTop: 0, marginBottom: "1.25rem" }}>
+        Structural tokens shared across all themes.
+      </p>
+      <div style={{ overflowX: "auto" }}>
+        <table
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}
+          aria-label="Spacing and radius tokens"
+        >
+          <thead>
+            <tr>
+              {["Token", "Value", "Usage"].map((h) => (
+                <th
+                  key={h}
+                  style={{
+                    textAlign: "left",
+                    padding: "0.5rem 0.75rem",
+                    borderBottom: "2px solid var(--line)",
+                    color: "var(--muted)",
+                    fontWeight: 600,
+                  }}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {SPACING_TOKENS.map((t, i) => (
+              <tr
+                key={t.token}
+                style={{
+                  background: i % 2 === 0 ? "transparent" : "var(--surface-soft)",
+                }}
+              >
+                <td style={{ padding: "0.5rem 0.75rem", fontFamily: "monospace", color: "var(--accent)" }}>
+                  {t.token}
+                </td>
+                <td style={{ padding: "0.5rem 0.75rem", fontFamily: "monospace" }}>
+                  {t.value}
+                </td>
+                <td style={{ padding: "0.5rem 0.75rem", color: "var(--muted)" }}>{t.usage}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CSS utilities reference
+// ---------------------------------------------------------------------------
+
+const CATEGORY_LABELS: Record<UtilityClass["category"], string> = {
+  button: "Buttons",
+  layout: "Layout",
+  typography: "Typography",
+  link: "Links",
+  state: "State / Misc",
+};
+
+function UtilityClassesReference() {
+  const categories = (Object.keys(CATEGORY_LABELS) as UtilityClass["category"][]);
+
+  return (
+    <section aria-labelledby="utilities-heading" style={{ marginBottom: "2.5rem" }}>
+      <h2 id="utilities-heading" style={{ marginBottom: "0.25rem" }}>
+        CSS Utility Classes
+      </h2>
+      <p style={{ color: "var(--muted)", marginTop: 0, marginBottom: "1.25rem" }}>
+        Reusable classes defined in{" "}
+        <code style={{ fontFamily: "monospace" }}>src/index.css</code>. Use these instead of
+        custom styles.
+      </p>
+
+      {categories.map((cat) => {
+        const items = UTILITY_CLASSES.filter((u) => u.category === cat);
+        return (
+          <div key={cat} style={{ marginBottom: "1.25rem" }}>
+            <p className="eyebrow" style={{ marginBottom: "0.6rem" }}>
+              {CATEGORY_LABELS[cat]}
+            </p>
+            <div
+              className="surface"
+              style={{ borderRadius: "var(--radius-lg, 20px)", overflow: "hidden" }}
+            >
+              {items.map((u, i) => (
+                <div
+                  key={u.name}
+                  style={{
+                    display: "flex",
+                    gap: "1rem",
+                    padding: "0.65rem 1.1rem",
+                    borderBottom:
+                      i < items.length - 1 ? "1px solid var(--line)" : undefined,
+                    alignItems: "flex-start",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <code
+                    style={{
+                      fontFamily: "monospace",
+                      fontSize: "0.82rem",
+                      color: "var(--accent)",
+                      flexShrink: 0,
+                      minWidth: 180,
+                    }}
+                  >
+                    {u.name}
+                  </code>
+                  <span style={{ color: "var(--muted)", fontSize: "0.875rem", lineHeight: 1.5 }}>
+                    {u.description}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page tabs
+// ---------------------------------------------------------------------------
+
+type TabId = "components" | "colours" | "typography" | "tokens" | "utilities";
+
+interface Tab {
+  id: TabId;
+  label: string;
+}
+
+const TABS: Tab[] = [
+  { id: "components", label: "Components" },
+  { id: "colours", label: "Colours" },
+  { id: "typography", label: "Typography" },
+  { id: "tokens", label: "Tokens" },
+  { id: "utilities", label: "Utilities" },
+];
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
+/**
+ * DesignSystemDocs
+ *
+ * Internal page at `/design-system/docs`. Provides:
+ *   - Tabbed navigation: Components | Colours | Typography | Tokens | Utilities
+ *   - Filterable component catalogue with live examples, props table, usage
+ *     snippets, and design-token chips.
+ *   - Full colour-token palette with swatches.
+ *   - Typography scale specimens.
+ *   - Spacing / radius token reference table.
+ *   - CSS utility class catalogue.
+ */
 export default function DesignSystemDocs(): JSX.Element {
   useDocumentTitle(
     "Design System – Callora",
     "Internal design-system documentation listing all UI components with live examples, props, and design tokens.",
   );
 
-  const [openIds, setOpenIds] = useState<Set<string>>(
-    new Set([COMPONENT_DOCS[0].id]),
-  );
+  const tabsId = useId();
 
+  // ── State ────────────────────────────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState<TabId>("components");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set([COMPONENT_DOCS[0].id]));
+
+  // ── Derived ──────────────────────────────────────────────────────────────
+  const filteredDocs = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return COMPONENT_DOCS;
+    return COMPONENT_DOCS.filter(
+      (d) =>
+        d.name.toLowerCase().includes(q) ||
+        d.description.toLowerCase().includes(q) ||
+        d.tokens.some((t) => t.toLowerCase().includes(q)),
+    );
+  }, [searchQuery]);
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
   const toggle = (id: string) => {
     setOpenIds((prev) => {
       const next = new Set(prev);
@@ -315,27 +1149,158 @@ export default function DesignSystemDocs(): JSX.Element {
     });
   };
 
-  const expandAll = () =>
-    setOpenIds(new Set(COMPONENT_DOCS.map((d) => d.id)));
+  const expandAll = () => setOpenIds(new Set(COMPONENT_DOCS.map((d) => d.id)));
   const collapseAll = () => setOpenIds(new Set());
 
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value;
+    setSearchQuery(value);
+    // Auto-expand all when searching so results are visible
+    if (value.trim()) {
+      setOpenIds(new Set(COMPONENT_DOCS.map((d) => d.id)));
+    }
+  };
+
+  const clearSearch = () => setSearchQuery("");
+
+  // ── Render ───────────────────────────────────────────────────────────────
   return (
-    <div style={{ maxWidth: "860px", margin: "0 auto", padding: "2rem 1rem" }}>
-      {/* Page header */}
+    <div style={{ maxWidth: 920, margin: "0 auto", padding: "2rem 1rem" }}>
+      {/* ── Page header ─────────────────────────────────────────────────── */}
       <header style={{ marginBottom: "2rem" }}>
         <p className="eyebrow">Internal reference</p>
-        <h1>Design System</h1>
-        <p style={{ marginTop: "0.5rem", opacity: 0.75 }}>
-          Per-component documentation with live examples, design tokens, and
-          prop definitions. All components adhere to WCAG 2.1 AA and use
-          dark-mode-consistent design tokens.
+        <h1 style={{ margin: "0.25rem 0 0.5rem" }}>Design System</h1>
+        <p style={{ marginTop: 0, color: "var(--muted)", maxWidth: 600, lineHeight: 1.6 }}>
+          Per-component documentation with live examples, design tokens, and prop definitions.
+          All components adhere to <strong>WCAG 2.1 AA</strong> and use dark-mode-consistent
+          design tokens.
         </p>
+      </header>
 
-        <div style={{ display: "flex", gap: "0.75rem", marginTop: "1rem" }}>
+      {/* ── Tabbed navigation ────────────────────────────────────────────── */}
+      <div
+        role="tablist"
+        aria-label="Design system sections"
+        id={tabsId}
+        style={{
+          display: "flex",
+          gap: "0.25rem",
+          borderBottom: "2px solid var(--line)",
+          marginBottom: "2rem",
+          overflowX: "auto",
+        }}
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            id={`tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              padding: "0.6rem 1rem",
+              border: "none",
+              borderBottom: activeTab === tab.id ? "2px solid var(--accent)" : "2px solid transparent",
+              background: "transparent",
+              cursor: "pointer",
+              fontWeight: activeTab === tab.id ? 600 : 400,
+              color: activeTab === tab.id ? "var(--accent)" : "var(--muted)",
+              marginBottom: -2,
+              whiteSpace: "nowrap",
+              transition: "color 200ms, border-color 200ms",
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Components tab ─────────────────────────────────────────────────── */}
+      <div
+        id="panel-components"
+        role="tabpanel"
+        aria-labelledby="tab-components"
+        hidden={activeTab !== "components"}
+      >
+        {/* Search + bulk controls */}
+        <div
+          style={{
+            display: "flex",
+            gap: "0.75rem",
+            flexWrap: "wrap",
+            alignItems: "center",
+            marginBottom: "1.25rem",
+          }}
+        >
+          {/* Search input */}
+          <div
+            role="search"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              flex: "1 1 240px",
+              padding: "0.45rem 0.75rem",
+              borderRadius: "var(--radius-md, 16px)",
+              background: "var(--surface-soft)",
+              border: "1px solid var(--line)",
+            }}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              aria-hidden="true"
+              style={{ flexShrink: 0, color: "var(--muted)" }}
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.35-4.35" />
+            </svg>
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={handleSearchChange}
+              placeholder="Search components…"
+              aria-label="Filter components"
+              style={{
+                border: "none",
+                outline: "none",
+                background: "transparent",
+                color: "var(--text)",
+                width: "100%",
+                fontSize: "0.875rem",
+              }}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                aria-label="Clear search"
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--muted)",
+                  padding: 0,
+                  lineHeight: 1,
+                }}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+
+          {/* Bulk toggle buttons */}
           <button
             type="button"
             className="secondary-button"
             onClick={expandAll}
+            style={{ flexShrink: 0 }}
           >
             Expand all
           </button>
@@ -343,23 +1308,90 @@ export default function DesignSystemDocs(): JSX.Element {
             type="button"
             className="secondary-button"
             onClick={collapseAll}
+            style={{ flexShrink: 0 }}
           >
             Collapse all
           </button>
         </div>
-      </header>
 
-      {/* Component list */}
-      <main id="main-content" aria-label="Component documentation">
-        {COMPONENT_DOCS.map((doc) => (
-          <ComponentSection
-            key={doc.id}
-            doc={doc}
-            isOpen={openIds.has(doc.id)}
-            onToggle={() => toggle(doc.id)}
-          />
-        ))}
-      </main>
+        {/* Live-region for search result count */}
+        <p
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {searchQuery
+            ? `${filteredDocs.length} component${filteredDocs.length !== 1 ? "s" : ""} found`
+            : ""}
+        </p>
+
+        {/* Component list */}
+        <main id="main-content" aria-label="Component documentation">
+          {filteredDocs.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "3rem 1rem", color: "var(--muted)" }}>
+              <p style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>🔍</p>
+              <p>No components match "{searchQuery}".</p>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={clearSearch}
+                style={{ marginTop: "0.75rem" }}
+              >
+                Clear search
+              </button>
+            </div>
+          ) : (
+            filteredDocs.map((doc) => (
+              <ComponentSection
+                key={doc.id}
+                doc={doc}
+                isOpen={openIds.has(doc.id)}
+                onToggle={() => toggle(doc.id)}
+              />
+            ))
+          )}
+        </main>
+      </div>
+
+      {/* ── Colours tab ───────────────────────────────────────────────────── */}
+      <div
+        id="panel-colours"
+        role="tabpanel"
+        aria-labelledby="tab-colours"
+        hidden={activeTab !== "colours"}
+      >
+        <ColourPalette />
+      </div>
+
+      {/* ── Typography tab ────────────────────────────────────────────────── */}
+      <div
+        id="panel-typography"
+        role="tabpanel"
+        aria-labelledby="tab-typography"
+        hidden={activeTab !== "typography"}
+      >
+        <TypographyScale />
+      </div>
+
+      {/* ── Tokens tab ────────────────────────────────────────────────────── */}
+      <div
+        id="panel-tokens"
+        role="tabpanel"
+        aria-labelledby="tab-tokens"
+        hidden={activeTab !== "tokens"}
+      >
+        <SpacingReference />
+      </div>
+
+      {/* ── Utilities tab ─────────────────────────────────────────────────── */}
+      <div
+        id="panel-utilities"
+        role="tabpanel"
+        aria-labelledby="tab-utilities"
+        hidden={activeTab !== "utilities"}
+      >
+        <UtilityClassesReference />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #388 

Expand DesignSystemDocs page (src/pages/DesignSystemDocs.tsx) from a minimal 6-component accordion stub into a full, tabbed design-system reference for contributors and designers.

## What changed

### src/pages/DesignSystemDocs.tsx
- Added tabbed navigation: Components | Colours | Typography | Tokens | Utilities
- Colour palette section with themed swatches for all token groups (Background, Text, Brand & Actions, Semantic, Borders)
- Typography scale specimens rendered with the correct HTML element per level
- Spacing & radius token reference table (--radius-xl/lg/md, --transition-speed)
- CSS utility-class catalogue grouped by category (button, layout, typography, link, state)
- Expanded component catalogue from 6 to 11 entries, adding: Primary Button (with disabled state), Secondary Button, Danger Button, Surface Card, Eyebrow Label, Status Chip, Skip Link, SearchBar, Skeleton, EmptyState, ServerError
- Each component accordion now shows: live example, copy-enabled usage snippet, design-token chip list, and an enhanced props table with Required and Default columns
- Search / filter box across component names, descriptions, and tokens; auto-expands matching accordions; shows an empty state with clear action
- aria-live region announces filtered result counts to screen readers
- WCAG 2.1 AA: aria-expanded/controls on all accordions, role=tablist/tab/ tabpanel with aria-selected, role=search on the filter, sr-only live region

### src/pages/DesignSystemDocs.test.tsx
- Rewrote the test suite from 4 smoke tests to 34 focused tests covering:
    - Page heading and eyebrow label rendering
    - All five tabs present and correctly switching (aria-selected, panel visibility)
    - One tab selected at a time invariant
    - Accordion default-open, expand-all, collapse-all, individual toggle
    - aria-expanded and aria-controls correctness
    - Search: filter by name, token name, description keyword
    - Empty-state rendered on no-match query
    - Clear-search restores full list
    - Auto-expand on search query
    - aria-live result-count announcement
    - Copy-button presence and initial label
    - Colour palette group labels and individual token names (panel-scoped)
    - Typography specimen labels
    - Spacing token names
    - Utility class names and category headings (panel-scoped)
    - Accessibility: tabpanel/tab roles, aria-labelledby linkage, search landmark

All 34 tests pass. Pre-existing failures in Breadcrumb, density, ApiCard, FiltersSidebar, FiltersBottomSheet, and MarketplacePage are unrelated to this change.