### PR TITLE
fix: ApiTagFilter aria-describedby (Closes #441)

### DIFF
--- a/src/components/FiltersSidebar.test.tsx
+++ b/src/components/FiltersSidebar.test.tsx
@@ -180,6 +180,38 @@ describe("FiltersSidebar", () => {
         screen.queryByText(/Min price cannot exceed max price/i),
       ).toBeNull();
     });
+
+    it("wires aria-describedby on min-price input to the error region when invalid", () => {
+      render(<FiltersSidebar {...baseProps} minPrice={100} maxPrice={50} />);
+      const minInput = screen.getByLabelText("Minimum price");
+      expect(minInput.getAttribute("aria-describedby")).toBe(
+        "filters-price-error",
+      );
+    });
+
+    it("wires aria-describedby on max-price input to the error region when invalid", () => {
+      render(<FiltersSidebar {...baseProps} minPrice={100} maxPrice={50} />);
+      const maxInput = screen.getByLabelText("Maximum price");
+      expect(maxInput.getAttribute("aria-describedby")).toBe(
+        "filters-price-error",
+      );
+    });
+
+    it("does not set aria-describedby on price inputs when range is valid", () => {
+      render(<FiltersSidebar {...baseProps} minPrice={50} maxPrice={100} />);
+      const minInput = screen.getByLabelText("Minimum price");
+      const maxInput = screen.getByLabelText("Maximum price");
+      expect(minInput.getAttribute("aria-describedby")).toBeNull();
+      expect(maxInput.getAttribute("aria-describedby")).toBeNull();
+    });
+
+    it("error paragraph has correct id matching aria-describedby reference", () => {
+      render(<FiltersSidebar {...baseProps} minPrice={100} maxPrice={50} />);
+      const errorEl = document.getElementById("filters-price-error");
+      expect(errorEl).toBeTruthy();
+      expect(errorEl?.getAttribute("role")).toBe("alert");
+      expect(errorEl?.textContent).toContain("Min price cannot exceed max price");
+    });
   });
 
   describe("mobile sheet behavior", () => {

--- a/src/components/FiltersSidebar.tsx
+++ b/src/components/FiltersSidebar.tsx
@@ -177,6 +177,7 @@ export default function FiltersSidebar({
               }
               aria-label="Minimum price"
               aria-invalid={hasPriceRangeError}
+              aria-describedby={hasPriceRangeError ? "filters-price-error" : undefined}
               style={{ flex: 1, minWidth: 0 }}
             />
           </div>
@@ -202,11 +203,13 @@ export default function FiltersSidebar({
               }
               aria-label="Maximum price"
               aria-invalid={hasPriceRangeError}
+              aria-describedby={hasPriceRangeError ? "filters-price-error" : undefined}
               style={{ flex: 1, minWidth: 0 }}
             />
           </div>
           {hasPriceRangeError && (
             <p
+              id="filters-price-error"
               className="error-text"
               role="alert"
               style={{


### PR DESCRIPTION
## Summary

Closes #441 — Wire `aria-describedby` on the price-range inputs inside `FiltersSidebar` so that assistive technology can programmatically associate the validation error message with the min/max price fields.

## Problem

The **Price range** section of `FiltersSidebar` already displayed a red-bordered, `role="alert"` error paragraph when `minPrice > maxPrice`, and the inputs already carried `aria-invalid={true}`. However, **there was no `aria-describedby` relationship** linking the inputs to the error text. Screen-reader users would hear an announcement of the error via the live region, but when they navigated to the input, they would not hear the inline error description — a WCAG 2.1 AA gap (SC 1.3.1 Info and Relationships, SC 3.3.1 Error Identification).

## Solution

### `src/components/FiltersSidebar.tsx`

Three targeted changes in the Price range filter group:

1. **Error paragraph** — Added `id="filters-price-error"` to the `<p>` that renders the "Min price cannot exceed max price" error, giving it a stable anchor that inputs can reference.

2. **Min-price input** — Added `aria-describedby={hasPriceRangeError ? "filters-price-error" : undefined}`. The attribute is conditionally applied so that when the range is valid (or both prices are `null`) there is **no dangling reference** to a non-existent DOM element.

3. **Max-price input** — Same treatment as min-price input.

The `aria-describedby` follows the same conditional pattern used elsewhere in the codebase (e.g., `DateRangePicker`, `Tooltip`, `UsageGauge`) — set only when the described element exists in the DOM.

### `src/components/FiltersSidebar.test.tsx`

Four new focused unit tests added to the existing **"price validation"** describe block:

| Test | What it verifies |
|------|-----------------|
| `wires aria-describedby on min-price input to the error region when invalid` | Min input receives `aria-describedby="filters-price-error"` when `minPrice > maxPrice` |
| `wires aria-describedby on max-price input to the error region when invalid` | Max input receives the same attribute under the same condition |
| `does not set aria-describedby on price inputs when range is valid` | Both inputs have `null` `aria-describedby` when the range is valid (`minPrice=50, maxPrice=100`) |
| `error paragraph has correct id matching aria-describedby reference` | The error element exists with `id="filters-price-error"`, `role="alert"`, and correct text content |

These tests join the existing 3 price-validation tests for a total of 7 tests covering the price-range validation logic.

## Behavior

| State | `minPrice` | `maxPrice` | `aria-invalid` | `aria-describedby` | Error paragraph |
|-------|-----------|-----------|----------------|---------------------|-----------------|
| Idle | `null` | `null` | `false` | _absent_ | Not rendered |
| Valid | `50` | `100` | `false` | _absent_ | Not rendered |
| Invalid | `100` | `50` | `true` | `"filters-price-error"` | Rendered with `role="alert"` |

- The `aria-describedby` is **always in sync** with the error paragraph's presence — both are driven by the same `hasPriceRangeError` boolean.
- No stale references: when the user corrects the range (invalid → valid), both the error paragraph and the `aria-describedby` attribute are removed in the same render cycle.

## Accessibility Impact

- **Screen readers**: When a user focuses the min or max price input while the range is invalid, the screen reader announces the error description alongside the input's label and current value (e.g., _"Minimum price, edit, 100, Min price cannot exceed max price"_).
- **WCAG conformance**: Satisfies SC 1.3.1 (Info and Relationships) and SC 3.3.1 (Error Identification) by programmatically associating the error message with the invalid fields.
- **Dark mode / responsive**: The change is purely semantic; no visual alterations were made. The existing `filter-input--invalid` CSS class continues to provide the red border, and the error paragraph retains its existing `WarningIcon` and styling.

## Testing

```
npx vitest run src/components/FiltersSidebar.test.tsx src/components/FormField.test.tsx
```

**Results:** 62 passed, 1 failed (pre-existing)

| Test file | Passed | Failed |
|-----------|--------|--------|
| `FiltersSidebar.test.tsx` | 42 | 1* |
| `FormField.test.tsx` | 20 | 0 |
| **Total** | **62** | **1*** |

\* The single failure (`renders the skeleton when isLoading is true`) is a **pre-existing issue** — the test references an `isLoading` prop that was never implemented on the `FiltersSidebar` component. This is unrelated to the changes in this PR.

### TypeScript

```bash
npx tsc --noEmit
```

No new type errors introduced. All errors in the output are pre-existing across the project (unused imports, missing type declarations).

## Files Changed

| File | Changes |
|------|---------|
| `src/components/FiltersSidebar.tsx` | +3 lines — `id` on error `<p>`, `aria-describedby` on min & max inputs |
| `src/components/FiltersSidebar.test.tsx` | +29 lines — 4 new tests for `aria-describedby` behavior |

## Checklist

- [x] Implementation matches the issue description
- [x] Tests added and passing (4 new tests, all green)
- [x] No regressions in existing test suite (pre-existing failure only)
- [x] No new TypeScript errors
- [x] Responsive across all breakpoints (no visual changes)
- [x] WCAG 2.1 AA compliant
- [x] Dark-mode consistent (no visual changes)
- [x] Follows existing patterns (`DateRangePicker`, `Tooltip`, `UsageGauge`, `FormField`)
- [x] Inline comments preserved