### PR TITLE
feat: add accessible context menu on ApiCard

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -374,14 +374,10 @@ size tailored specifically for inline use inside FiltersSidebar.
   /* Marketplace results area */
 }
 {
-  filteredApis.length === 0 && Object.keys(activeFilters).length === 0 && (
-    <EmptyState variant="empty" />
-  );
+  filteredApis.length === 0 && Object.keys(activeFilters).length === 0 && <EmptyState variant="empty" />;
 }
 {
-  filteredApis.length === 0 && Object.keys(activeFilters).length > 0 && (
-    <EmptyState variant="filtered" onClearFilters={resetFilters} />
-  );
+  filteredApis.length === 0 && Object.keys(activeFilters).length > 0 && <EmptyState variant="filtered" onClearFilters={resetFilters} />;
 }
 {
   fetchError && <EmptyState variant="error" onRetry={refetch} />;
@@ -391,13 +387,7 @@ size tailored specifically for inline use inside FiltersSidebar.
   /* FiltersSidebar inline zero-results notice */
 }
 {
-  resultCount === 0 && hasActiveFilters && (
-    <EmptyState
-      variant="filtered"
-      size="compact"
-      onClearFilters={clearFilters}
-    />
-  );
+  resultCount === 0 && hasActiveFilters && <EmptyState variant="filtered" size="compact" onClearFilters={clearFilters} />;
 }
 ```
 
@@ -678,12 +668,53 @@ Displays a tooltip with a 5-star rating distribution breakdown upon hovering or 
 **Usage Example:**
 
 ```tsx
-<RatingHistogram
-  rating={4.5}
-  distribution={{ 5: 100, 4: 50, 3: 10, 2: 5, 1: 0 }}
->
+<RatingHistogram rating={4.5} distribution={{ 5: 100, 4: 50, 3: 10, 2: 5, 1: 0 }}>
   <span>⭐ 4.5</span>
 </RatingHistogram>
+```
+
+### ContextMenu
+
+Accessible context menu for `ApiCard`. Triggered by right-click on desktop or a 600 ms long-press on touch devices.
+
+**Props:**
+
+- `x: number` — Viewport X coordinate to anchor the menu
+- `y: number` — Viewport Y coordinate to anchor the menu
+- `onClose: () => void` — Called when the menu should close
+- `actions: ContextMenuAction[]` — Array of `{ label, action, isCritical? }`
+
+**Visual Spec:**
+
+- Background: `var(--surface-strong)` with `backdrop-filter: blur(20px)`
+- Border: `1px solid var(--line-strong)`
+- Border radius: `var(--radius-md)`
+- Shadow: `var(--shadow)`
+- Item height: ~40px, `0.875rem` font, `var(--text)` color
+- Critical items: `var(--danger)` color
+- Hover/focus: `var(--surface-soft)` background
+
+**Behavior:**
+
+- Viewport-edge clamped: never renders off-screen
+- Auto-focuses the first `menuitem` on mount
+- Closes on: Escape, outside click/touch, or after any action is selected
+- Does not open when the right-click/touch target is a `<button>` or `<a>` inside the card
+
+**Accessibility (WCAG 2.1 AA):**
+
+- `role="menu"` with `aria-label="API Card Options"` on the container
+- `role="menuitem"` on each action button
+- Auto-focuses first item on open (2.4.3 Focus Order)
+- Keyboard dismiss via Escape (2.1.1 Keyboard)
+- All colors use design tokens; no hardcoded hex
+
+**Usage:**
+
+```tsx
+{
+  menuPos && <ContextMenu x={menuPos.x} y={menuPos.y} onClose={() => setMenuPos(null)} actions={contextActions} />;
+}
 ```
 
 ---
@@ -771,11 +802,7 @@ Search input with clear button and keyboard shortcuts.
 **Usage Example:**
 
 ```tsx
-<SearchBar
-  value={searchQuery}
-  onChange={setSearchQuery}
-  onSearch={handleSearch}
-/>
+<SearchBar value={searchQuery} onChange={setSearchQuery} onSearch={handleSearch} />
 ```
 
 ---
@@ -817,12 +844,7 @@ Server error display with retry functionality.
 **Usage Example:**
 
 ```tsx
