### PR TITLE
fix: improve ApiUsage breadcrumb accessibility

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -233,7 +233,7 @@ Navigation breadcrumb showing page hierarchy.
 
 - `aria-label="breadcrumb"` on nav
 - `aria-current="page"` on current item
-- Collapsed middle crumbs open from a real button with `aria-expanded` and `aria-controls`
+- Collapsed middle crumbs open from a real button with `aria-haspopup="menu"`, `aria-expanded`, and `aria-controls`
 - Keyboard navigation supports Enter/Space on links and buttons, Arrow Up/Down, Home, End, and Escape in the collapsed crumbs menu
 - Focus moves into the collapsed menu when opened and returns to the trigger when closed with Escape
 

--- a/src/ApiUsage.test.tsx
+++ b/src/ApiUsage.test.tsx
@@ -29,6 +29,19 @@ describe('ApiUsage - Filter Reset', () => {
       },
       writable: true,
     });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
     vi.clearAllMocks();
   });
 
@@ -36,22 +49,35 @@ describe('ApiUsage - Filter Reset', () => {
     render(<ApiUsage />);
     
     const resetButton = screen.getByRole('button', { name: /Reset Filters/i });
-    expect(resetButton).toBeDisabled();
+    expect((resetButton as HTMLButtonElement).disabled).toBe(true);
 
     // Change a filter to activate the reset button
-    const successTab = screen.getByRole('button', { name: /Success/i });
+    const successTab = screen.getByRole('tab', { name: /Success/i });
     fireEvent.click(successTab);
 
-    expect(resetButton).not.toBeDisabled();
+    expect((resetButton as HTMLButtonElement).disabled).toBe(false);
 
     // Reset filters
     fireEvent.click(resetButton);
 
     // Verify filters are reset
-    expect(resetButton).toBeDisabled();
+    expect((resetButton as HTMLButtonElement).disabled).toBe(true);
     
     // Verify screen reader announcement
     const srAnnouncement = screen.getByRole('status');
     expect(srAnnouncement.textContent).toBe('Filters reset. Showing all calls from the last 24 hours.');
+  });
+
+  it('renders an accessible breadcrumb with the current page announced', () => {
+    render(<ApiUsage />);
+
+    const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(breadcrumb).toBeTruthy();
+
+    const marketplaceLink = screen.getByRole('link', { name: 'Marketplace' });
+    expect(marketplaceLink.getAttribute('href')).toBe('/marketplace');
+
+    const currentCrumb = screen.getByText('User Profile API usage');
+    expect(currentCrumb.getAttribute('aria-current')).toBe('page');
   });
 });

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -5,24 +5,25 @@ import { formatPrice } from './utils/format';
 import type { JsonSchema } from './components/RequestBodyEditor';
 import CallHistoryRow from './components/CallHistoryRow';
 import Breadcrumb from './components/Breadcrumb';
+import RequestHistoryPanel from './components/RequestHistoryPanel';
 import ParamsBuilder from './components/ParamsBuilder';
 import { useFetchTracker } from './hooks/useFetchTracker';
 import { useQuota } from './hooks/useQuota';
 import PlanNudge from './components/PlanNudge';
 import CallsHeatmap from './components/CallsHeatmap';
 import Tabs from './components/Tabs';
+import { Icons } from './utils/icons';
+import { LinkIcon } from './components/icons';
+import {
+  clearHistory,
+  loadHistory,
+  saveEntry,
+  type HistoryEntry,
+} from './state/testCallHistory';
+import { copySnapshotUrl, parseSnapshotUrl } from './utils/snapshotUrl';
 
 const MOCK_USAGE_PERCENT = 80;
 const LOADING_DELAY_MS = 500;
