### PR TITLE
fix: polish ApiCard loading skeleton to match final card shape

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -291,6 +291,32 @@ describe("ApiCard reduced motion", () => {
   });
 });
 
+describe("ApiCard skeleton", () => {
+  it("includes sparkline placeholder to match final card layout", () => {
+    render(<ApiCard loading />);
+    // The skeleton should have the sparkline section (24h label + sparkline area)
+    const cards = document.querySelectorAll(".api-card-skeleton");
+    expect(cards.length).toBe(1);
+    // Verify the skeleton is rendered (not the actual card)
+    expect(screen.getByText("Loading API")).toBeTruthy();
+  });
+
+  it("includes WhyApi placeholder to match comfortable-mode card shape", () => {
+    const { container } = render(<ApiCard loading />);
+    // The skeleton renders multiple Skeleton blocks — one for the WhyApi section
+    const skeletons = container.querySelectorAll(".skeleton--stellar");
+    // Title, provider, description lines, tags, WhyApi lines, sparkline label,
+    // sparkline, 3 stat labels, 3 stat values, CTA, rating
+    expect(skeletons.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it("uses tone stellar for themed skeleton appearance", () => {
+    const { container } = render(<ApiCard loading />);
+    const skeletons = container.querySelectorAll(".skeleton--stellar");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
 describe("ApiCard responsiveness", () => {
   const mockApi: APIItem = {
     id: "api-resp",

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -71,10 +71,32 @@ export function ApiCardSkeleton() {
         </div>
       </div>
 
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         <Skeleton tone="stellar" width={45} height={24} borderRadius={8} />
         <Skeleton tone="stellar" width={55} height={24} borderRadius={8} />
         <Skeleton tone="stellar" width={40} height={24} borderRadius={8} />
+      </div>
+
+      {/* WhyApi placeholder — matches the real card's rationale section
+          that appears in comfortable mode. */}
+      <div style={{ marginTop: 2, display: "flex", flexDirection: "column", gap: 4 }}>
+        <Skeleton tone="stellar" width="35%" height={12} />
+        <Skeleton tone="stellar" width="80%" height={12} />
+      </div>
+
+      {/* Sparkline section — matches the real card's 24h sparkline
+          that appears between tags and stats. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          marginTop: 2,
+        }}
+      >
+        <Skeleton tone="stellar" width={52} height={12} />
+        <Skeleton tone="stellar" width={90} height={28} />
       </div>
 
       <div


### PR DESCRIPTION
## Summary

Polish the ApiCard loading skeleton to match the final card shape and prevent layout shift.

### Changes
- Added WhyApi placeholder section to skeleton (2 skeleton lines, matches comfortable mode)
- Added sparkline placeholder section with 24h label (matches all modes)
- Removed unnecessary marginTop on tags to match real card spacing
- Added 3 new tests for skeleton structure and elements

Closes #570