### PR TITLE
fix: MarketplacePage tabular-nums

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -911,6 +911,7 @@ The following utility classes are defined in `src/index.css` and should be used 
 - `.brand` - Large brand heading
 - `.eyebrow` - Small uppercase label
 - `.helper-text` - Secondary/muted text
+- `.numeric-tabular` - Apply `font-variant-numeric: tabular-nums` to any numeric display (prices, counts, stats, pagination). Use this wherever digits must stay fixed-width so values don't cause layout shift as they change. Defined in `src/styles/typography.css`. `.tabular-nums` is kept as a backwards-compatible alias but `.numeric-tabular` is the canonical name.
 
 ### Link Classes
 

--- a/src/pages/MarketplacePage.test.tsx
+++ b/src/pages/MarketplacePage.test.tsx
@@ -127,4 +127,55 @@ describe("MarketplacePage", () => {
     const grid = document.querySelector(".marketplace-grid");
     expect(grid).toBeTruthy();
   });
+
+  // ── tabular-nums (#476) ────────────────────────────────────────────────────
+
+  it("wraps page-count numbers in .numeric-tabular spans for tabular-nums alignment", () => {
+    renderMarketplacePage();
+    settleMarketplaceTimers();
+
+    // All numeric spans inside the count label must carry the utility class.
+    const count = document.querySelector(".marketplace-count");
+    expect(count).toBeTruthy();
+
+    const numericSpans = count!.querySelectorAll("span.numeric-tabular");
+    // Expects at least 3 spans: startItem, endItem, filtered.length
+    expect(numericSpans.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("numeric-tabular spans contain only digit characters", () => {
+    renderMarketplacePage();
+    settleMarketplaceTimers();
+
+    const count = document.querySelector(".marketplace-count");
+    const numericSpans = count!.querySelectorAll("span.numeric-tabular");
+
+    numericSpans.forEach((span) => {
+      expect(span.textContent?.trim()).toMatch(/^\d+$/);
+    });
+  });
+
+  it("renders two .numeric-tabular spans showing '0' when no APIs match the search", () => {
+    renderMarketplacePage();
+    settleMarketplaceTimers();
+
+    // Type a search term that matches nothing
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "zzz_no_match_zzz" } });
+
+    // Advance debounce (300 ms) + any remaining timers
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const count = document.querySelector(".marketplace-count");
+    expect(count).toBeTruthy();
+
+    const numericSpans = count!.querySelectorAll("span.numeric-tabular");
+    // When 0 results: two spans showing "0" and "0"
+    expect(numericSpans.length).toBe(2);
+    numericSpans.forEach((span) => {
+      expect(span.textContent?.trim()).toBe("0");
+    });
+  });
 });

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -453,12 +453,26 @@ export default function MarketplacePage(): JSX.Element {
           }
         >
           <div className="marketplace-toolbar">
+            {/* numeric-tabular keeps page/count digits fixed-width so the
+                label doesn't shift as the user pages through results. */}
             <div className="marketplace-count">
               {filtered.length === 0 ? (
-                <>Showing 0 of 0 APIs</>
+                <>
+                  Showing{" "}
+                  <span className="numeric-tabular">0</span>
+                  {" "}of{" "}
+                  <span className="numeric-tabular">0</span>
+                  {" "}APIs
+                </>
               ) : (
                 <>
-                  Showing {startItem}-{endItem} of {filtered.length} APIs
+                  Showing{" "}
+                  <span className="numeric-tabular">{startItem}</span>
+                  {"–"}
+                  <span className="numeric-tabular">{endItem}</span>
+                  {" "}of{" "}
+                  <span className="numeric-tabular">{filtered.length}</span>
+                  {" "}APIs
                 </>
               )}
               {selectedTag && (

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,8 +1,12 @@
 /* Numeric typography utilities
-   tabular-nums — fixed-width numerals so digits (especially in tables,
-   stats, and prices) don't shift as values change.  This meets a common
-   data-display requirement and improves readability of financial / metric
-   readouts across light and dark themes. */
+   numeric-tabular / tabular-nums — fixed-width numerals so digits (especially
+   in tables, stats, and prices) don't shift as values change.  This meets a
+   common data-display requirement and improves readability of financial and
+   metric readouts across light and dark themes.
+
+   Use `.numeric-tabular` (canonical name, matches the design system doc and
+   ApiCard).  `.tabular-nums` is kept as an alias for backwards compatibility. */
+.numeric-tabular,
 .tabular-nums {
   font-variant-numeric: tabular-nums;
 }

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -4,8 +4,6 @@ export const DENSITY_STORAGE_KEY = 'callora.density';
 
 const VALID: DensityPreference[] = ['comfortable', 'compact'];
 
-export const DENSITY_STORAGE_KEY = 'callora.density';
-
 export function readDensityPreference(): DensityPreference {
   try {
     const stored = localStorage.getItem(DENSITY_STORAGE_KEY);


### PR DESCRIPTION
  ## Summary

  Implements issue #476 — applies `font-variant-numeric: tabular-nums` to numeric displays on `MarketplacePage` so digits stay fixed-width and don't cause
  layout shift as values change during filtering and pagination.
  
  ## Changes

  ### `src/styles/typography.css`
  - Added `.numeric-tabular` as the canonical utility class (`font-variant-numeric: tabular-nums`)
  - `.tabular-nums` kept as a backwards-compatible alias
  - Resolves the class name mismatch between `ApiCard` (which already used `numeric-tabular`) and the stylesheet (which only defined `tabular-nums`)

  ### `src/pages/MarketplacePage.tsx`
  - Wrapped the three numerals in the "Showing X–Y of Z APIs" count label with `<span className="numeric-tabular">` so page numbers and result counts
  remain fixed-width during filtering and pagination
  - Zero-results path ("Showing 0 of 0 APIs") wrapped consistently
  
  ### `src/pages/MarketplacePage.test.tsx`
  - Added 3 focused tests:
    1. `.numeric-tabular` spans are present in `.marketplace-count` when results exist (≥ 3 spans)
    2. Each span contains only digit characters
    3. Zero-results path renders exactly two `0` spans
  
  ### `docs/UI-Design-System.md`
  - Added `.numeric-tabular` to the Typography Classes section with usage guidance and a note that `.tabular-nums` is the legacy alias
  
  ### `src/utils/density.ts`
  - Fixed a pre-existing duplicate `export const DENSITY_STORAGE_KEY` that was blocking the entire test suite from running (unrelated to this feature but
  required for tests to pass)

  ## Test output

  ✓ src/pages/MarketplacePage.test.tsx (9 tests) 2334ms
  Test Files  1 passed (1)
  Tests       9 passed (9)
  
  ## Accessibility
  
  `font-variant-numeric: tabular-nums` has no negative accessibility impact. It is a typographic rendering hint only — no color, contrast, focus, or
  semantic changes. WCAG 2.1 AA is unaffected.
  
  ## Design system compliance
  
  - No hardcoded hex values
  - Uses existing CSS layer conventions in `src/styles/typography.css`
  - Works in both light and dark themes (property is theme-agnostic)
  - Responsive at all breakpoints (the CSS rule applies regardless of viewport width)
  
closes #476 