### PR TITLE
feat: add API detail keyboard shortcut hints

### DIFF
--- a/src/components/KbdHint.tsx
+++ b/src/components/KbdHint.tsx
@@ -1,0 +1,24 @@
+import type { Shortcut } from "../hooks/useGlobalShortcuts";
+
+type KbdHintProps = {
+  shortcuts: readonly Shortcut[];
+  label?: string;
+};
+
+export default function KbdHint({
+  shortcuts,
+  label = "Keyboard shortcuts",
+}: KbdHintProps) {
+  if (shortcuts.length === 0) return null;
+
+  return (
+    <aside className="kbd-hint" aria-label={label}>
+      {shortcuts.map((shortcut) => (
+        <span className="kbd-hint__item" key={`${shortcut.key}-${shortcut.description}`}>
+          <kbd className="kbd-hint__key">{shortcut.key}</kbd>
+          <span>{shortcut.description}</span>
+        </span>
+      ))}
+    </aside>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1965,6 +1965,34 @@ code,
   background: var(--page-bg);
 }
 
+.kbd-hint {
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  padding: 8px 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.kbd-hint__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.kbd-hint__key {
+  min-width: 24px;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface-soft);
+  color: var(--text);
+  font: inherit;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
 /* The .api-detail-tabs button rule is now handled by .tabs-tab inside Tabs.tsx */
 
 .api-detail-two-column,
@@ -3108,6 +3136,17 @@ code,
 
   .api-detail-tabs {
     margin-bottom: 22px;
+  }
+
+  .kbd-hint {
+    justify-content: flex-start;
+    gap: 12px;
+    overflow-x: auto;
+    scrollbar-width: thin;
+  }
+
+  .kbd-hint__item {
+    flex: 0 0 auto;
   }
 
   /* Tighten tab button spacing on narrow viewports */
@@ -4930,4 +4969,3 @@ code,
     font-size: 0.6875rem; /* 11 px */
   }
 }
-

--- a/src/pages/ApiDetailPage.test.tsx
+++ b/src/pages/ApiDetailPage.test.tsx
@@ -123,6 +123,17 @@ describe("ApiDetailPage", () => {
     expect(screen.getByText("Integration Gallery")).toBeTruthy();
   });
 
+  it("shows the available page shortcuts next to the tab navigation", () => {
+    renderWithProviders(<ApiDetailPage />);
+    settleLoadingState();
+
+    const hint = screen.getByLabelText("Keyboard shortcuts");
+    expect(within(hint).getByText("Esc")).toBeTruthy();
+    expect(within(hint).getByText("Go back to Marketplace")).toBeTruthy();
+    expect(within(hint).getByText("1-5")).toBeTruthy();
+    expect(within(hint).getByText(/Switch tabs/)).toBeTruthy();
+  });
+
   // ── ApiDetailStickyTOC integration ────────────────────────────────────────
 
   it("renders the TOC nav when the documentation tab is active", () => {

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -21,6 +21,8 @@ import { useToast } from "../components/Toast";
 import { useCollections } from "../state/collectionsStore";
 import RelatedApisRail from "../components/RelatedApisRail";
 import MOCK_APIS from "../data/mockApis";
+import KbdHint from "../components/KbdHint";
+import { SHORTCUTS } from "../hooks/useGlobalShortcuts";
 
 /**
  * ApiDetailPage
@@ -103,6 +105,10 @@ const TAB_ITEMS = [
   { id: "reviews", label: "Reviews" },
   { id: "embed", label: "Embed" },
 ] as const satisfies Array<{ id: TabType; label: string }>;
+
+const API_DETAIL_SHORTCUTS = SHORTCUTS.filter(
+  (shortcut) => shortcut.category === "ApiDetailPage",
+);
 
 // ── Endpoint save controls ───────────────────────────────────────────────────
 
@@ -640,6 +646,7 @@ print(response.json())`;
             <div className="content-left">
               {/* Tab navigation */}
               <div className="api-detail-tabs no-print">
+                <KbdHint shortcuts={API_DETAIL_SHORTCUTS} />
                 <Tabs tabs={TAB_ITEMS} activeTab={tab} onChange={(id) => setTab(id as TabType)} />
               </div>
 


### PR DESCRIPTION
## Summary

- add a reusable `KbdHint` component backed by the existing shortcut registry
- show the ApiDetailPage shortcuts above the tab navigation
- use semantic `kbd` elements, design tokens, and responsive overflow behavior
- cover the visible shortcut content with a focused page test

## Testing

- `npm test -- --run src/pages/ApiDetailPage.test.tsx` (14 tests passed)
- `npm test -- --run` (baseline failures remain in unrelated tests, including Breadcrumb, ApiUsage, and a missing test dependency)
- `npm run build` (baseline TypeScript errors remain in unrelated files)

A browser smoke check is currently blocked by the existing duplicate `FiltersBottomSheet` import in `MarketplacePage.tsx`.

Closes #463