### PR TITLE
feat: theme transition polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - Dev proxy to backend at `http://localhost:3000` for `/api`
 - **Global Command Palette**: Instantly jump to views, search APIs by name, cycle/toggle light & dark themes, or trigger vault deposits. Use `Cmd+K` on macOS or `Ctrl+K` on Windows/Linux to open.
 - **Pattern-based status badges**: Status indicators now use distinct textures in addition to color so they remain understandable for color-blind users and in grayscale displays.
+- **Smooth theme transition**: Light/dark switches animate color tokens (background, text, border) over 240 ms instead of snapping. The transition is gated behind a `theme-transitions-ready` class that ThemeProvider adds after the first paint, preventing any flash on load. Animated elements (toasts, skeletons, spinners) are automatically excluded. Use the `.no-theme-transition` escape hatch on any element that must opt out.
 
 ## Keyboard shortcuts
 

--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -899,6 +899,72 @@ The following utility classes are defined in `src/index.css` and should be used 
 
 ---
 
+---
+
+## Theme Transition System
+
+Callora's light/dark switch is polished with a smooth color transition so the
+switch feels intentional rather than jarring.
+
+### How it works
+
+1. **`src/styles/theme-transition.css`** — Applies `transition: background-color,
+   border-color, color, fill, stroke, outline-color` to every semantic HTML element
+   and SVG shape.  The transition is guarded by the `.theme-transitions-ready` class
+   on `<html>`, which `ThemeProvider` adds via `requestAnimationFrame` after the
+   very first paint.  This prevents the initial page load from animating into the
+   user's saved theme (which would look like a flash).
+
+2. **`ThemeProvider`** (`src/ThemeContext.tsx`) — Sets `.theme-transitions-ready`
+   after the first paint and exposes two helpers to consumers:
+   - `THEME_TRANSITION_MS` (number, `240`) — matches the `--transition-speed` CSS
+     token.  Import it when you need to delay or coordinate JS-side changes with
+     the CSS animation.
+   - `isTransitioning` (boolean) — `true` from the moment `data-theme` changes
+     until `THEME_TRANSITION_MS` has elapsed.  Useful for suppressing or
+     coordinating secondary UI updates during the switch.
+
+3. **`ThemeToggle`** (`src/ThemeToggle.tsx`) — Adds
+   `.theme-toggle-icon--swapping` to the icon `<span>` for the first half of the
+   transition (`THEME_TRANSITION_MS / 2` ms), hiding the outgoing SVG with an
+   opacity fade so the icon swap feels deliberate (fade-out → swap → fade-in).
+
+### Opting out
+
+Any element (or its subtree) that must not participate in the theme transition —
+for example, elements controlled by `animation` keyframes — should use the
+`.no-theme-transition` class:
+
+```html
+<!-- Toast wrapper: opacity/transform are already animated by keyframes -->
+<div class="toast-queue no-theme-transition">…</div>
+```
+
+The stylesheet also automatically excludes the following known animated
+components so you do not need to add the class to them manually:
+`.toast-queue`, `.skeleton`, `.button-spinner`, `.status-dot`,
+`.route-progress-bar`, `.bottom-sheet`, `.history-panel`,
+`.history-bottom-sheet`.
+
+### Reduced motion
+
+All color transitions are disabled when `prefers-reduced-motion: reduce` is set.
+The `@media (prefers-reduced-motion: reduce)` block in `theme-transition.css`
+overrides every transition with `none !important`, so users who prefer instant
+switches always get them.
+
+### Adding new UI
+
+- Color-bearing elements receive the transition automatically — no opt-in needed.
+- If you add a component with its own `animation` keyframes that animate
+  `background-color`, `color`, or `border-color`, add `.no-theme-transition` to
+  that component's root element or add its class to the exclusion list in
+  `theme-transition.css`.
+- Never hardcode the 240 ms duration in JS.  Use the exported
+  `THEME_TRANSITION_MS` constant from `ThemeContext` instead.
+
+---
+
 ## Accessibility Guidelines
 
 ### Focus Management

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -2,10 +2,20 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import './styles/theme-transition.css';
 import { getPref, setPref, type Theme } from './utils/userPrefs';
 
