### PR TITLE
fix: improve ApiCard mobile breakpoint layout

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -30,6 +30,23 @@ vi.mock("../state/compareStore", () => ({
   },
 }));
 
+/* ── Test data ─────────────────────────────────────────────────────────── */
+
+const mockApi: APIItem = {
+  id: "api-1",
+  name: "Stellar Metering API",
+  endpoint: "/api/v1/meter",
+  description: "A mock API for testing.",
+  tags: ["weather", "forecast", "geo"],
+  pricePerRequest: 0.01,
+  provider: { name: "Acme Labs" },
+  rating: 4.5,
+  uptimePercent: 99.9,
+  avgLatencyMs: 180,
+  pricePerCall: 0.01,
+  endpoints: [{ id: "e1", url: "/api/v1/meter", method: "GET" }],
+};
+
 /* ── Test suites ─────────────────────────────────────────────────────────── */
 
 describe("ApiCard — Context Menu", () => {
@@ -284,5 +301,87 @@ describe("ApiCard reduced motion", () => {
 
     expect(screen.getByText("Stellar Metering API")).toBeDefined();
     window.matchMedia = origMatchMedia;
+  });
+});
+
+describe("ApiCard responsive layout", () => {
+  const responsiveApi: APIItem = {
+    id: "resp-1",
+    name: "Responsive API",
+    description: "An API with long description text that might overflow on narrow viewports if not handled correctly.",
+    tags: ["analytics", "reporting", "data", "insights"],
+    pricePerRequest: 0.005,
+    provider: { name: "DataCorp" },
+    rating: 4.2,
+    uptimePercent: 99.95,
+    avgLatencyMs: 220,
+    pricePerCall: 0.005,
+  };
+
+  beforeEach(() => {
+    // Always ensure matchMedia returns a valid MediaQueryList-like object.
+    // Previous test suites may have replaced it with a mock that returns undefined.
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as any;
+  });
+
+  it("renders with proper responsive CSS classes for marketplace card", () => {
+    render(<ApiCard api={responsiveApi} />);
+
+    const card = screen.getByRole("button", { name: /View details for Responsive API/i });
+    expect(card.className).toContain("api-marketplace-card");
+    expect(card.className).toContain("preview-card");
+  });
+
+  it("renders card in compact mode with compact CSS class", () => {
+    render(<ApiCard api={responsiveApi} density="compact" />);
+
+    const card = screen.getByRole("button", { name: /View details for Responsive API/i });
+    expect(card.className).toContain("api-card--compact");
+  });
+
+  it("renders stats grid which collapses on narrow viewports", () => {
+    render(<ApiCard api={responsiveApi} />);
+
+    const statsGrid = screen.getByLabelText("API stats");
+    expect(statsGrid).toBeTruthy();
+    expect(statsGrid.className).toContain("api-card__stats");
+
+    // All three stat cells are present
+    const statCells = statsGrid.querySelectorAll(".api-card__stat");
+    expect(statCells.length).toBe(3);
+  });
+
+  it("renders wrapped tag chips that fit narrow viewports", () => {
+    render(<ApiCard api={responsiveApi} />);
+
+    const tagButtons = screen.getAllByRole("button", { name: /Filter marketplace by tag/ });
+    expect(tagButtons.length).toBe(4);
+  });
+
+  it("renders prices as numeric-tabular for consistent number display", () => {
+    render(<ApiCard api={responsiveApi} />);
+
+    // The price div should have the numeric-tabular class for tabular numbers
+    const priceElement = document.querySelector(".api-marketplace-card-price");
+    expect(priceElement).toBeTruthy();
+    expect(priceElement?.className).toContain("numeric-tabular");
+  });
+
+  it("has proper min-width: 0 on body to prevent overflow", () => {
+    render(<ApiCard api={responsiveApi} />);
+
+    const bodyEl = document.querySelector(".api-marketplace-card-body");
+    expect(bodyEl).toBeTruthy();
+    // Browsers may normalize "0" as 0 or "0px" — either is fine
+    expect(Number((bodyEl as HTMLElement).style.minWidth)).toBe(0);
   });
 });

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -642,34 +642,7 @@ export default function ApiCard({
         prefersReducedMotion={prefersReducedMotion}
       />
 
-       {/* Pin button - absolutely positioned, top-left */}
-       <button
-         onClick={handleCompareClick}
-         disabled={!canCompare}
-         className="api-card__compare-btn"
-         style={{
-           position: "absolute",
-           top: "8px",
-           left: "48px",
-           zIndex: 10,
-           background: isCompared ? "var(--accent)" : "rgba(0,0,0,0.5)",
-           color: "white",
-           border: "none",
-           borderRadius: "8px",
-           padding: "4px 8px",
-           fontSize: "0.75rem",
-           fontWeight: 600,
-           cursor: canCompare ? "pointer" : "not-allowed",
-           opacity: isCompared ? 1 : 0.6,
-           transition: prefersReducedMotion ? "none" : "opacity 0.2s, background 0.2s"
-         }}
-         aria-label={isCompared ? `Remove ${api.name} from comparison` : `Add ${api.name} to comparison`}
-         aria-pressed={isCompared}
-       >
-         {isCompared ? "Compared" : "Compare"}
-       </button>
-
-      {/* Pin button - absolutely positioned, top-left */}
+      {/* Compare button - absolutely positioned, top-left */}
       <button
         onClick={handleCompareClick}
         disabled={!canCompare}
@@ -688,7 +661,10 @@ export default function ApiCard({
           fontWeight: 600,
           cursor: canCompare ? "pointer" : "not-allowed",
           opacity: isCompared ? 1 : 0.6,
-          transition: "opacity 0.2s, background 0.2s",
+          transition: prefersReducedMotion ? "none" : "opacity 0.2s, background 0.2s",
+          minWidth: 44,
+          minHeight: 44,
+          whiteSpace: "nowrap",
         }}
         aria-label={isCompared ? `Remove ${api.name} from comparison` : `Add ${api.name} to comparison`}
         aria-pressed={isCompared}
@@ -696,7 +672,7 @@ export default function ApiCard({
         {isCompared ? "Compared" : "Compare"}
       </button>
 
-      <div className="api-marketplace-card-header" style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <div className="api-marketplace-card-header" style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
         <div
           className="api-marketplace-card-icon"
           style={{
@@ -715,7 +691,7 @@ export default function ApiCard({
         </div>
 
         <div className="api-marketplace-card-body" style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-          <div className="api-marketplace-card-title-row" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+          <div className="api-marketplace-card-title-row" style={{ display: "flex", gap: 8, alignItems: "baseline", flexWrap: "wrap" }}>
             <strong>{api.name}</strong>
             <div style={{ color: "var(--muted)", fontSize: 12 }}>{api.provider?.name}</div>
           </div>
@@ -771,6 +747,7 @@ export default function ApiCard({
           alignItems: "center",
           justifyContent: "space-between",
           gap: 12,
+          flexWrap: "wrap",
         }}
       >
         <span
@@ -823,6 +800,7 @@ export default function ApiCard({
             justifyContent: "space-between",
             alignItems: "center",
             gap: 12,
+            flexWrap: "wrap",
           }}
         >
           <span className="ghost-button" aria-hidden="true" style={{ display: "inline-flex", alignItems: "center" }}>

--- a/src/index.css
+++ b/src/index.css
@@ -1774,6 +1774,114 @@ code,
   color: var(--muted);
 }
 
+/* ─── ApiCard responsive breakpoints ────────────────────────────────────── */
+/* Narrow viewports (≤768px): reduce spacing and adjust stat grid. */
+@media (max-width: 768px) {
+  .api-marketplace-card {
+    padding: 10px;
+    gap: 6px;
+    min-height: auto;
+  }
+
+  .api-marketplace-card-header {
+    gap: 8px;
+  }
+
+  .api-marketplace-card-icon {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    font-size: 16px;
+    border-radius: 8px;
+  }
+
+  .api-marketplace-card-price {
+    padding-right: 28px;
+  }
+
+  .api-card__stats {
+    gap: 8px;
+    padding: 10px 0 0;
+  }
+
+  .api-card__stat-label {
+    font-size: 10px;
+  }
+
+  .api-card__stat-value {
+    font-size: 0.875rem;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .api-marketplace-card-footer-row {
+    gap: 8px;
+  }
+
+  .kbd-hint {
+    gap: 8px;
+  }
+
+  .kbd-hint__item {
+    font-size: 0.65rem;
+  }
+}
+
+/* Extra-narrow viewports (≤480px): stack content, collapse stats. */
+@media (max-width: 480px) {
+  .api-marketplace-card {
+    padding: 8px;
+    gap: 6px;
+  }
+
+  .api-marketplace-card-header {
+    gap: 6px;
+  }
+
+  .api-marketplace-card-title-row {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .api-marketplace-card-description {
+    font-size: 0.8125rem;
+  }
+
+  .api-card__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    padding: 8px 0 0;
+  }
+
+  .api-card__stat-value {
+    font-size: 0.8125rem;
+  }
+
+  .api-card__compare-btn {
+    padding: 4px 6px;
+    font-size: 0.65rem;
+    left: 44px;
+    min-width: 36px;
+    min-height: 36px;
+  }
+
+  .kbd-hint {
+    gap: 4px;
+    padding: 4px 0;
+  }
+
+  .kbd-hint__item {
+    font-size: 0.6rem;
+    gap: 2px;
+  }
+
+  .kbd-hint__key {
+    min-width: 20px;
+    padding: 1px 4px;
+    font-size: 0.65rem;
+  }
+}
+
 .marketplace-filter-modal {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
- Remove duplicate Compare button
- Add flexWrap to header, title-row, activity, and footer for responsive wrapping
- Add WCAG touch targets (minWidth/minHeight: 44) to Compare button
- Add @media (max-width: 768px) and (max-width: 480px) responsive CSS
- Stats grid collapses to 2 columns on extra-narrow viewports
- Add module-level mockApi definition fixing pre-existing test failures
- Add 6 responsive-focused tests

Closes #409