### PR TITLE
fix: add themed empty-state illustration for FiltersSidebar

### DIFF
--- a/src/components/FiltersSidebar.test.tsx
+++ b/src/components/FiltersSidebar.test.tsx
@@ -279,9 +279,13 @@ describe("FiltersSidebar", () => {
       expect(screen.queryByTestId("filters-zero-results")).toBeNull();
     });
 
-    it("does NOT render zero-results block when resultCount is 0 but NO filters active", () => {
+    it("renders empty variant when resultCount=0 and NO filters active (genuine empty marketplace)", () => {
       render(<FiltersSidebar {...baseProps} resultCount={0} />);
-      expect(screen.queryByTestId("filters-zero-results")).toBeNull();
+      const block = screen.getByTestId("filters-zero-results");
+      expect(block).toBeTruthy();
+      expect(
+        block.querySelector('[data-testid="empty-state-empty"]'),
+      ).toBeTruthy();
     });
 
     it("renders zero-results illustration when resultCount=0 and categories selected", () => {
@@ -323,6 +327,20 @@ describe("FiltersSidebar", () => {
         <FiltersSidebar {...baseProps} favoritesOnly={true} resultCount={0} />,
       );
       expect(screen.getByTestId("filters-zero-results")).toBeTruthy();
+    });
+
+    it("renders filtered variant when resultCount=0 AND filters active", () => {
+      render(
+        <FiltersSidebar
+          {...baseProps}
+          selectedCategories={new Set(["AI/ML"])}
+          resultCount={0}
+        />,
+      );
+      const block = screen.getByTestId("filters-zero-results");
+      expect(
+        block.querySelector('[data-testid="empty-state-filtered"]'),
+      ).toBeTruthy();
     });
 
     it("uses compact size EmptyState inside the sidebar", () => {

--- a/src/components/FiltersSidebar.tsx
+++ b/src/components/FiltersSidebar.tsx
@@ -306,32 +306,33 @@ export default function FiltersSidebar({
         </div>
       </FilterGroup>
 
-      {/* ── Zero-results illustration (v7) ───────────────────────────────
-         Visually separates from the filter groups above with a soft token-
-         based top border so the call-to-action feels grouped with the
-         result-count feedback rather than with the Favorites section.
-         The wrapper is aria-live="polite" so screen readers announce the
-         zero-results state when filters narrow the count to 0. */}
-      {typeof resultCount === "number" &&
-        resultCount === 0 &&
-        hasActiveFilters && (
-          <div
-            data-testid="filters-zero-results"
-            style={{
-              margin: "12px 0 12px",
-              paddingTop: "12px",
-              borderTop: "1px solid var(--line)",
-            }}
-            role="status"
-            aria-live="polite"
-          >
-            <EmptyState
-              variant="filtered"
-              size="compact"
-              onClearFilters={hasActiveFilters ? clearFilters : undefined}
-            />
-          </div>
-        )}
+      {/* ── Zero-results / Empty-state illustration (v7) ─────────────────
+         Two distinct cases:
+         1. Active filters + zero results → "filtered" variant with a
+            Clear-filters CTA so users can broaden their search.
+         2. No filters active + zero results → "empty" variant telling
+            users no APIs are available yet.
+
+         Both are wrapped in role="status" aria-live="polite" so screen
+         readers announce the state change. */}
+      {typeof resultCount === "number" && resultCount === 0 && (
+        <div
+          data-testid="filters-zero-results"
+          style={{
+            margin: "12px 0 12px",
+            paddingTop: "12px",
+            borderTop: "1px solid var(--line)",
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <EmptyState
+            variant={hasActiveFilters ? "filtered" : "empty"}
+            size="compact"
+            onClearFilters={hasActiveFilters ? clearFilters : undefined}
+          />
+        </div>
+      )}
 
       {/* ── Clear ──────────────────────────────────────────────────────── */}
       <div style={{ marginTop: 8 }}>


### PR DESCRIPTION
## Summary

Add themed empty-state illustration for FiltersSidebar when no data is available.

### Changes
- Empty-state now renders whenever resultCount is 0 (not just with active filters)
- Uses filtered variant + clear CTA when filters are active
- Uses empty variant when no filters are active (genuine empty marketplace)
- Updated and added tests for both empty and filtered zero-results states

Closes #574