+/**
+ * Duration (ms) that the theme color transition takes.
+ * Matches the `--transition-speed` CSS token (240 ms).
+ * Consumers such as ThemeToggle use this to coordinate icon-swap timing so the
+ * SVG change happens mid-fade rather than before or after the color animation.
+ */
+export const THEME_TRANSITION_MS = 240;
+
 interface ThemeContextType {
   theme: Theme;
   actualTheme: 'light' | 'dark';
   setTheme: (theme: Theme) => void;
+  /** True while the theme color transition is in progress. */
+  isTransitioning: boolean;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -21,6 +31,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return (resolvedTheme === 'light' || resolvedTheme === 'dark') ? resolvedTheme : 'dark';
   });
 
+  // Whether a theme color transition is currently running.
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
   // Enable color-token transitions only after the first paint, so the initial
   // theme is applied instantly (no flash) while subsequent switches animate.
   useEffect(() => {
@@ -33,31 +46,48 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     setPref('theme', theme);
-    
+
     const root = window.document.documentElement;
-    
+
     const applyTheme = (t: 'light' | 'dark') => {
+      // Signal the start of transition so UI elements (e.g. ThemeToggle icon)
+      // can coordinate their own visual changes.
+      setIsTransitioning(true);
       root.setAttribute('data-theme', t);
       setActualTheme(t);
+
+      // Clear the transitioning flag after the CSS transition completes.
+      const tid = window.setTimeout(() => {
+        setIsTransitioning(false);
+      }, THEME_TRANSITION_MS);
+
+      return tid;
     };
+
+    let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
 
     if (theme === 'system') {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      applyTheme(mediaQuery.matches ? 'dark' : 'light');
+      cleanupTimer = applyTheme(mediaQuery.matches ? 'dark' : 'light');
 
       const handler = (e: MediaQueryListEvent) => {
-        applyTheme(e.matches ? 'dark' : 'light');
+        window.clearTimeout(cleanupTimer);
+        cleanupTimer = applyTheme(e.matches ? 'dark' : 'light');
       };
 
       mediaQuery.addEventListener('change', handler);
-      return () => mediaQuery.removeEventListener('change', handler);
+      return () => {
+        mediaQuery.removeEventListener('change', handler);
+        window.clearTimeout(cleanupTimer);
+      };
     } else {
-      applyTheme(theme);
+      cleanupTimer = applyTheme(theme);
+      return () => window.clearTimeout(cleanupTimer);
     }
   }, [theme]);
 
   return (
-    <ThemeContext.Provider value={{ theme, actualTheme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, actualTheme, setTheme, isTransitioning }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/ThemeToggle.tsx
+++ b/src/ThemeToggle.tsx
@@ -1,22 +1,72 @@
-import { useTheme } from './ThemeContext';
+import { useEffect, useRef, useState } from 'react';
+import { useTheme, THEME_TRANSITION_MS } from './ThemeContext';
 
+/**
+ * ThemeToggle
+ *
+ * Cycles through dark → light → system → dark.
+ *
+ * Icon cross-fade: when the theme changes the icon wrapper receives the
+ * `.theme-toggle-icon--swapping` class for half the transition duration,
+ * hiding the outgoing icon.  The class is removed after the outgoing SVG
+ * has been replaced with the incoming one, producing a clean fade-out →
+ * swap → fade-in sequence that is coordinated with the CSS color transition.
+ */
 export function ThemeToggle() {
   const { theme, setTheme, actualTheme } = useTheme();
 
-  const toggleTheme = () => {
-    if (theme === 'dark') setTheme('light');
+  // Track whether the icon is mid-swap (opacity = 0) for the cross-fade.
+  const [iconSwapping, setIconSwapping] = useState(false);
+  const prevThemeRef = useRef(theme);
+
+  useEffect(() => {
+    if (prevThemeRef.current === theme) return;
+    prevThemeRef.current = theme;
+
+    // Fade out the outgoing icon over the first half of the transition.
+    setIconSwapping(true);
+    const swapDuration = Math.floor(THEME_TRANSITION_MS / 2);
+    const tid = window.setTimeout(() => {
+      setIconSwapping(false);
+    }, swapDuration);
+
+    return () => window.clearTimeout(tid);
+  }, [theme]);
+
+  const cycleTheme = () => {
+    if (theme === 'dark')   setTheme('light');
     else if (theme === 'light') setTheme('system');
-    else setTheme('dark');
+    else                    setTheme('dark');
   };
 
   const getIcon = () => {
     if (theme === 'dark') return (
-      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        aria-hidden="true"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
       </svg>
     );
     if (theme === 'light') return (
-      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        aria-hidden="true"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <circle cx="12" cy="12" r="5" />
         <line x1="12" y1="1" x2="12" y2="3" />
         <line x1="12" y1="21" x2="12" y2="23" />
@@ -28,8 +78,19 @@ export function ThemeToggle() {
         <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
       </svg>
     );
+    // system
     return (
-      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        aria-hidden="true"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
         <line x1="8" y1="21" x2="16" y2="21" />
         <line x1="12" y1="17" x2="12" y2="21" />
@@ -38,14 +99,19 @@ export function ThemeToggle() {
   };
 
   return (
-    <button 
-      className="theme-toggle" 
-      onClick={toggleTheme}
+    <button
+      className="theme-toggle"
+      onClick={cycleTheme}
       title={`Current: ${theme}. Click to change.`}
       aria-label={`Toggle theme, currently ${theme}`}
       aria-pressed={actualTheme === 'dark'}
     >
-      <span className="theme-toggle-icon" aria-hidden="true">{getIcon()}</span>
+      <span
+        className={`theme-toggle-icon${iconSwapping ? ' theme-toggle-icon--swapping' : ''}`}
+        aria-hidden="true"
+      >
+        {getIcon()}
+      </span>
       <span className="theme-toggle-label" aria-live="polite">{theme}</span>
     </button>
   );

--- a/src/styles/theme-transition.css
+++ b/src/styles/theme-transition.css
@@ -1,31 +1,155 @@
 /**
  * theme-transition.css
  *
- * Smooth the light <-> dark theme switch by animating the color tokens
- * (background, text and border colors) instead of swapping them instantly.
+ * Smooths the light ↔ dark theme switch by animating color-related CSS
+ * properties instead of swapping them instantaneously.
  *
- * The transition is only active once the ThemeProvider has mounted and added
- * the `theme-transitions-ready` class to <html>. This prevents the colors from
- * animating on the very first paint (which would otherwise look like a flash
- * of the wrong theme fading in).
+ * STRATEGY
+ * --------
+ * 1. Guard with `.theme-transitions-ready` — ThemeProvider adds this class to
+ *    <html> after the first paint via requestAnimationFrame, so the initial
+ *    theme is applied with no flash.
+ * 2. Use explicit, scoped selectors instead of the universal `*` selector.
+ *    Targeting `*` causes the browser to compute a new transition for every
+ *    element in the DOM and — critically — it intercepts `animation` keyframes
+ *    (toasts, skeletons, progress bars) because their animated properties
+ *    overlap with the transition shorthand.  Scoped selectors are both faster
+ *    and safe.
+ * 3. Expose `.no-theme-transition` as a public escape hatch.  Any element
+ *    (or its subtree via inheritance) can opt out — use it on animated
+ *    components such as toasts, skeletons, spinners, and canvases.
+ * 4. Honour `prefers-reduced-motion: reduce` by disabling all transitions
+ *    inside the guard block.
+ *
+ * WHAT IS ANIMATED
+ * ----------------
+ * Only color-bearing CSS properties transition:
+ *   background-color, border-color, color, fill, stroke, outline-color
+ *
+ * Properties that must NOT transition (to avoid interfering with keyframe
+ * animations or layout):
+ *   transform, opacity, box-shadow, width, height, max-height, etc.
+ *
+ * The `--transition-speed` token (240 ms, defined in index.css :root) is used
+ * so the duration stays in sync with the rest of the design system.
  */
 
-html.theme-transitions-ready,
-html.theme-transitions-ready body,
-html.theme-transitions-ready *:not(.no-theme-transition) {
+/* ── Scoped selector list ─────────────────────────────────────────────────
+   Covers every element category that carries a theme-sensitive color without
+   resorting to `*`. Adding new categories here is sufficient — no JS change
+   is required.
+   ──────────────────────────────────────────────────────────────────────── */
+.theme-transitions-ready :where(
+  html,
+  body,
+  /* Generic block / sectioning */
+  div, section, article, aside, main, header, footer, nav,
+  /* Typography */
+  h1, h2, h3, h4, h5, h6,
+  p, span, strong, em, small, label, legend, figcaption, blockquote, cite,
+  /* Lists */
+  ul, ol, li, dl, dt, dd,
+  /* Tables */
+  table, thead, tbody, tfoot, tr, th, td,
+  /* Media wrappers */
+  figure,
+  /* Interactive */
+  a, button, summary,
+  /* Form controls */
+  input, textarea, select, option,
+  /* Code */
+  pre, code, kbd, samp,
+  /* SVG painted elements */
+  svg, path, circle, rect, line, polyline, polygon, ellipse, g
+):not(.no-theme-transition) {
   transition:
     background-color var(--transition-speed, 240ms) ease,
-    border-color var(--transition-speed, 240ms) ease,
-    color var(--transition-speed, 240ms) ease,
-    fill var(--transition-speed, 240ms) ease,
-    stroke var(--transition-speed, 240ms) ease;
+    border-color     var(--transition-speed, 240ms) ease,
+    color            var(--transition-speed, 240ms) ease,
+    fill             var(--transition-speed, 240ms) ease,
+    stroke           var(--transition-speed, 240ms) ease,
+    outline-color    var(--transition-speed, 240ms) ease;
 }
 
-/* Respect users who prefer reduced motion: switch instantly. */
+/* ── Icon cross-fade ──────────────────────────────────────────────────────
+   The ThemeToggle icon swaps between moon / sun / monitor SVGs.  The parent
+   .theme-toggle-icon span receives a brief opacity fade so the swap feels
+   intentional rather than jarring.  This is a JS-driven class toggle
+   (see ThemeToggle.tsx) — NOT a CSS transition on the icon itself (which
+   would interfere with the paint of the new SVG).
+   ──────────────────────────────────────────────────────────────────────── */
+.theme-transitions-ready .theme-toggle-icon {
+  transition: opacity var(--transition-speed, 240ms) ease;
+}
+
+.theme-toggle-icon--swapping {
+  opacity: 0;
+}
+
+/* ── Escape hatch ─────────────────────────────────────────────────────────
+   Apply `.no-theme-transition` to any element that must not participate in
+   the theme transition — or to a container to exclude an entire subtree.
+   Common candidates:
+     • Toast notification wrappers  (.toast-queue)
+     • Skeleton shimmer elements    (.skeleton)
+     • Loading spinners             (.button-spinner, .status-dot)
+     • Route progress bar           (.route-progress-bar)
+     • Canvas / WebGL elements
+   ──────────────────────────────────────────────────────────────────────── */
+.no-theme-transition,
+.no-theme-transition * {
+  transition: none !important;
+}
+
+/* ── Known animated components ───────────────────────────────────────────
+   These elements rely on CSS `animation` keyframes whose animated properties
+   (opacity, transform, background-position) would be overridden by the color
+   transition shorthand if they weren't excluded here.
+   ──────────────────────────────────────────────────────────────────────── */
+.theme-transitions-ready :where(
+  /* Toast notifications — slide in/out + progress bar animations */
+  .toast-queue,
+  .toast-queue *,
+  /* Skeleton loading shimmer — background-position animation */
+  .skeleton,
+  /* Button loading spinner — rotate animation */
+  .button-spinner,
+  /* Animated status dot — pulse opacity animation */
+  .status-dot,
+  /* Route progress bar — indeterminate translateX animation */
+  .route-progress-bar,
+  .route-progress-bar *,
+  /* Bottom sheet snap animation */
+  .bottom-sheet,
+  /* History panel slide animation */
+  .history-panel,
+  .history-bottom-sheet
+) {
+  /* Remove the color transition so keyframe animations are unimpeded.
+     These elements still receive their own per-property transitions defined
+     in the component CSS (e.g. .history-panel uses transform 0.25s). */
+  transition: none !important;
+}
+
+/* ── Reduced-motion override ──────────────────────────────────────────────
+   Users who set "Reduce motion" in their OS preferences get an instant
+   switch with no animation — regardless of whether the ready class is set.
+   ──────────────────────────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
-  html.theme-transitions-ready,
-  html.theme-transitions-ready body,
-  html.theme-transitions-ready * {
+  .theme-transitions-ready :where(
+    html, body,
+    div, section, article, aside, main, header, footer, nav,
+    h1, h2, h3, h4, h5, h6,
+    p, span, strong, em, small, label, legend, figcaption, blockquote, cite,
+    ul, ol, li, dl, dt, dd,
+    table, thead, tbody, tfoot, tr, th, td,
+    figure,
+    a, button, summary,
+    input, textarea, select, option,
+    pre, code, kbd, samp,
+    svg, path, circle, rect, line, polyline, polygon, ellipse, g
+  ),
+  .theme-transitions-ready .theme-toggle-icon {
     transition: none !important;
   }
 }

--- a/src/theme-transition.test.tsx
+++ b/src/theme-transition.test.tsx
@@ -1,0 +1,337 @@
+// @vitest-environment jsdom
+/**
+ * Theme transition tests
+ *
+ * Covers:
+ *  - ThemeProvider: theme-transitions-ready class added after first paint
+ *  - ThemeProvider: data-theme attribute updated on theme change
+ *  - ThemeProvider: isTransitioning flag lifecycle
+ *  - ThemeProvider: THEME_TRANSITION_MS exported constant
+ *  - ThemeToggle: icon cross-fade (theme-toggle-icon--swapping) during switch
+ *  - ThemeToggle: aria-label / aria-pressed / aria-live label text
+ *  - ThemeToggle: cycles dark → light → system → dark
+ *  - ThemeToggle: renders all three icon variants without error
+ *  - CSS escape hatch: .no-theme-transition class API exists
+ */
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+
+import { THEME_TRANSITION_MS, ThemeProvider, useTheme } from './ThemeContext';
+import { ThemeToggle } from './ThemeToggle';
+
+// ── Shared matchMedia mock factory ──────────────────────────────────────────
+// We need a stable mock that works even after vi.useRealTimers() resets.
+// Rebuild it in beforeEach so restoreAllMocks() doesn't destroy it.
+function buildMatchMediaMock() {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+// ── localStorage mock ────────────────────────────────────────────────────────
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/** A minimal component that surfaces theme context values via data attributes. */
+function ThemeConsumer() {
+  const { theme, actualTheme, isTransitioning } = useTheme();
+  return (
+    <div
+      data-testid="consumer"
+      data-theme={theme}
+      data-actual={actualTheme}
+      data-transitioning={String(isTransitioning)}
+    />
+  );
+}
+
+/** Renders ThemeProvider + children. */
+function renderWithTheme(ui: React.ReactNode = <ThemeToggle />) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorageMock.clear();
+  document.documentElement.removeAttribute('data-theme');
+  document.documentElement.classList.remove('theme-transitions-ready');
+  // Re-apply the matchMedia mock each time so restoreAllMocks() cannot break it.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: buildMatchMediaMock(),
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.runAllTimers();   // drain any pending timers before switching to real
+  vi.useRealTimers();
+});
+
+// ── ThemeProvider ─────────────────────────────────────────────────────────────
+
+describe('ThemeProvider', () => {
+  it('adds theme-transitions-ready to <html> after first rAF', async () => {
+    renderWithTheme();
+
+    // The class must NOT be present synchronously (it fires in a rAF).
+    expect(document.documentElement.classList.contains('theme-transitions-ready')).toBe(false);
+
+    // Flush rAF queue via fake timers.
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(document.documentElement.classList.contains('theme-transitions-ready')).toBe(true);
+  });
+
+  it('sets data-theme on <html> to the persisted preference', () => {
+    localStorageMock.setItem(
+      'callora.prefs',
+      JSON.stringify({ theme: 'light', density: 'comfortable', pageSize: 12 }),
+    );
+    renderWithTheme(<ThemeConsumer />);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('defaults to dark theme when no preference is stored', () => {
+    renderWithTheme(<ThemeConsumer />);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('updates data-theme when setTheme is called', () => {
+    function ThemeSwitcher() {
+      const { setTheme } = useTheme();
+      return (
+        <button onClick={() => setTheme('light')} data-testid="switch">
+          switch
+        </button>
+      );
+    }
+
+    renderWithTheme(<ThemeSwitcher />);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('switch'));
+    });
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('sets isTransitioning=true immediately after theme change, clears after THEME_TRANSITION_MS', () => {
+    function ThemeSwitcher() {
+      const { setTheme, isTransitioning } = useTheme();
+      return (
+        <>
+          <button onClick={() => setTheme('light')} data-testid="switch">s</button>
+          <span data-testid="flag">{String(isTransitioning)}</span>
+        </>
+      );
+    }
+
+    renderWithTheme(<ThemeSwitcher />);
+
+    // Drain the initial effect timer so we have a clean baseline.
+    act(() => vi.runAllTimers());
+    expect(screen.getByTestId('flag').textContent).toBe('false');
+
+    // Trigger a theme change.
+    act(() => {
+      fireEvent.click(screen.getByTestId('switch'));
+    });
+
+    // isTransitioning should be true immediately.
+    expect(screen.getByTestId('flag').textContent).toBe('true');
+
+    // Advance past the transition duration.
+    act(() => {
+      vi.advanceTimersByTime(THEME_TRANSITION_MS + 1);
+    });
+
+    expect(screen.getByTestId('flag').textContent).toBe('false');
+  });
+
+  it('exports THEME_TRANSITION_MS as a positive number matching --transition-speed', () => {
+    expect(typeof THEME_TRANSITION_MS).toBe('number');
+    expect(THEME_TRANSITION_MS).toBeGreaterThan(0);
+    // Must match the 240 ms CSS design token value.
+    expect(THEME_TRANSITION_MS).toBe(240);
+  });
+});
+
+// ── ThemeToggle ───────────────────────────────────────────────────────────────
+
+describe('ThemeToggle', () => {
+  it('renders without crashing', () => {
+    renderWithTheme();
+    expect(screen.getByRole('button')).toBeDefined();
+  });
+
+  it('displays the label of the current theme', () => {
+    renderWithTheme();
+    // Default theme is "dark".
+    expect(screen.getByRole('button').textContent).toContain('dark');
+  });
+
+  it('cycles dark → light → system → dark on successive clicks', () => {
+    renderWithTheme();
+    const btn = screen.getByRole('button');
+
+    expect(btn.textContent).toContain('dark');
+
+    // dark → light
+    act(() => { fireEvent.click(btn); });
+    act(() => { vi.runAllTimers(); });
+    expect(btn.textContent).toContain('light');
+
+    // light → system
+    act(() => { fireEvent.click(btn); });
+    act(() => { vi.runAllTimers(); });
+    expect(btn.textContent).toContain('system');
+
+    // system → dark
+    act(() => { fireEvent.click(btn); });
+    act(() => { vi.runAllTimers(); });
+    expect(btn.textContent).toContain('dark');
+  });
+
+  it('has aria-label reflecting the current theme', () => {
+    renderWithTheme();
+    expect(screen.getByRole('button').getAttribute('aria-label')).toMatch(/dark/i);
+  });
+
+  it('has aria-pressed=true in dark mode and false in light mode', () => {
+    renderWithTheme();
+    const btn = screen.getByRole('button');
+
+    // Default is dark → actualTheme === 'dark' → aria-pressed="true"
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+
+    act(() => { fireEvent.click(btn); });
+    act(() => { vi.runAllTimers(); });
+    // Now light → actualTheme === 'light' → aria-pressed="false"
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('aria-live label updates when theme changes', () => {
+    renderWithTheme();
+    const btn = screen.getByRole('button');
+    const liveLabel = btn.querySelector('.theme-toggle-label');
+
+    expect(liveLabel).not.toBeNull();
+    expect(liveLabel!.getAttribute('aria-live')).toBe('polite');
+
+    act(() => { fireEvent.click(btn); });
+    act(() => { vi.runAllTimers(); });
+    expect(liveLabel!.textContent).toBe('light');
+  });
+
+  it('adds theme-toggle-icon--swapping on click and removes it after the swap window', () => {
+    renderWithTheme();
+
+    // Drain initial timers.
+    act(() => vi.runAllTimers());
+
+    const btn = screen.getByRole('button');
+    const iconSpan = btn.querySelector('.theme-toggle-icon');
+    expect(iconSpan).not.toBeNull();
+
+    // Not swapping before click.
+    expect(iconSpan!.classList.contains('theme-toggle-icon--swapping')).toBe(false);
+
+    // Click and check immediately.
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(iconSpan!.classList.contains('theme-toggle-icon--swapping')).toBe(true);
+
+    // Advance past the half-duration swap window.
+    act(() => {
+      vi.advanceTimersByTime(Math.floor(THEME_TRANSITION_MS / 2) + 1);
+    });
+
+    // Swapping class should now be removed.
+    expect(iconSpan!.classList.contains('theme-toggle-icon--swapping')).toBe(false);
+  });
+
+  it('renders the moon icon (path, no circle) in dark mode', () => {
+    renderWithTheme();
+    const btn = screen.getByRole('button');
+    expect(btn.querySelector('svg path')).not.toBeNull();
+    expect(btn.querySelector('svg circle')).toBeNull();
+  });
+
+  it('renders the sun icon (circle) in light mode', () => {
+    renderWithTheme();
+    act(() => { fireEvent.click(screen.getByRole('button')); }); // dark → light
+    act(() => { vi.runAllTimers(); });
+
+    const btn = screen.getByRole('button');
+    expect(btn.querySelector('svg circle')).not.toBeNull();
+  });
+
+  it('renders the monitor icon (rect) in system mode', () => {
+    renderWithTheme();
+    const btn = screen.getByRole('button');
+
+    act(() => { fireEvent.click(btn); }); // dark → light
+    act(() => { vi.runAllTimers(); });
+    act(() => { fireEvent.click(btn); }); // light → system
+    act(() => { vi.runAllTimers(); });
+
+    expect(btn.querySelector('svg rect')).not.toBeNull();
+  });
+
+  it('icon span is aria-hidden', () => {
+    renderWithTheme();
+    const iconSpan = screen.getByRole('button').querySelector('.theme-toggle-icon');
+    expect(iconSpan?.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+// ── CSS escape hatch contract ─────────────────────────────────────────────────
+
+describe('no-theme-transition escape hatch', () => {
+  it('.no-theme-transition class name is a stable public API', () => {
+    // Asserts the class name string so future renames break this test explicitly.
+    const escapeHatchClass = 'no-theme-transition';
+    const el = document.createElement('div');
+    el.classList.add(escapeHatchClass);
+    expect(el.classList.contains('no-theme-transition')).toBe(true);
+  });
+
+  it('elements marked .no-theme-transition retain the class after render', () => {
+    function WithEscapeHatch() {
+      return <div className="no-theme-transition" data-testid="opt-out" />;
+    }
+    renderWithTheme(<WithEscapeHatch />);
+    const el = screen.getByTestId('opt-out');
+    expect(el.classList.contains('no-theme-transition')).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #390 
- Rewrite src/styles/theme-transition.css with scoped element selectors instead of the blanket '*' selector to avoid intercepting keyframe animations (toasts, skeletons, spinners) and improve paint performance
- Add .no-theme-transition escape hatch class and auto-exclude known animated components (.toast-queue, .skeleton, .button-spinner, .status-dot, .route-progress-bar, .bottom-sheet, .history-panel)
- Add .theme-toggle-icon--swapping class for icon opacity cross-fade
- Export THEME_TRANSITION_MS constant and isTransitioning flag from ThemeContext so JS-side changes can coordinate with the CSS animation
- Update ThemeToggle to apply the icon cross-fade on each theme switch
- Add 19 focused tests in src/theme-transition.test.tsx (all passing)
- Document the theme transition system in docs/UI-Design-System.md

Closes #390