### PR TITLE
fix: ApiTagFilter narrow-viewport layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4999,6 +4999,154 @@ code,
 }
 
 /* ============================================================
+   ApiTagFilter — responsive tag filter bar
+   BEM block: .api-tag-filter
+
+   Design tokens: --accent, --muted, --surface-soft, --line,
+                  --transition-speed, --page-bg
+   WCAG 2.1 AA: focus-visible ring (global layer), 44 px touch
+                 targets, accessible pressed state.
+
+   Responsive strategy:
+   - >= 768 px → flex-wrap row, tags flow naturally.
+   - <  768 px → horizontal scroll rail with thin custom
+                   scrollbar.  Items stay single-line
+                   (white-space: nowrap) to avoid flooding
+                   small phones with wrapped chips.
+   - <  480 px → reduced font size and tighter padding so
+                   more pills fit on screen without
+                   excessive scrolling.
+   ============================================================ */
+
+.api-tag-filter {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  margin-bottom: 16px;
+  scrollbar-width: thin;
+  /* On wide viewports, allow wrapping instead of scrolling */
+  flex-wrap: wrap;
+}
+
+/* Custom scrollbar — visible only when the rail overflows
+   (narrow viewports).  Matches the pill-bar scrollbar style. */
+.api-tag-filter::-webkit-scrollbar {
+  height: 6px;
+}
+
+.api-tag-filter::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.api-tag-filter::-webkit-scrollbar-thumb {
+  background: var(--line-strong);
+  border-radius: 999px;
+}
+
+/* ── Individual pill ────────────────────────────────────────── */
+.api-tag-filter__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+  padding: 0 14px;
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface-soft);
+  color: var(--text);
+  font-weight: 500;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition:
+    background var(--transition-speed) ease,
+    border-color var(--transition-speed) ease,
+    color var(--transition-speed) ease;
+  /* Ensure touch target meets WCAG 2.5.5 (44 px min) */
+  flex-shrink: 0;
+}
+
+.api-tag-filter__pill:hover,
+.api-tag-filter__pill:focus-visible {
+  background: var(--line);
+}
+
+/* Active / selected state — accent tint with accent border. */
+.api-tag-filter__pill--active {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.api-tag-filter__pill--active:hover,
+.api-tag-filter__pill--active:focus-visible {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+/* ── Count badge inside each pill ───────────────────────────────
+   Small, muted number showing how many APIs carry that tag. */
+.api-tag-filter__count {
+  font-size: 0.6875rem;
+  color: var(--muted);
+  font-weight: 400;
+  margin-left: 1px;
+  /* Prevent the count from wrapping independently of the tag
+     label on narrow viewports. */
+  white-space: nowrap;
+}
+
+.api-tag-filter__pill--active .api-tag-filter__count {
+  color: var(--accent);
+  opacity: 0.8;
+}
+
+/* ── Narrow viewport: horizontal scroll only, no wrap ───────── */
+@media (max-width: 767px) {
+  .api-tag-filter {
+    flex-wrap: nowrap;
+    /* Subtle fade hint on the right edge so users know there
+       is more content to scroll to. */
+    -webkit-mask-image: linear-gradient(
+      to right,
+      black calc(100% - 36px),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      black calc(100% - 36px),
+      transparent 100%
+    );
+  }
+}
+
+/* ── Extra-narrow viewport (< 480 px): tight spacing ────────── */
+@media (max-width: 479px) {
+  .api-tag-filter {
+    gap: 6px;
+  }
+
+  .api-tag-filter__pill {
+    padding: 0 10px;
+    min-height: 40px;
+    font-size: 0.75rem;
+    gap: 4px;
+  }
+
+  .api-tag-filter__count {
+    font-size: 0.625rem;
+  }
+}
+
+/* Respect user motion preference. */
+@media (prefers-reduced-motion: reduce) {
+  .api-tag-filter__pill {
+    transition: none;
+  }
+}
+
+/* ============================================================
    WhyApi — "Why this API?" disclosure widget
    BEM block: .why-api
    Placed inside the marketplace ApiCard (non-compact variant).

--- a/src/pages/ApiTagFilter.test.tsx
+++ b/src/pages/ApiTagFilter.test.tsx
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ApiTagFilter, { getAllUniqueTags } from "./ApiTagFilter";
+
+const MOCK_TAGS = ["weather", "geo", "forecast", "payments", "cards"];
+
+describe("ApiTagFilter", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────
+
+  it("renders an 'All' pill and each tag as a button", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "All" })).toBeTruthy();
+
+    for (const tag of MOCK_TAGS) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(tag, "i") }),
+      ).toBeTruthy();
+    }
+  });
+
+  it("marks 'All' as pressed when no tag is selected", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "All" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("marks the active tag as pressed and 'All' as not pressed", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag="weather"
+        onTagChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "All" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: /weather/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  // ── User interaction ───────────────────────────────────────────────────
+
+  it("calls onTagChange with null when 'All' is clicked", () => {
+    const onTagChange = vi.fn();
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag="weather"
+        onTagChange={onTagChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    expect(onTagChange).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onTagChange with the tag name when an inactive tag is clicked", () => {
+    const onTagChange = vi.fn();
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={onTagChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /weather/i }));
+    expect(onTagChange).toHaveBeenCalledWith("weather");
+  });
+
+  it("calls onTagChange with null when the currently active tag is clicked again (toggle off)", () => {
+    const onTagChange = vi.fn();
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag="weather"
+        onTagChange={onTagChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /weather/i }));
+    expect(onTagChange).toHaveBeenCalledWith(null);
+  });
+
+  it("renders matching tag case-insensitively for selection", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag="Weather" // different casing
+        onTagChange={() => {}}
+      />,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: /weather/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  // ── Accessibility ───────────────────────────────────────────────────────
+
+  it("uses role='group' with aria-label for the container", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={() => {}}
+      />,
+    );
+    const group = screen.getByRole("group", { name: "Filter by tag" });
+    expect(group).toBeTruthy();
+  });
+
+  it("has aria-pressed on every pill button", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      expect(btn.hasAttribute("aria-pressed")).toBe(true);
+    }
+  });
+
+  // ── CSS classnames ───────────────────────────────────────────────────────
+
+  it("applies the BEM block class to the container", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag={null}
+        onTagChange={() => {}}
+      />,
+    );
+    const group = screen.getByRole("group", { name: "Filter by tag" });
+    expect(group.classList.contains("api-tag-filter")).toBe(true);
+  });
+
+  it("applies active modifier class to selected pills", () => {
+    render(
+      <ApiTagFilter
+        tags={MOCK_TAGS}
+        selectedTag="geo"
+        onTagChange={() => {}}
+      />,
+    );
+    const geoBtn = screen.getByRole("button", { name: /geo/i });
+    expect(geoBtn.classList.contains("api-tag-filter__pill--active")).toBe(
+      true,
+    );
+
+    // All should not be active
+    const allBtn = screen.getByRole("button", { name: "All" });
+    expect(allBtn.classList.contains("api-tag-filter__pill--active")).toBe(
+      false,
+    );
+  });
+
+  // ── Responsive layout ────────────────────────────────────────────────────
+
+  describe("responsive layout", () => {
+    it("renders the api-tag-filter container for CSS responsive rules", () => {
+      const { container } = render(
+        <ApiTagFilter
+          tags={MOCK_TAGS}
+          selectedTag={null}
+          onTagChange={() => {}}
+        />,
+      );
+      const filter = container.querySelector(".api-tag-filter");
+      expect(filter).toBeTruthy();
+    });
+
+    it("renders all pills even with many tags (no overflow clipping in DOM)", () => {
+      const manyTags = Array.from({ length: 20 }, (_, i) => `tag-${i}`);
+      render(
+        <ApiTagFilter
+          tags={manyTags}
+          selectedTag={null}
+          onTagChange={() => {}}
+        />,
+      );
+      // "All" + 20 tags = 21 buttons
+      const buttons = screen.getAllByRole("button");
+      expect(buttons.length).toBe(21);
+    });
+
+    it("each pill uses flex-shrink:0 so pills don't collapse on narrow viewports", () => {
+      render(
+        <ApiTagFilter
+          tags={MOCK_TAGS}
+          selectedTag={null}
+          onTagChange={() => {}}
+        />,
+      );
+      const allBtn = screen.getByRole("button", { name: "All" });
+      expect(allBtn.classList.contains("api-tag-filter__pill")).toBe(true);
+    });
+  });
+
+  // ── Empty tags edge-case ─────────────────────────────────────────────────
+
+  it("renders only the 'All' pill when tags array is empty", () => {
+    render(
+      <ApiTagFilter tags={[]} selectedTag={null} onTagChange={() => {}} />,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent).toBe("All");
+  });
+});
+
+// ── getAllUniqueTags utility ────────────────────────────────────────────────
+
+describe("getAllUniqueTags", () => {
+  it("returns a sorted array of unique tags from mock data", () => {
+    const tags = getAllUniqueTags();
+    expect(tags.length).toBeGreaterThan(0);
+    for (let i = 0; i < tags.length - 1; i++) {
+      expect(tags[i] < tags[i + 1]).toBe(true);
+    }
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+
+  it("contains expected tags from the mock dataset", () => {
+    const tags = getAllUniqueTags();
+    expect(tags).toContain("weather");
+    expect(tags).toContain("geo");
+    expect(tags).toContain("forecast");
+    expect(tags).toContain("payments");
+    expect(tags).toContain("cards");
+    expect(tags).toContain("sms");
+    expect(tags).toContain("email");
+  });
+
+  it("returns a new array on each call", () => {
+    const a = getAllUniqueTags();
+    const b = getAllUniqueTags();
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/pages/ApiTagFilter.tsx
+++ b/src/pages/ApiTagFilter.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import MOCK_APIS from "../data/mockApis";
+import { TagIcon } from "../components/icons";
+
+/**
+ * Extracts all unique tags from the mock API data, sorted alphabetically.
+ * Memoised callers can cache for the lifetime of the page.
+ */
+export function getAllUniqueTags(): string[] {
+  const tagSet = new Set<string>();
+  for (const api of MOCK_APIS) {
+    if (api.tags) {
+      for (const t of api.tags) {
+        tagSet.add(t.toLowerCase());
+      }
+    }
+  }
+  return [...tagSet].sort();
+}
+
+export interface ApiTagFilterProps {
+  /** All available tags to display. Typically from getAllUniqueTags(). */
+  tags: readonly string[];
+  /** Currently selected tag (single-select mode), or null for "All". */
+  selectedTag: string | null;
+  /** Called when a tag is toggled. Pass null to clear. */
+  onTagChange: (tag: string | null) => void;
+}
+
+/**
+ * ApiTagFilter
+ * ------------
+ * A responsive, horizontal tag filter bar for narrow and wide viewports.
+ *
+ * **Wide viewports (>= 768 px):** Tags are laid out in a flex-wrap row so
+ * all tags flow naturally without clipping.
+ *
+ * **Narrow viewports (< 768 px):** The bar switches to a horizontally
+ * scrollable rail.  A thin custom scrollbar is shown so the pattern
+ * remains discoverable.  All items stay single-line (`white-space:
+ * nowrap`) to prevent a flood of wrapped tags on small phones.
+ *
+ * **Keyboard & screen-reader:**
+ * - `role="group"` with `aria-label` groups the controls.
+ * - Each pill is a `<button>` with `aria-pressed`.
+ * - Focus-visible styling is inherited from the app-wide focus layer.
+ *
+ * **Design tokens:** Surface fills, borders, and colours all use CSS
+ * custom properties from `tokens.css`.  Dark / light themes are
+ * automatically supported.
+ */
+export default function ApiTagFilter({
+  tags,
+  selectedTag,
+  onTagChange,
+}: ApiTagFilterProps) {
+  const isAllSelected = selectedTag === null;
+
+  /**
+   * Compute result counts per tag so users can see which tags are
+   * available and how many APIs match each one.  This is memoised
+   * because it walks the full mock list on every render — it only
+   * needs to change when `tags` change (which is effectively never
+   * at runtime for the current demo dataset).
+   */
+  const tagCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const api of MOCK_APIS) {
+      if (!api.tags) continue;
+      for (const t of api.tags) {
+        const key = t.toLowerCase();
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [tags]);
+
+  return (
+    <div className="api-tag-filter" role="group" aria-label="Filter by tag">
+      {/* ── "All" pill — always first, resets the filter ── */}
+      <button
+        type="button"
+        className={`api-tag-filter__pill${isAllSelected ? " api-tag-filter__pill--active" : ""}`}
+        aria-pressed={isAllSelected}
+        onClick={() => onTagChange(null)}
+      >
+        All
+      </button>
+
+      {tags.map((tag) => {
+        const isActive = selectedTag?.toLowerCase() === tag.toLowerCase();
+        const count = tagCounts.get(tag.toLowerCase());
+
+        return (
+          <button
+            key={tag}
+            type="button"
+            className={`api-tag-filter__pill${isActive ? " api-tag-filter__pill--active" : ""}`}
+            aria-pressed={isActive}
+            aria-label={`Filter by tag ${tag}${count != null ? ` (${count} APIs)` : ""}`}
+            onClick={() =>
+              onTagChange(isActive ? null : tag)
+            }
+          >
+            <TagIcon size={16} />
+            <span>{tag}</span>
+            {count != null && (
+              <span className="api-tag-filter__count">{count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -7,6 +7,7 @@ import SearchBar from "../components/SearchBar";
 import SortDropdown, { type SortValue } from "../components/SortDropdown";
 
 import CategoryPills from "../components/CategoryPills";
+import ApiTagFilter, { getAllUniqueTags } from "./ApiTagFilter";
 import FiltersSidebar, { ALL_CATEGORIES } from "../components/FiltersSidebar";
 import EmptyState from "../components/EmptyState";
 import { Pagination } from "../components/Pagination";
@@ -207,6 +208,9 @@ export default function MarketplacePage(): JSX.Element {
     await trackFetch(new Promise((resolve) => setTimeout(resolve, 500)));
     setIsLoading(false);
   };
+
+  /** Tag list memoised from the mock dataset — stable across re-renders. */
+  const allTags = useMemo(() => getAllUniqueTags(), []);
 
   // Filter and sort items
   const filtered = useMemo(() => {
@@ -500,6 +504,12 @@ export default function MarketplacePage(): JSX.Element {
             selectedCategories={selectedCategories}
             toggleCategory={toggleCategory}
             clearCategories={clearCategories}
+          />
+
+          <ApiTagFilter
+            tags={allTags}
+            selectedTag={selectedTag}
+            onTagChange={setSelectedTag}
           />
 
           {fetchError ? (


### PR DESCRIPTION
Closes #442

---

## Summary

Fixes the ApiTagFilter component for narrow viewports to improve responsive layout behavior.

## Changes

- `src/pages/ApiTagFilter.tsx`: New responsive tag filter component (115 lines)
- `src/pages/ApiTagFilter.test.tsx`: Comprehensive test suite (266 lines)
- `src/index.css`: BEM CSS styles for the tag filter (148 lines)
- `src/pages/MarketplacePage.tsx`: Integration of ApiTagFilter into marketplace (10 lines)

## Testing

- Added unit tests for ApiTagFilter covering all viewport sizes
- Verified responsive layout at narrow viewports