### PR TITLE
Task/apidetailpage empty v7

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -331,3 +331,5 @@ export default function Tabs({
     </>
   );
 }
+/ /   R e - t r i g g e r i n g   P R  
+ 

--- a/src/pages/ApiDetailPage.test.tsx
+++ b/src/pages/ApiDetailPage.test.tsx
@@ -101,6 +101,18 @@ describe("ApiDetailPage", () => {
     expect(screen.getByRole("heading", { level: 1 })).toBeTruthy();
   });
 
+  // ── Not found / Empty state ───────────────────────────────────────────────
+
+  it("shows the EmptyState when API is not found", () => {
+    window.history.pushState({}, "", "/details/non-existent-api");
+    renderWithProviders(<ApiDetailPage />);
+    settleLoadingState();
+
+    expect(screen.getByRole("heading", { name: "API not found" })).toBeTruthy();
+    expect(screen.getByText("We couldn't find that API. Try the marketplace.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Back to marketplace" })).toBeTruthy();
+  });
+
   // ── Tab switching ─────────────────────────────────────────────────────────
 
   it("defaults to the overview tab", () => {

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -442,12 +442,11 @@ export default function ApiDetailPage({ onBack }: Props) {
               { label: "Not Found", href: "", isCurrent: true },
             ]}
           />
-          <EmptyState title="API not found" message="We couldn't find that API. Try the marketplace." />
-          <div style={{ textAlign: "center", marginTop: 12 }}>
-            <button className="primary-button" onClick={() => (window.location.href = "/marketplace")}>
-              Back to marketplace
-            </button>
-          </div>
+          <EmptyState 
+            title="API not found" 
+            message="We couldn't find that API. Try the marketplace." 
+            action={{ label: "Back to marketplace", onClick: () => (window.location.href = "/marketplace") }}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
Closes #464 

## Description
This PR implements the missing empty state for the `ApiDetailPage` per the issue requirements. 

Previously, the "API not found" fallback rendered a standalone primary button manually appended beneath the `EmptyState` component. This has been refactored to cleanly pass the `action` prop directly to the `EmptyState` component, ensuring UI consistency with the rest of the application's empty/error states and adhering to our design system.

## Changes Made
- **src/pages/ApiDetailPage.tsx**: Refactored the `if (!isLoading && !api)` fallback return to pass the `action` prop to the `<EmptyState />` component instead of wrapping a separate button element.
- **src/pages/ApiDetailPage.test.tsx**: Added a focused test to cover the "Not Found" state, ensuring the correct empty state text, heading, and action button are rendered when the API data is missing.

## Testing
- [x] Verified that the empty state renders as expected for non-existent APIs.
- [x] Added automated testing for the `ApiDetailPage` empty state.
- [x] Verified responsive display across device breakpoints.

## Acceptance Criteria Met
- Implementation precisely matches the design expectations.
- Tests added and passing successfully.
- Follows the project's code styles and lint configurations.