### PR TITLE
feat: ApiDetailPage empty state

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -320,6 +320,7 @@ size tailored specifically for inline use inside FiltersSidebar.
 
 - **Illustrations** are custom line-art SVGs, one per variant:
   - `empty`: Open crate/box with subtle accent sparkles → "nothing to show yet"
+  - `api-detail`: API card with a plug motif → "requested API is unavailable"
   - `filtered`: Funnel shape + magnifier-with-slash focal motif, accent tag pills → "filters exclude everything"
   - `error`: Warning triangle with accent-marked exclamation caret, dashed baseline → "something went wrong"
 - All strokes use `var(--muted)` (primary) and `var(--accent)` (subordinate accents). **No hardcoded hex.**
@@ -342,6 +343,7 @@ size tailored specifically for inline use inside FiltersSidebar.
 | Variant  | Default title         | Default message (default)                           | Default message (compact)                 |
 | -------- | --------------------- | --------------------------------------------------- | ----------------------------------------- |
 | empty    | "No APIs available"   | "Check back soon for new integrations."             | same (compact not typical)                |
+| api-detail | "API not found"     | "This API may have moved or is no longer available." | same (compact not typical)               |
 | filtered | "No results found"    | "Your filters are too narrow. Try adjusting them."  | "Adjust filters or clear to see results." |
 | error    | "Failed to load APIs" | "We encountered an error fetching the marketplace…" | "Error loading results. Please retry."    |
 

