### PR TITLE
fix: ApiUsage reduced-motion static fallback

### DIFF
--- a/src/ApiUsage.test.tsx
+++ b/src/ApiUsage.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ApiUsage from './ApiUsage';
 
 // Mock dependencies
@@ -91,11 +91,71 @@ describe('ApiUsage - Tabular Numerals', () => {
     const statValues = document.querySelectorAll('.stat-value.tabular-nums');
     expect(statValues.length).toBe(5);
     const labels = ['Calls Today', 'Calls This Week', 'Total Spent', 'Avg Response Time', 'Success Rate'];
-    statValues.forEach((el, i) => {
-      expect(el.classList.contains('tabular-nums')).toBe(true);
-      const card = el.closest('.stat-card');
-      expect(card.querySelector('.stat-label').textContent).toBe(labels[i]);
-    });
-  });
+statValues.forEach((el, i) => {
+       expect(el.classList.contains('tabular-nums')).toBe(true);
+       const card = el.closest('.stat-card');
+       expect(card.querySelector('.stat-label').textContent).toBe(labels[i]);
+     });
+   });
+ });
 
-});
+describe('ApiUsage - prefers-reduced-motion', () => {
+   let originalMatchMedia: typeof window.matchMedia;
+
+   beforeEach(() => {
+     vi.useFakeTimers();
+     originalMatchMedia = window.matchMedia;
+   });
+
+   afterEach(() => {
+     vi.useRealTimers();
+     window.matchMedia = originalMatchMedia;
+   });
+
+   it('bypasses table loading delay and shows content immediately when prefers-reduced-motion is active', async () => {
+     window.matchMedia = vi.fn().mockImplementation((query) => ({
+       matches: query === '(prefers-reduced-motion: reduce)' || query.includes('reduce'),
+       media: query,
+       onchange: null,
+       addListener: vi.fn(),
+       removeListener: vi.fn(),
+       addEventListener: vi.fn(),
+       removeEventListener: vi.fn(),
+       dispatchEvent: vi.fn(),
+     }));
+
+     render(<ApiUsage />);
+
+     await act(async () => {
+       await vi.advanceTimersByTimeAsync(0);
+     });
+
+     expect(screen.getByText('Call History')).toBeTruthy();
+     const skeletonRows = document.querySelectorAll('.skeleton-cell');
+     expect(skeletonRows.length).toBe(0);
+   });
+
+   it('uses the normal loading delay when prefers-reduced-motion is not active', async () => {
+     window.matchMedia = vi.fn().mockImplementation((query) => ({
+       matches: false,
+       media: query,
+       onchange: null,
+       addListener: vi.fn(),
+       removeListener: vi.fn(),
+       addEventListener: vi.fn(),
+       removeEventListener: vi.fn(),
+       dispatchEvent: vi.fn(),
+     }));
+
+     render(<ApiUsage />);
+
+     const skeletonRows = document.querySelectorAll('.skeleton-cell');
+     expect(skeletonRows.length).toBeGreaterThan(0);
+
+     await act(async () => {
+       await vi.advanceTimersByTimeAsync(500);
+     });
+
+     expect(screen.getByText('Call History')).toBeTruthy();
+   });
+ });

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import EmptyState from './components/EmptyState';
 import Skeleton, { SkeletonRow } from './components/Skeleton';
 import { formatPrice } from './utils/format';
@@ -230,12 +230,19 @@ export default function ApiUsage() {
   const toggleHistory = useCallback(() => setIsHistoryOpen(prev => !prev), []);
   const [historyEntries, setHistoryEntries] = useState<any[]>([]);
 
+  const prefersReducedMotion = useMemo(() => {
+    return typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }, []);
+
   useEffect(() => {
+    const delay = prefersReducedMotion ? 0 : LOADING_DELAY_MS;
     const timer = setTimeout(() => {
       setIsTableLoading(false);
-    }, LOADING_DELAY_MS);
+    }, delay);
     return () => clearTimeout(timer);
-  }, []);
+  }, [prefersReducedMotion]);
 
   const [selectedRange, setSelectedRange] = useState<DateRange>({ preset: '24h' });
   const [selectedLanguage, setSelectedLanguage] = useState<'javascript' | 'python' | 'curl'>('javascript');

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -331,5 +331,3 @@ export default function Tabs({
     </>
   );
 }
-/ /   R e - t r i g g e r i n g   P R  
- 


### PR DESCRIPTION
Closes #487

## Summary
Implements a static fallback for `prefers-reduced-motion` on the `ApiUsage` component (Stellar Wave / FWC26 campaign).

## Changes

### `src/ApiUsage.tsx`
- Added `useMemo` import
- Added `prefersReducedMotion` detection via `window.matchMedia('(prefers-reduced-motion: reduce)')` on mount
- When reduced motion is active, the table loading skeleton delay is bypassed (0ms instead of 500ms), providing an immediate static render
- Follows the same proven pattern already used in `ApiDetailPage.tsx` and `FiltersBottomSheet.tsx`

### `src/ApiUsage.test.tsx`
- Added `ApiUsage - prefers-reduced-motion` test suite with two focused tests:
  - **Reduced motion active**: Verifies table content renders immediately (0ms delay) with no skeleton cells
  - **Reduced motion inactive**: Verifies skeleton cells appear and resolve after the normal 500ms delay
- Uses `vi.useFakeTimers()` consistent with the rest of the test suite
- Properly saves/restores `window.matchMedia` in `beforeEach`/`afterEach`

### `src/components/Tabs.tsx`
- Removed null-byte corruption at end of file that was blocking test compilation (pre-existing issue)

## Accessibility
- WCAG 2.1 AA compliant: users who have requested reduced motion get instant content instead of waiting for skeleton shimmer animations
- Respects the same `prefers-reduced-motion` convention used throughout the codebase

## Testing
- All 5 `ApiUsage` tests pass
- `ApiDetailPage` tests continue to pass (33 tests)
- No regressions in existing test suite