### PR TITLE
feat: ApiUsage keyboard shortcut hint (v7)

### DIFF
--- a/src/ApiUsage.test.tsx
+++ b/src/ApiUsage.test.tsx
@@ -99,6 +99,53 @@ statValues.forEach((el, i) => {
    });
  });
 
+describe('ApiUsage - Keyboard Shortcut Hints', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { search: '', pathname: '/api-usage' },
+      writable: true,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false, media: query, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    vi.clearAllMocks();
+  });
+
+  it('renders the KbdHint component with ApiUsage shortcuts', () => {
+    render(<ApiUsage />);
+    const kbdHint = document.querySelector('.kbd-hint');
+    expect(kbdHint).toBeTruthy();
+    expect(kbdHint?.getAttribute('aria-label')).toBe('Keyboard shortcuts');
+  });
+
+  it('displays the make test call shortcut key', () => {
+    render(<ApiUsage />);
+    const kbdHint = document.querySelector('.kbd-hint');
+    expect(kbdHint?.textContent).toContain('m');
+    expect(kbdHint?.textContent).toContain('Make test call');
+  });
+
+  it('displays the toggle history shortcut key', () => {
+    render(<ApiUsage />);
+    const kbdHint = document.querySelector('.kbd-hint');
+    expect(kbdHint?.textContent).toContain('h');
+    expect(kbdHint?.textContent).toContain('Toggle request history');
+  });
+
+  it('displays the reset filters shortcut key', () => {
+    render(<ApiUsage />);
+    const kbdHint = document.querySelector('.kbd-hint');
+    expect(kbdHint?.textContent).toContain('r');
+    expect(kbdHint?.textContent).toContain('Reset call history filters');
+  });
+});
+
 describe('ApiUsage - prefers-reduced-motion', () => {
    let originalMatchMedia: typeof window.matchMedia;
 

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -14,6 +14,8 @@ import CallsHeatmap from './components/CallsHeatmap';
 import Tabs from './components/Tabs';
 import { Icons } from './utils/icons';
 import { LinkIcon } from './components/icons';
+import KbdHint from './components/KbdHint';
+import { SHORTCUTS } from './hooks/useGlobalShortcuts';
 import {
   clearHistory,
   loadHistory,
@@ -193,6 +195,10 @@ curl -X GET "https://api.callora.com/v1/user/profile" \\
   -H "Authorization: Bearer your-api-key-here" \\
   -H "Content-Type: application/json"`
 };
+
+const API_USAGE_SHORTCUTS = SHORTCUTS.filter(
+  (s) => s.category === "ApiUsage",
+);
 
 
 
@@ -567,6 +573,8 @@ export default function ApiUsage() {
           </div>
         </div>
       </div>
+
+      <KbdHint shortcuts={API_USAGE_SHORTCUTS} />
 
       {/* API Key Section */}
       <div className="surface api-key-section">

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -23,6 +23,11 @@ export const SHORTCUTS: Shortcut[] = [
   // ApiDetailPage
   { key: 'Esc', description: 'Go back to Marketplace', category: 'ApiDetailPage' },
   { key: '1-5', description: 'Switch tabs (1=Overview, 2=Documentation, 3=Pricing, 4=Examples, 5=Reviews)', category: 'ApiDetailPage' },
+
+  // ApiUsage
+  { key: 'm', description: 'Make test call', category: 'ApiUsage' },
+  { key: 'h', description: 'Toggle request history', category: 'ApiUsage' },
+  { key: 'r', description: 'Reset call history filters', category: 'ApiUsage' },
 ];
 
 export function useGlobalShortcuts(handler: (event: KeyboardEvent) => void) {


### PR DESCRIPTION
# PR: feat: ApiUsage keyboard shortcut hint (v7)

Closes #483   
**Branch:** `task/apiusage-kbd-v7`

## Description

Shows keyboard shortcut hint on ApiUsage using the existing `KbdHint` component. Three ApiUsage shortcuts are defined and displayed as a persistent hint bar below the header.

## Changes

### `src/hooks/useGlobalShortcuts.ts`
- Added 3 shortcuts for the `ApiUsage` category:
  - `m` — Make test call
  - `h` — Toggle request history
  - `r` — Reset call history filters

### `src/ApiUsage.tsx`
- Imported `KbdHint` component and `SHORTCUTS` constant
- Defined `API_USAGE_SHORTCUTS` as a module-level filter (matches `API_DETAIL_SHORTCUTS` pattern in `ApiDetailPage.tsx`)
- Rendered `<KbdHint shortcuts={API_USAGE_SHORTCUTS} />` between the header section and the API Key section

### `src/ApiUsage.test.tsx`
- Added `ApiUsage - Keyboard Shortcut Hints` test suite with 4 tests:
  - Renders the KbdHint component with correct `aria-label`
  - Displays the `m` / "Make test call" shortcut
  - Displays the `h` / "Toggle request history" shortcut
  - Displays the `r` / "Reset call history filters" shortcut

## Testing

- All 9 ApiUsage tests pass
- TypeScript compilation: no new errors

## Acceptance Criteria

- [x] Keyboard shortcut hints visible on ApiUsage page
- [x] Tests added and passing
- [x] WCAG 2.1 AA (aria-label on KbdHint)
- [x] Consistent with existing KbdHint usage on ApiDetailPage and ApiCard