--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -15,7 +15,7 @@ describe("EmptyState", () => {
   });
 
   describe("variants", () => {
-    const variants: EmptyStateVariant[] = ["empty", "filtered", "error"];
+    const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error"];
 
     it.each(variants)("renders the %s variant illustration", (variant) => {
       render(<EmptyState variant={variant} />);
@@ -28,6 +28,7 @@ describe("EmptyState", () => {
       render(<EmptyState variant={variant} />);
       const titles = {
         empty: /No APIs available/i,
+        "api-detail": /API not found/i,
         filtered: /No results found/i,
         error: /Failed to load APIs/i,
       };
@@ -199,7 +200,7 @@ describe("EmptyState", () => {
     });
 
     it("nested SVG illustrations also carry aria-hidden (WCAG 1.1.1 Non-text Content)", () => {
-      const variants: EmptyStateVariant[] = ["empty", "filtered", "error"];
+      const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error"];
       variants.forEach((variant) => {
         const { container, unmount } = render(<EmptyState variant={variant} />);
         const svgs = container.querySelectorAll("svg");
@@ -211,7 +212,7 @@ describe("EmptyState", () => {
     });
 
     it("SVG illustrations use strokeLinecap='round' for consistent v7 line-art style", () => {
-      const variants: EmptyStateVariant[] = ["empty", "filtered", "error"];
+      const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error"];
       variants.forEach((variant) => {
         const { container, unmount } = render(
           <EmptyState variant={variant} size="default" />,
@@ -249,6 +250,15 @@ describe("EmptyState", () => {
       expect(svg).toBeTruthy();
       const accentFills = svg?.querySelectorAll('[fill="var(--accent)"]');
       expect((accentFills?.length ?? 0) >= 2).toBe(true);
+    });
+
+    it("api-detail illustration uses tokenized API card and plug motifs", () => {
+      const { container } = render(<EmptyState variant="api-detail" />);
+      const svg = container.querySelector("svg");
+      expect(svg?.querySelector("rect")).toBeTruthy();
+      expect(
+        (svg?.querySelectorAll('[stroke="var(--accent)"]').length ?? 0) >= 1,
+      ).toBe(true);
     });
 
     it("error illustration uses var(--accent) for the exclamation caret highlight", () => {
@@ -303,7 +313,7 @@ describe("EmptyState", () => {
     });
 
     it("no illustration contains hardcoded hex colors — all strokes/fills reference design tokens", () => {
-      const variants: EmptyStateVariant[] = ["empty", "filtered", "error"];
+      const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error"];
       const hexRe = /#[0-9a-f]{3,8}/i;
       variants.forEach((variant) => {
         const { container, unmount } = render(<EmptyState variant={variant} />);

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ExternalLink from "./ExternalLink";
 
-export type EmptyStateVariant = "empty" | "filtered" | "error";
+export type EmptyStateVariant = "empty" | "api-detail" | "filtered" | "error";
 export type EmptyStateSize = "default" | "compact";
 
 export interface EmptyStateProps {
@@ -73,6 +73,47 @@ function EmptyIllustration({
           d="M50 40l2 2M54 44l1.5 1.5"
           stroke="var(--accent)"
           strokeWidth={accentStroke}
+        />
+      </svg>
+    );
+  }
+
+  if (variant === "api-detail") {
+    return (
+      <svg
+        width={box}
+        height={box}
+        viewBox="0 0 64 64"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect
+          x="13"
+          y="16"
+          width="38"
+          height="32"
+          rx="6"
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth}
+        />
+        <path
+          d="M20 25h14M20 32h10M20 39h7"
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth * 0.85}
+        />
+        <path
+          d="M40 28v-4M46 28v-4M38 28h10v8a5 5 0 0 1-10 0v-8zM43 41v7"
+          stroke="var(--accent)"
+          strokeWidth={accentStroke}
+        />
+        <circle cx="52" cy="13" r="1.5" fill="var(--accent)" stroke="none" />
+        <path
+          d="M10 51h18"
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth * 0.7}
+          strokeDasharray="2 3"
         />
       </svg>
     );
@@ -177,6 +218,7 @@ function EmptyIllustration({
  *
  * Variants:
  * - empty:    Default state when no APIs exist in the marketplace.
+ * - api-detail: A requested API listing is unavailable. Uses an API-card illustration.
  * - filtered: Active filters yield zero results. Shows a "Clear all filters" CTA.
  *             Used inline inside FiltersSidebar (compact) and the results grid (default).
  * - error:    Network/fetch failure. Shows a "Retry" button plus a status link.
@@ -215,6 +257,10 @@ export default function EmptyState({
     empty: {
       title: "No APIs available",
       message: "Check back soon for new integrations.",
+    },
+    "api-detail": {
+      title: "API not found",
+      message: "This API may have moved or is no longer available.",
     },
     filtered: {
       title: "No results found",

--- a/src/pages/ApiDetailPage.test.tsx
+++ b/src/pages/ApiDetailPage.test.tsx
@@ -109,8 +109,11 @@ describe("ApiDetailPage", () => {
     settleLoadingState();
 
     expect(screen.getByRole("heading", { name: "API not found" })).toBeTruthy();
-    expect(screen.getByText("We couldn't find that API. Try the marketplace.")).toBeTruthy();
+    expect(
+      screen.getByText("This API may have moved or is no longer available."),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Back to marketplace" })).toBeTruthy();
+    expect(screen.getByTestId("empty-state-api-detail").querySelector("svg")).toBeTruthy();
   });
 
   // ── Tab switching ─────────────────────────────────────────────────────────

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -458,10 +458,12 @@ export default function ApiDetailPage({ onBack }: Props) {
               { label: "Not Found", href: "", isCurrent: true },
             ]}
           />
-          <EmptyState 
-            title="API not found" 
-            message="We couldn't find that API. Try the marketplace." 
-            action={{ label: "Back to marketplace", onClick: () => (window.location.href = "/marketplace") }}
+          <EmptyState
+            variant="api-detail"
+            action={{
+              label: "Back to marketplace",
+              onClick: () => (window.location.href = "/marketplace"),
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated, token-based API detail empty-state illustration
- show helpful unavailable-API copy and a marketplace CTA
- document the new visible variant and extend focused accessibility/design-token tests

Closes #414

## Validation
- `npm test -- --run src/pages/ApiDetailPage.test.tsx` ? 33 passed
- focused `EmptyState.test.tsx` API-detail selection ? 4 passed
- `git diff --check` ? passed

## Known baseline failures
- Full `EmptyState.test.tsx`: 2 pre-existing retry-state test failures (timeout and disabled-attribute assertion)
- `npm run build`: blocked by existing TypeScript errors in unrelated files, including `ApiUsage.tsx`, `App.tsx`, `MethodChip.tsx`, and `ApiReviews.tsx`
- No lint script is defined in `package.json`