-const Icons = { History: () => null };
-const LinkIcon = () => null;
-type HistoryEntry = any;
-const saveEntry = (entry: any) => {};
-const loadHistory = () => [];
-const clearHistory = () => {};
-const parseSnapshotUrl = (url: string) => ({} as any);
-const copySnapshotUrl = async (path: string, params: any) => true;
-
 
 type ApiEndpoint = {
   id: string;

--- a/src/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb.test.tsx
@@ -44,6 +44,7 @@ describe("Breadcrumb", () => {
     expect(button?.getAttribute("aria-label")).toBe(
       "Show collapsed breadcrumb items",
     );
+    expect(button.getAttribute("aria-haspopup")).toBe("menu");
     expect(button.getAttribute("aria-expanded")).toBe("false");
 
     fireEvent.click(button);
@@ -56,6 +57,9 @@ describe("Breadcrumb", () => {
     );
 
     expect(popover).toBeTruthy();
+    expect(popover?.getAttribute("aria-label")).toBe(
+      "Collapsed breadcrumb items",
+    );
     expect(menuItems.map((item) => item.textContent)).toEqual([
       "Developer Tools",
       "Very Long Machine Learning API Name",
@@ -89,20 +93,48 @@ describe("Breadcrumb", () => {
 
     fireEvent.click(button);
 
-    const menuItems = screen.getAllByRole("menuitem");
+    const menu = container.querySelector<HTMLElement>('[role="menu"]');
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('[role="menuitem"]'),
+    );
+
+    if (!menu) throw new Error("Expected breadcrumb popover menu");
+
     expect(document.activeElement).toBe(menuItems[0]);
 
-    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(document.activeElement).toBe(menuItems[1]);
 
-    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(document.activeElement).toBe(menuItems[0]);
 
-    fireEvent.keyDown(screen.getByRole("menu"), { key: "End" });
+    fireEvent.keyDown(menu, { key: "End" });
     expect(document.activeElement).toBe(menuItems[1]);
 
-    fireEvent.keyDown(screen.getByRole("menu"), { key: "Home" });
+    fireEvent.keyDown(menu, { key: "Home" });
     expect(document.activeElement).toBe(menuItems[0]);
+  });
+
+  it("wraps focus to the last collapsed crumb on ArrowUp", () => {
+    const { container } = render(<Breadcrumb items={longBreadcrumb} />);
+
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+
+    if (!button) throw new Error("Expected breadcrumb ellipsis button");
+
+    fireEvent.click(button);
+
+    const menu = container.querySelector<HTMLElement>('[role="menu"]');
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('[role="menuitem"]'),
+    );
+
+    if (!menu) throw new Error("Expected breadcrumb popover menu");
+
+    fireEvent.keyDown(menu, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(menuItems[1]);
   });
 
   it("returns focus to the ellipsis button when closing the popover with Escape", () => {
@@ -115,10 +147,14 @@ describe("Breadcrumb", () => {
     if (!button) throw new Error("Expected breadcrumb ellipsis button");
 
     fireEvent.click(button);
-    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+    const menu = container.querySelector<HTMLElement>('[role="menu"]');
+
+    if (!menu) throw new Error("Expected breadcrumb popover menu");
+
+    fireEvent.keyDown(menu, { key: "Escape" });
 
     expect(button.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.queryByRole("menu")).toBeNull();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
     expect(document.activeElement).toBe(button);
   });
 

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -93,11 +93,15 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
 
     switch (event.key) {
       case "ArrowDown":
-        focusMenuItem((currentIndex + 1) % menuItems.length);
+        focusMenuItem(
+          currentIndex === -1 ? 0 : (currentIndex + 1) % menuItems.length,
+        );
         break;
       case "ArrowUp":
         focusMenuItem(
-          (currentIndex - 1 + menuItems.length) % menuItems.length,
+          currentIndex === -1
+            ? menuItems.length - 1
+            : (currentIndex - 1 + menuItems.length) % menuItems.length,
         );
         break;
       case "Home":
@@ -283,6 +287,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                     type="button"
                     className="breadcrumb-ellipsis"
                     aria-label="Show collapsed breadcrumb items"
+                    aria-haspopup="menu"
                     aria-expanded={isPopoverOpen}
                     aria-controls={popoverId}
                     onClick={() => setIsPopoverOpen((open) => !open)}
@@ -295,6 +300,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                       className="breadcrumb-popover"
                       id={popoverId}
                       role="menu"
+                      aria-label="Collapsed breadcrumb items"
                       onKeyDown={handlePopoverKeyDown}
                     >
                       <ol className="breadcrumb-popover-list">


### PR DESCRIPTION
## Overview

This PR improves the shared breadcrumb accessibility used by the ApiUsage page so the current page is announced correctly and collapsed breadcrumb items behave like a proper keyboard-navigable menu.

## Related Issue

Closes #374

## Changes

### Breadcrumb accessibility

* **[MODIFY]** `src/components/Breadcrumb.tsx`
  * Adds `aria-haspopup=menu` to the collapsed breadcrumb trigger.
  * Adds an accessible label for the collapsed breadcrumb menu.
  * Hardens Arrow Up / Arrow Down keyboard navigation when focus needs to wrap inside the collapsed menu.

* **[MODIFY]** `src/components/Breadcrumb.test.tsx`
  * Adds focused coverage for the collapsed menu semantics.
  * Adds keyboard coverage for ArrowUp wrapping and Escape focus return.

### ApiUsage coverage

* **[MODIFY]** `src/ApiUsage.test.tsx`
  * Adds a regression test that verifies the ApiUsage breadcrumb landmark is rendered and the current crumb exposes `aria-current=page`.
  * Updates the existing filter-reset test so it matches the current Tabs semantics in the page.

* **[MODIFY]** `src/ApiUsage.tsx`
  * Replaces placeholder imports used in the page with the real shared helpers and components referenced by the tests.

### Documentation

* **[MODIFY]** `docs/UI-Design-System.md`
  * Documents the breadcrumb trigger's `aria-haspopup=menu` behavior.

## Verification Results

```bash
npm test -- src/components/Breadcrumb.test.tsx src/ApiUsage.test.tsx
```

✅ 9/9 passed

| Acceptance Criteria | Status |
| --- | --- |
| Implementation matches the issue | ✅ Breadcrumb trigger/menu semantics improved for ApiUsage breadcrumb usage |
| Tests added and passing | ✅ Focused breadcrumb and ApiUsage regression tests added and passing |
| API / visible changes documented | ✅ UI design system breadcrumb accessibility note updated |
| Keyboard accessibility verified | ✅ Arrow navigation, Escape close, and current-page announcement covered |