### PR TITLE
feat: MarketplacePage kbd hints

### DIFF
--- a/src/pages/MarketplacePage.test.tsx
+++ b/src/pages/MarketplacePage.test.tsx
@@ -94,4 +94,14 @@ describe("MarketplacePage", () => {
 
     pushStateSpy.mockRestore();
   });
+
+  it("renders keyboard shortcuts hint", () => {
+    renderMarketplacePage();
+    settleMarketplaceTimers();
+
+    const hint = screen.getByRole("complementary", { name: "Keyboard shortcuts" });
+    expect(hint).toBeTruthy();
+    expect(screen.getByText("Focus search bar")).toBeTruthy();
+    expect(screen.getByText("Add/remove focused API card to comparison")).toBeTruthy();
+  });
 });

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -9,6 +9,8 @@ import SortDropdown, { type SortValue } from "../components/SortDropdown";
 import CategoryPills from "../components/CategoryPills";
 import ApiTagFilter, { getAllUniqueTags } from "./ApiTagFilter";
 import FiltersSidebar, { ALL_CATEGORIES } from "../components/FiltersSidebar";
+import KbdHint from "../components/KbdHint";
+import { SHORTCUTS } from "../hooks/useGlobalShortcuts";
 import EmptyState from "../components/EmptyState";
 import { Pagination } from "../components/Pagination";
 import MOCK_APIS, { type APIItem } from "../data/mockApis";
@@ -575,6 +577,11 @@ export default function MarketplacePage(): JSX.Element {
         favoritesOnly={favoritesOnly}
         toggleFavoritesOnly={() => setFavoritesOnly(!favoritesOnly)}
         triggerRef={filtersTriggerRef}
+      />
+
+      {/* Keyboard shortcuts hint */}
+      <KbdHint
+        shortcuts={SHORTCUTS.filter((s) => s.category === "Marketplace")}
       />
     </div>
   );


### PR DESCRIPTION
Closes #473 
**Description:**
This PR resolves the UI/UX issue for the GrantFox FWC26 (Stellar Wave) campaign by adding the `KbdHint` keyboard shortcuts hint to the `MarketplacePage`. It ensures users are visually informed about available shortcuts to improve the application's overall accessibility and navigation experience.

**Changes:**
- Imported and rendered `KbdHint` at the bottom of the `MarketplacePage`.
- Filtered `SHORTCUTS` from `useGlobalShortcuts` to only display shortcuts explicitly related to the Marketplace category (e.g., Focus search bar `/`).
- Added a focused unit test to `MarketplacePage.test.tsx` to ensure `KbdHint` renders properly with its accessibility labels.

**Acceptance Criteria Met:**
- [x] Implementation matches the description.
- [x] Focused tests added and passing successfully.
- [x] Ensures WCAG 2.1 AA accessibility (using appropriate `aria-label`).
- [x] Adheres to repository code style and design-token consistency.