-<ServerError
-  onRetry={fetchData}
-  requestId="req_abc123"
-  title="Connection failed"
-  description="Unable to reach the server. Please check your connection."
-/>
+<ServerError onRetry={fetchData} requestId="req_abc123" title="Connection failed" description="Unable to reach the server. Please check your connection." />
 ```
 
 ---

--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -1,9 +1,15 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act, within } from "@testing-library/react";
 import ApiCard from "./ApiCard";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import type { APIItem } from "../data/mockApis";
 import { pinnedApisStore } from "../state/pinnedApis";
+
+/* ── Mocks ─────────────────────────────────────────────────────────────────
+   vi.mock factories are hoisted to the top of the file by Vitest, so they
+   cannot reference variables declared in module scope. All mock state must
+   be defined inline inside the factory.
+────────────────────────────────────────────────────────────────────────── */
 
 vi.mock("../state/collectionsStore", () => ({
   useCollections: () => ({
@@ -12,104 +18,199 @@ vi.mock("../state/collectionsStore", () => ({
     addEndpointToCollection: vi.fn(),
     removeEndpointFromCollection: vi.fn(),
     collectionIdsForEndpoint: () => new Set(),
-      createCollectionWithEndpoint: vi.fn(),
+    createCollectionWithEndpoint: vi.fn(),
+  }),
+}));
+
+vi.mock("../state/compareStore", () => ({
+  compareStore: {
+    addApi: vi.fn(),
     removeApi: vi.fn(),
     setOpen: vi.fn(),
-    subscribe: vi.fn((listener) => {
-      return () => {};
-    }),
+    subscribe: vi.fn(() => () => {}),
     getSnapshot: vi.fn(() => ({ apis: [], isOpen: false })),
-  };
+  },
+  useCompareStore: () => ({ apis: [], isOpen: false }),
+}));
 
-  return {
-    compareStore: mockCompareStore,
-    useCompareStore: () => ({ apis: [], isOpen: false }),
-  };
-});
+/* ── Shared fixture ─────────────────────────────────────────────────────── */
 
-describe("ApiCard Accessibility and Context Layouts", () => {
-  const mockApi: APIItem = {
-    id: "api-1",
-    name: "Stellar Metering API",
-    endpoint: "/api/v1/meter",
-    description: "A mock API for testing.",
-    tags: ["weather", "forecast", "geo"],
-    pricePerRequest: 0.01,
-  };
+const mockApi: APIItem = {
+  id: "api-1",
+  name: "Stellar Metering API",
+  provider: { name: "TestCo" },
+  description: "A mock API for testing.",
+  tags: ["weather", "forecast", "geo"],
+  pricePerRequest: 0.01,
+  endpoints: [{ id: "ep1", url: "/api/v1/meter", method: "GET" }],
+};
 
+/* ── Test suites ─────────────────────────────────────────────────────────── */
+
+describe("ApiCard — Context Menu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // jsdom does not implement clipboard; provide a no-op stub.
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
   });
 
-  it("opens context menu correctly on right click invocation", () => {
-    render(
-      <ApiCard api={mockApi} onViewDetails={() => {}} />
-    );
+  it("opens context menu on right-click (contextmenu event)", () => {
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
 
-    const card = screen.getByText("Stellar Metering API");
-    fireEvent.contextMenu(card);
+    const card = screen.getByRole("button", {
+      name: /View details for Stellar Metering API/i,
+    });
+    fireEvent.contextMenu(card, { clientX: 100, clientY: 200 });
 
-    expect(screen.getByRole("menu")).toBeDefined();
-    expect(screen.getByText("Copy Endpoint URL")).toBeDefined();
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeTruthy();
+    expect(within(menu).getByText("Copy Endpoint URL")).toBeTruthy();
+    expect(within(menu).getByText("View Details")).toBeTruthy();
+  });
+
+  it("does NOT open context menu when right-clicking a button inside the card", () => {
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
+
+    const bookmarkBtn = screen.getByRole("button", {
+      name: /Save to collection/i,
+    });
+    fireEvent.contextMenu(bookmarkBtn);
+
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes context menu on Escape key", () => {
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
+
+    const card = screen.getByRole("button", {
+      name: /View details for/i,
+    });
+    fireEvent.contextMenu(card, { clientX: 50, clientY: 50 });
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes context menu after selecting an action", () => {
+    const onViewDetails = vi.fn();
+    render(<ApiCard api={mockApi} onViewDetails={onViewDetails} />);
+
+    const card = screen.getByRole("button", { name: /View details for/i });
+    fireEvent.contextMenu(card, { clientX: 50, clientY: 50 });
+    const menu = screen.getByRole("menu");
+    fireEvent.click(within(menu).getByText("View Details"));
+
+    expect(onViewDetails).toHaveBeenCalledWith(mockApi);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("copies endpoint URL when 'Copy Endpoint URL' is clicked", () => {
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
+
+    const card = screen.getByRole("button", { name: /View details for/i });
+    fireEvent.contextMenu(card, { clientX: 50, clientY: 50 });
+    fireEvent.click(screen.getByText("Copy Endpoint URL"));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/api/v1/meter");
+  });
+
+  it("opens context menu on long-press touch (after 600 ms)", () => {
+    vi.useFakeTimers();
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
+
+    const card = screen.getByRole("button", { name: /View details for/i });
+
+    fireEvent.touchStart(card, {
+      touches: [{ clientX: 80, clientY: 80 }],
+    });
+
+    // Menu must NOT appear before the threshold.
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    // Advance past the 600 ms long-press threshold.
+    act(() => {
+      vi.advanceTimersByTime(650);
+    });
+
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+
+  it("does NOT open menu when touch ends before 600 ms (tap, not long-press)", () => {
+    vi.useFakeTimers();
+    render(<ApiCard api={mockApi} onViewDetails={() => {}} />);
+
+    const card = screen.getByRole("button", { name: /View details for/i });
+
+    fireEvent.touchStart(card, { touches: [{ clientX: 80, clientY: 80 }] });
+    fireEvent.touchEnd(card); // cancel before threshold fires
+
+    act(() => {
+      vi.advanceTimersByTime(650);
+    });
+
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    vi.useRealTimers();
+  });
+});
+
+describe("ApiCard — Accessibility and Tag Chips", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it("renders tag chips with correct ARIA labels", () => {
     render(<ApiCard api={mockApi} />);
 
-    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
-    const forecastChip = screen.getByLabelText("Filter marketplace by tag forecast");
-    const geoChip = screen.getByLabelText("Filter marketplace by tag geo");
-
-    expect(weatherChip).toBeDefined();
-    expect(forecastChip).toBeDefined();
-    expect(geoChip).toBeDefined();
+    expect(screen.getByLabelText("Filter marketplace by tag weather")).toBeTruthy();
+    expect(screen.getByLabelText("Filter marketplace by tag forecast")).toBeTruthy();
+    expect(screen.getByLabelText("Filter marketplace by tag geo")).toBeTruthy();
   });
 
   it("calls onTagClick when a tag chip is clicked", () => {
     const handleTagClick = vi.fn();
     render(<ApiCard api={mockApi} onTagClick={handleTagClick} />);
 
-    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
-    fireEvent.click(weatherChip);
-
-    expect(handleTagClick).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("Filter marketplace by tag weather"));
     expect(handleTagClick).toHaveBeenCalledWith("weather");
   });
 
   it("marks the active tag chip as pressed", () => {
     render(<ApiCard api={mockApi} activeTag="weather" />);
 
-    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
-    expect(weatherChip.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByLabelText("Filter marketplace by tag weather").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("does not mark non-active tag chips as pressed", () => {
     render(<ApiCard api={mockApi} activeTag="weather" />);
 
-    const forecastChip = screen.getByLabelText("Filter marketplace by tag forecast");
-    expect(forecastChip.getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByLabelText("Filter marketplace by tag forecast").getAttribute("aria-pressed")).toBe("false");
   });
 
   it("handles case-insensitive active tag matching", () => {
     render(<ApiCard api={mockApi} activeTag="WEATHER" />);
 
-    const weatherChip = screen.getByLabelText("Filter marketplace by tag weather");
-    expect(weatherChip.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByLabelText("Filter marketplace by tag weather").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("renders tag chips even when no activeTag is set", () => {
     render(<ApiCard api={mockApi} />);
 
-    const chips = screen.getAllByRole("button", { name: /Filter marketplace by tag/ });
-    expect(chips.length).toBe(3);
+    expect(screen.getAllByRole("button", { name: /Filter marketplace by tag/ }).length).toBe(3);
   });
 
   it("toggles pin state when the pin button is clicked", () => {
     pinnedApisStore._reset();
     render(<ApiCard api={mockApi} />);
 
-    const pinButton = screen.getByRole("button", { name: /Pin api-1 to dashboard/i });
-    expect(pinButton).toBeTruthy();
+    const pinButton = screen.getByRole("button", {
+      name: /Pin api-1 to dashboard/i,
+    });
     expect(pinButton.getAttribute("aria-pressed")).toBe("false");
 
     fireEvent.click(pinButton);

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -6,8 +6,8 @@
  * allowing users to add/remove the endpoint from collections.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ContextMenu } from './ContextMenu';
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ContextMenu } from "./ContextMenu";
 import Skeleton from "./Skeleton";
 import TagChip from "./TagChip";
 import { formatPrice } from "../utils/format";
@@ -40,9 +40,7 @@ export function ApiCardSkeleton() {
       <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
         <Skeleton width={56} height={56} borderRadius={10} />
 
-        <div
-          style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}
-        >
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
           <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
             <Skeleton width="60%" height={18} />
             <Skeleton width="20%" height={12} />
@@ -123,7 +121,10 @@ function FavoriteButton({ endpointId, isFavorite, onToggle }: FavoriteButtonProp
   return (
     <button
       ref={btnRef}
-      onClick={(e) => { e.stopPropagation(); onToggle(endpointId); }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle(endpointId);
+      }}
       style={{
         position: "absolute",
         top: "8px",
@@ -170,14 +171,8 @@ interface BookmarkButtonProps {
 }
 
 function BookmarkButton({ endpointId }: BookmarkButtonProps) {
-  const {
-    collections,
-    isEndpointSaved,
-    addEndpointToCollection,
-    removeEndpointFromCollection,
-    collectionIdsForEndpoint,
-    createCollectionWithEndpoint,
-  } = useCollections();
+  const { collections, isEndpointSaved, addEndpointToCollection, removeEndpointFromCollection, collectionIdsForEndpoint, createCollectionWithEndpoint } =
+    useCollections();
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
@@ -196,10 +191,7 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
       }
     };
     const handleClick = (e: MouseEvent) => {
-      if (
-        panelRef.current && !panelRef.current.contains(e.target as Node) &&
-        btnRef.current && !btnRef.current.contains(e.target as Node)
-      ) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node) && btnRef.current && !btnRef.current.contains(e.target as Node)) {
         setPopoverOpen(false);
       }
     };
@@ -238,8 +230,14 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
   }, [newName, createCollectionWithEndpoint, endpointId]);
 
   const handleNewKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") { e.preventDefault(); handleCreateAndAdd(); }
-    if (e.key === "Escape") { setShowNew(false); setNewName(""); }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleCreateAndAdd();
+    }
+    if (e.key === "Escape") {
+      setShowNew(false);
+      setNewName("");
+    }
   };
 
   return (
@@ -247,7 +245,10 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
       {/* SVG bookmark button — absolutely positioned in card top-right */}
       <button
         ref={btnRef}
-        onClick={(e) => { e.stopPropagation(); toggleSave(); }}
+        onClick={(e) => {
+          e.stopPropagation();
+          toggleSave();
+        }}
         style={{
           position: "absolute",
           top: "8px",
@@ -313,11 +314,7 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
             Save to collection
           </p>
 
-          {collections.length === 0 && !showNew && (
-            <p style={{ color: "var(--muted)", fontSize: "0.82rem", margin: "0 0 8px" }}>
-              No collections yet.
-            </p>
-          )}
+          {collections.length === 0 && !showNew && <p style={{ color: "var(--muted)", fontSize: "0.82rem", margin: "0 0 8px" }}>No collections yet.</p>}
 
           {collections.map((col) => (
             <label
@@ -331,12 +328,8 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
                 aria-label={`${savedIn.has(col.id) ? "Remove from" : "Add to"} collection "${col.name}"`}
                 style={{ accentColor: "var(--accent)", width: 15, height: 15 }}
               />
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
-                {col.name}
-              </span>
-              <span style={{ color: "var(--muted)", fontSize: 11 }}>
-                {col.endpointIds.length}
-              </span>
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>{col.name}</span>
+              <span style={{ color: "var(--muted)", fontSize: 11 }}>{col.endpointIds.length}</span>
             </label>
           ))}
 
@@ -349,13 +342,30 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
                 onKeyDown={handleNewKeyDown}
                 placeholder="Collection name"
                 aria-label="New collection name"
-                style={{ flex: 1, background: "rgba(255,255,255,0.06)", border: "1px solid var(--accent)", borderRadius: 6, color: "var(--text)", padding: "4px 8px", fontSize: "0.82rem" }}
+                style={{
+                  flex: 1,
+                  background: "rgba(255,255,255,0.06)",
+                  border: "1px solid var(--accent)",
+                  borderRadius: 6,
+                  color: "var(--text)",
+                  padding: "4px 8px",
+                  fontSize: "0.82rem",
+                }}
               />
               <button
                 onClick={handleCreateAndAdd}
                 disabled={!newName.trim()}
                 aria-label="Create collection"
-                style={{ background: "var(--accent)", border: "none", borderRadius: 6, color: "#fff", cursor: "pointer", padding: "4px 8px", fontSize: "0.82rem", fontWeight: 700 }}
+                style={{
+                  background: "var(--accent)",
+                  border: "none",
+                  borderRadius: 6,
+                  color: "#fff",
+                  cursor: "pointer",
+                  padding: "4px 8px",
+                  fontSize: "0.82rem",
+                  fontWeight: 700,
+                }}
               >
                 ✓
               </button>
@@ -363,7 +373,21 @@ function BookmarkButton({ endpointId }: BookmarkButtonProps) {
           ) : (
             <button
               onClick={() => setShowNew(true)}
-              style={{ display: "flex", alignItems: "center", gap: 4, width: "100%", marginTop: 8, background: "none", border: "1px dashed var(--line-strong, rgba(169,184,255,0.28))", borderRadius: 8, color: "var(--accent)", cursor: "pointer", padding: "5px 8px", fontSize: "0.82rem", fontWeight: 600 }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 4,
+                width: "100%",
+                marginTop: 8,
+                background: "none",
+                border: "1px dashed var(--line-strong, rgba(169,184,255,0.28))",
+                borderRadius: 8,
+                color: "var(--accent)",
+                cursor: "pointer",
+                padding: "5px 8px",
+                fontSize: "0.82rem",
+                fontWeight: 600,
+              }}
             >
               <span aria-hidden="true">＋</span> New collection
             </button>
@@ -383,7 +407,10 @@ function PinButton({ apiId }: { apiId: string }) {
 
   return (
     <button
-      onClick={(e) => { e.stopPropagation(); pinnedApisStore.toggle(apiId); }}
+      onClick={(e) => {
+        e.stopPropagation();
+        pinnedApisStore.toggle(apiId);
+      }}
       style={{
         position: "absolute",
         top: "48px",
@@ -431,11 +458,7 @@ const EM_DASH = "—";
 
 function renderStatValue(value: string | undefined) {
   if (!value) {
-    return (
-      <span className="api-card__stat-value api-card__stat-value--empty">
-        {EM_DASH}
-      </span>
-    );
+    return <span className="api-card__stat-value api-card__stat-value--empty">{EM_DASH}</span>;
   }
   return <span className="api-card__stat-value">{value}</span>;
 }
@@ -459,7 +482,7 @@ export default function ApiCard({
 
   const { isFavorite, toggleFavorite } = useFavorites();
   const { apis: comparedApis } = useCompareStore();
-  const isCompared = comparedApis.some(item => item.id === api.id);
+  const isCompared = comparedApis.some((item) => item.id === api.id);
   const canCompare = isCompared || comparedApis.length < 3;
 
   const handleCompareClick = (e: React.MouseEvent) => {
@@ -488,7 +511,7 @@ export default function ApiCard({
     // Handle 'c' key for add-to-compare shortcut (lowercase only, no modifiers)
     if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
       // Don't fire if focus is in a form field
-      if ((e.target as HTMLElement).closest('input, textarea, [contenteditable]')) {
+      if ((e.target as HTMLElement).closest("input, textarea, [contenteditable]")) {
         return;
       }
 
@@ -499,25 +522,21 @@ export default function ApiCard({
   };
 
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleOpenMenu = (
-    e: React.MouseEvent | React.TouchEvent,
-    clientX: number,
-    clientY: number,
-  ) => {
+  const handleOpenMenu = (e: React.MouseEvent | React.TouchEvent, clientX: number, clientY: number) => {
     e.preventDefault();
     setMenuPos({ x: clientX, y: clientY });
   };
 
   const handleContextMenu = (e: React.MouseEvent) => {
     // Prevent menu from opening on interactive elements
-    if ((e.target as HTMLElement).closest('button, a')) return;
+    if ((e.target as HTMLElement).closest("button, a")) return;
     handleOpenMenu(e, e.clientX, e.clientY);
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {
-    if ((e.target as HTMLElement).closest('button, a')) return;
+    if ((e.target as HTMLElement).closest("button, a")) return;
     const touch = e.touches[0];
     longPressTimer.current = setTimeout(() => {
       handleOpenMenu(e, touch.clientX, touch.clientY);
@@ -528,13 +547,27 @@ export default function ApiCard({
     if (longPressTimer.current) clearTimeout(longPressTimer.current);
   };
 
-  const contextActions = [
-    { label: 'View Details', action: () => onViewDetails?.(api) },
+  const contextActions: import("./ContextMenu").ContextMenuAction[] = [
     {
-      label: 'Copy Endpoint URL',
-      action: () => navigator.clipboard.writeText(api.endpoint),
+      label: "View Details",
+      action: () => onViewDetails?.(api),
     },
-    { label: 'Add to Comparison', action: () => compareStore.addApi(api), isCritical: false },
+    {
+      label: "Copy Endpoint URL",
+      action: () => {
+        const url = api.endpoints?.[0]?.url ?? `/${api.id}`;
+        navigator.clipboard.writeText(url).catch(() => {
+          /* clipboard unavailable in tests */
+        });
+      },
+    },
+    {
+      label: isCompared ? "Remove from Comparison" : "Add to Comparison",
+      action: () => {
+        if (isCompared) compareStore.removeApi(api.id);
+        else if (canCompare) compareStore.addApi(api);
+      },
+    },
   ];
 
   return (
@@ -557,58 +590,43 @@ export default function ApiCard({
         gap: isCompact ? 6 : 8,
       }}
     >
-      {menuPos && (
-        <ContextMenu
-          x={menuPos.x}
-          y={menuPos.y}
-          onClose={() => setMenuPos(null)}
-          actions={contextActions}
-        />
-      )}
+      {menuPos && <ContextMenu x={menuPos.x} y={menuPos.y} onClose={() => setMenuPos(null)} actions={contextActions} />}
       {/* Absolutely-positioned bookmark button in the top-right corner */}
       <BookmarkButton endpointId={api.id} />
 
       {/* Pin/unpin button — below bookmark, top-right */}
       <PinButton apiId={api.id} />
-      
-      <FavoriteButton
-        endpointId={api.id}
-        isFavorite={isFavorite(api.id)}
-        onToggle={toggleFavorite}
-      />
 
-       {/* Pin button - absolutely positioned, top-left */}
-       <button
-         onClick={handleCompareClick}
-         disabled={!canCompare}
-         className="api-card__compare-btn"
-         style={{
-           position: "absolute",
-           top: "8px",
-           left: "48px",
-           zIndex: 10,
-           background: isCompared ? "var(--accent)" : "rgba(0,0,0,0.5)",
-           color: "white",
-           border: "none",
-           borderRadius: "8px",
-           padding: "4px 8px",
-           fontSize: "0.75rem",
-           fontWeight: 600,
-           cursor: canCompare ? "pointer" : "not-allowed",
-           opacity: isCompared ? 1 : 0.6,
-           transition: "opacity 0.2s, background 0.2s"
-         }}
-         aria-label={isCompared ? `Remove ${api.name} from comparison` : `Add ${api.name} to comparison`}
-         aria-pressed={isCompared}
-       >
-         {isCompared ? "Compared" : "Compare"}
-       </button>
+      <FavoriteButton endpointId={api.id} isFavorite={isFavorite(api.id)} onToggle={toggleFavorite} />
 
-
-      <div
-        className="api-marketplace-card-header"
-        style={{ display: "flex", gap: 12, alignItems: "center" }}
+      {/* Pin button - absolutely positioned, top-left */}
+      <button
+        onClick={handleCompareClick}
+        disabled={!canCompare}
+        className="api-card__compare-btn"
+        style={{
+          position: "absolute",
+          top: "8px",
+          left: "48px",
+          zIndex: 10,
+          background: isCompared ? "var(--accent)" : "rgba(0,0,0,0.5)",
+          color: "white",
+          border: "none",
+          borderRadius: "8px",
+          padding: "4px 8px",
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          cursor: canCompare ? "pointer" : "not-allowed",
+          opacity: isCompared ? 1 : 0.6,
+          transition: "opacity 0.2s, background 0.2s",
+        }}
+        aria-label={isCompared ? `Remove ${api.name} from comparison` : `Add ${api.name} to comparison`}
+        aria-pressed={isCompared}
       >
+        {isCompared ? "Compared" : "Compare"}
+      </button>
+
+      <div className="api-marketplace-card-header" style={{ display: "flex", gap: 12, alignItems: "center" }}>
         <div
           className="api-marketplace-card-icon"
           style={{
@@ -626,18 +644,10 @@ export default function ApiCard({
           {api.name[0]}
         </div>
 
-        <div
-          className="api-marketplace-card-body"
-          style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}
-        >
-          <div
-            className="api-marketplace-card-title-row"
-            style={{ display: "flex", gap: 8, alignItems: "baseline" }}
-          >
+        <div className="api-marketplace-card-body" style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+          <div className="api-marketplace-card-title-row" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
             <strong>{api.name}</strong>
-            <div style={{ color: "var(--muted)", fontSize: 12 }}>
-              {api.provider?.name}
-            </div>
+            <div style={{ color: "var(--muted)", fontSize: 12 }}>{api.provider?.name}</div>
           </div>
 
           {!isCompact && (
@@ -658,20 +668,11 @@ export default function ApiCard({
         </div>
 
         {/* Price — bookmark moved out of here, paddingRight leaves room for it */}
-        <div
-          className="api-marketplace-card-price"
-          style={{ textAlign: "right", paddingRight: 36, flexShrink: 0 }}
-        >
-          <div style={{ color: "var(--muted)", fontSize: 12 }}>
-            {`$${formatPrice(pricePerCall)}`} / call
-          </div>
+        <div className="api-marketplace-card-price" style={{ textAlign: "right", paddingRight: 36, flexShrink: 0 }}>
+          <div style={{ color: "var(--muted)", fontSize: 12 }}>{`$${formatPrice(pricePerCall)}`} / call</div>
           {api.rating !== undefined && (
             <div style={{ color: "var(--muted)", marginTop: 6 }}>
-              <RatingHistogram
-                rating={api.rating}
-                distribution={api.ratingDistribution}
-                placement="top-end"
-              >
+              <RatingHistogram rating={api.rating} distribution={api.ratingDistribution} placement="top-end">
                 ⭐ {api.rating}
               </RatingHistogram>
             </div>
@@ -679,17 +680,9 @@ export default function ApiCard({
         </div>
       </div>
 
-      <div
-        className="api-marketplace-card-tags"
-        style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
-      >
+      <div className="api-marketplace-card-tags" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         {((api.tags as string[]) || []).slice(0, 4).map((t: string) => (
-          <TagChip
-            key={t}
-            tag={t}
-            active={activeTag?.toLowerCase() === t.toLowerCase()}
-            onClick={onTagClick}
-          />
+          <TagChip key={t} tag={t} active={activeTag?.toLowerCase() === t.toLowerCase()} onClick={onTagClick} />
         ))}
       </div>
 
@@ -697,42 +690,25 @@ export default function ApiCard({
       {!isCompact && <WhyApi api={api} />}
 
       <div
-  style={{
-    marginTop: 10,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 12,
-  }}
->
-  <span
-    style={{
-      fontSize: 12,
-      color: "var(--muted)",
-      fontWeight: 600,
-    }}
-  >
-    Last 24h
-  </span>
+        style={{
+          marginTop: 10,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12,
+            color: "var(--muted)",
+            fontWeight: 600,
+          }}
+        >
+          Last 24h
+        </span>
 
-  <Sparkline
-  values={[
-    18,
-    22,
-    20,
-    24,
-    26,
-    25,
-    30,
-    32,
-    31,
-    34,
-    36,
-    35,
-  ]}
-  width={90}
-  height={28}
-/>
+        <Sparkline values={[18, 22, 20, 24, 26, 25, 30, 32, 31, 34, 36, 35]} width={90} height={28} />
       </div>
 
       <div
@@ -748,31 +724,21 @@ export default function ApiCard({
         <div className="api-card__stats" aria-label="API stats">
           <div className="api-card__stat">
             <span className="api-card__stat-label">Price / call</span>
-            {renderStatValue(
-              pricePerCall !== undefined
-                ? `$${formatPrice(pricePerCall)}`
-                : undefined,
-            )}
+            {renderStatValue(pricePerCall !== undefined ? `$${formatPrice(pricePerCall)}` : undefined)}
           </div>
 
           <div className="api-card__stat">
             <span className="api-card__stat-label" style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
               <ClockIcon size={16} /> Latency
             </span>
-            {renderStatValue(
-              avgLatencyMs !== undefined ? `${avgLatencyMs} ms` : undefined,
-            )}
+            {renderStatValue(avgLatencyMs !== undefined ? `${avgLatencyMs} ms` : undefined)}
           </div>
 
           <div className="api-card__stat">
             <span className="api-card__stat-label" style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
               <BoltIcon size={16} /> Uptime
             </span>
-            {renderStatValue(
-              uptimePercent !== undefined
-                ? `${uptimePercent.toFixed(2)}%`
-                : undefined,
-            )}
+            {renderStatValue(uptimePercent !== undefined ? `${uptimePercent.toFixed(2)}%` : undefined)}
           </div>
         </div>
 
@@ -784,20 +750,12 @@ export default function ApiCard({
             gap: 12,
           }}
         >
-          <span
-            className="ghost-button"
-            aria-hidden="true"
-            style={{ display: "inline-flex", alignItems: "center" }}
-          >
+          <span className="ghost-button" aria-hidden="true" style={{ display: "inline-flex", alignItems: "center" }}>
             View Details
           </span>
           <div style={{ color: "var(--muted)", fontSize: 12 }}>
             {api.rating ? (
-              <RatingHistogram
-                rating={api.rating}
-                distribution={api.ratingDistribution}
-                placement="top-end"
-              >
+              <RatingHistogram rating={api.rating} distribution={api.ratingDistribution} placement="top-end">
                 {api.rating} ★
               </RatingHistogram>
             ) : (

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,36 +1,85 @@
+/**
+ * ContextMenu.tsx
+ *
+ * Accessible context menu for ApiCard.
+ * Triggered by right-click (desktop) or long-press (touch, 600 ms threshold).
+ *
+ * Accessibility:
+ *  - role="menu" with aria-label on the container
+ *  - role="menuitem" on each action button
+ *  - Auto-focuses the first item on mount (keyboard + screen-reader entry)
+ *  - Closes on Escape, outside click/touch, and after any action
+ *  - Positioned with viewport-edge clamping so it never renders off-screen
+ *  - All colors, borders, and shadows use design tokens (no hardcoded hex)
+ *  - Respects prefers-reduced-motion for the fade-in animation
+ *
+ * WCAG 2.1 AA: 2.1.1 Keyboard, 2.4.3 Focus Order, 4.1.2 Name/Role/Value
+ */
+
 import React, { useEffect, useRef } from "react";
 
-interface ContextMenuProps {
-  x: number;
-  y: number;
-  onClose: () => void;
-  actions: { label: string; action: () => void; isCritical?: boolean }[];
+export interface ContextMenuAction {
+  label: string;
+  action: () => void;
+  /** Renders the item in var(--danger) to signal a destructive operation. */
+  isCritical?: boolean;
 }
+
+interface ContextMenuProps {
+  /** Viewport X coordinate where the menu should anchor (from MouseEvent or Touch). */
+  x: number;
+  /** Viewport Y coordinate where the menu should anchor. */
+  y: number;
+  /** Called when the menu should close (Escape, outside click, or after an action). */
+  onClose: () => void;
+  actions: ContextMenuAction[];
+}
+
+/** Minimum distance (px) to keep the menu from any viewport edge. */
+const EDGE_MARGIN = 8;
+
+/** Estimated menu dimensions used for pre-render clamping. */
+const MENU_WIDTH = 192;
+const MENU_HEIGHT_PER_ITEM = 40;
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, onClose, actions }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Focus trap & dismiss on Escape or clicking outside
+  /* ── Clamp position so the menu stays inside the viewport ── */
+  const estimatedHeight = actions.length * MENU_HEIGHT_PER_ITEM + 8;
+  const clampedX = Math.min(Math.max(x, EDGE_MARGIN), window.innerWidth - MENU_WIDTH - EDGE_MARGIN);
+  const clampedY = Math.min(Math.max(y, EDGE_MARGIN), window.innerHeight - estimatedHeight - EDGE_MARGIN);
+
+  /* ── Focus trap, Escape dismiss, outside-click dismiss ── */
   useEffect(() => {
+    // Auto-focus the first menu item for keyboard and screen-reader users.
+    const firstItem = menuRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    firstItem?.focus();
+
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
     };
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+
+    const handlePointerDown = (e: MouseEvent | TouchEvent) => {
+      const target = "touches" in e ? e.touches[0]?.target : (e as MouseEvent).target;
+      if (menuRef.current && !menuRef.current.contains(target as Node)) {
         onClose();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("mousedown", handleClickOutside);
-    
-    // Auto-focus first interactive element for keyboard screen-reader accessibility
-    const firstButton = menuRef.current?.querySelector("button");
-    if (firstButton) firstButton.focus();
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown as EventListener, {
+      passive: true,
+    });
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown as EventListener);
     };
   }, [onClose]);
 
@@ -39,8 +88,23 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, onClose, actions
       ref={menuRef}
       role="menu"
       aria-label="API Card Options"
-      className="fixed z-50 min-w-[160px] bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg shadow-xl py-1 animate-in fade-in zoom-in-95 duration-100"
-      style={{ top: `${y}px`, left: `${x}px` }}
+      /* Stop card's own onClick from firing when clicking inside the menu. */
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: "fixed",
+        top: clampedY,
+        left: clampedX,
+        zIndex: 200,
+        minWidth: MENU_WIDTH,
+        background: "var(--surface-strong)",
+        border: "1px solid var(--line-strong)",
+        borderRadius: "var(--radius-md)",
+        boxShadow: "var(--shadow)",
+        padding: "4px 0",
+        backdropFilter: "blur(20px)",
+        /* Fade-in — suppressed for users who prefer reduced motion. */
+        animation: "contextmenu-appear 100ms ease both",
+      }}
     >
       {actions.map((item, index) => (
         <button
@@ -50,11 +114,22 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, onClose, actions
             item.action();
             onClose();
           }}
-          className={`w-full text-left px-4 py-2 text-sm transition-colors duration-150 outline-none focus:bg-zinc-100 dark:focus:bg-zinc-800 ${
-            item.isCritical 
-              ? "text-red-600 focus:text-red-700" 
-              : "text-zinc-700 dark:text-zinc-300"
-          }`}
+          style={{
+            display: "block",
+            width: "100%",
+            textAlign: "left",
+            padding: "10px 16px",
+            background: "none",
+            border: "none",
+            borderRadius: 0,
+            cursor: "pointer",
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            color: item.isCritical ? "var(--danger)" : "var(--text)",
+            transition: "background 120ms ease, color 120ms ease",
+          }}
+          /* Highlight on keyboard focus and mouse hover via CSS class below. */
+          className="context-menu__item"
         >
           {item.label}
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -3564,8 +3564,13 @@ code,
 }
 
 @keyframes route-progress-glow-pulse {
-    0%, 100% { opacity: 0.6; }
-    50%      { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .route-progress-bar {
@@ -4283,7 +4288,9 @@ code,
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
-  transition: background 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    border-color 180ms ease;
 }
 
 .filter-group__header:hover,
@@ -4862,13 +4869,14 @@ code,
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.75rem;        /* 12 px */
+  font-size: 0.75rem; /* 12 px */
   font-weight: 600;
   color: var(--accent);
   line-height: 1;
   /* Smooth colour transition on hover/focus so the change isn't jarring. */
-  transition: color var(--transition-speed, 240ms) ease,
-              opacity var(--transition-speed, 240ms) ease;
+  transition:
+    color var(--transition-speed, 240ms) ease,
+    opacity var(--transition-speed, 240ms) ease;
 }
 
 .why-api__toggle:hover {
@@ -4936,7 +4944,7 @@ code,
   display: flex;
   align-items: flex-start;
   gap: 6px;
-  font-size: 0.75rem;   /* 12 px */
+  font-size: 0.75rem; /* 12 px */
   line-height: 1.5;
   color: var(--muted);
 }
@@ -4969,4 +4977,43 @@ code,
   .why-api__item {
     font-size: 0.6875rem; /* 11 px */
   }
+}
+
+/* ── ContextMenu ────────────────────────────────────────────────────────────
+   Token-based styles for the ApiCard right-click / long-press menu.
+   The animation is suppressed for users who prefer reduced motion.
+   ───────────────────────────────────────────────────────────────────────── */
+
+@keyframes contextmenu-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes contextmenu-appear {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+.context-menu__item:hover,
+.context-menu__item:focus-visible {
+  background: var(--surface-soft);
+  outline: none;
+}
+
+/* Restore the global focus ring for keyboard users inside the menu. */
+.context-menu__item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }


### PR DESCRIPTION
## Summary

Implements an accessible right-click + long-press context menu on `ApiCard`
as described in issue #368. The menu exposes quick actions (View Details,
Copy Endpoint URL, Add to Comparison) without requiring the user to open
the full detail page.

## Changes

### `src/components/ContextMenu.tsx`
- Full rewrite replacing non-functional Tailwind classes with design tokens
- Viewport-edge clamping: menu stays within the viewport on all screen sizes
- Auto-focuses first `menuitem` on mount for keyboard and screen-reader users
- Dismisses on Escape, outside click, outside touch, or after any action fires
- Suppresses open when the event target is a `<button>` or `<a>` (prevents
  conflict with bookmark, pin, favorite, and compare buttons on the card)
- All colors, borders, shadows reference `var(--token)` — no hardcoded hex
- Fade-in animation suppressed under `prefers-reduced-motion: reduce`

### `src/components/ApiCard.tsx`
- Fixed `contextActions` clipboard target: `api.endpoint` (did not exist on
  `APIItem`) → `api.endpoints?.[0]?.url` with a safe fallback
- Fixed `longPressTimer` type: `NodeJS.Timeout` → `ReturnType<typeof setTimeout>`
  (browser-safe, no Node type dependency)
- Context menu label for the comparison action is now dynamic:
  "Add to Comparison" / "Remove from Comparison" based on current state

### `src/index.css`
- Added `@keyframes contextmenu-appear` for the menu fade-in
- Added `.context-menu__item` hover and focus-visible styles using
  `var(--surface-soft)` and `var(--accent)` — consistent with app-wide
  focus layer pattern

### `docs/UI-Design-System.md`
- Added `ContextMenu` component section documenting props, visual spec,
  behavior, accessibility notes, and usage example

### `src/components/ApiCard.test.tsx`
- Fixed pre-existing syntax error in `compareStore` mock (broken factory
  caused by hoisting — inlined object into `vi.mock` factory)
- Added 7 new focused tests:
  - Opens on right-click (`contextmenu` event)
  - Does not open when right-clicking a button inside the card
  - Closes on Escape key
  - Closes and fires action on item selection
  - Copies correct endpoint URL to clipboard
  - Opens after 600 ms long-press touch
  - Does not open on short tap (touch cancelled before threshold)

## Test Output

```
✓ ApiCard — Context Menu (7)
✓ ApiCard — Accessibility and Tag Chips (7)
Tests: 14 passed
```

## Accessibility (WCAG 2.1 AA)

| Criterion | How it's met |
|---|---|
| 2.1.1 Keyboard | Menu opens via right-click; Escape closes; Enter/Space activates items |
| 2.4.3 Focus Order | First `menuitem` auto-focused on open |
| 4.1.2 Name/Role/Value | `role="menu"` + `aria-label`, `role="menuitem"` on each action |
| 1.4.1 Use of Color | `isCritical` items use `var(--danger)` plus label text — not color alone |
| 1.4.11 Non-text Contrast | Focus ring uses `var(--accent)` at 2px, meets 3:1 in both themes |

## Notes for Reviewers

- Pre-existing TypeScript errors exist across 22 other files unrelated to
  this PR (`npm run build` fails repo-wide before this change). All files
  touched in this PR are type-clean under `npx tsc --noEmit --skipLibCheck`.
- No new dependencies introduced.
- Tested manually in both light and dark themes.

Closes #368
