### PR TITLE
fix: add visible focus-visible outline on ApiDetailPage interactive elements

### DIFF
--- a/src/focus-layer.test.ts
+++ b/src/focus-layer.test.ts
@@ -56,4 +56,24 @@ describe("@layer focus contract", () => {
     const dropdown = read("src/components/Dropdown.tsx");
     expect(dropdown).not.toMatch(/outline:\s*open\s*\?[^:]*:\s*["']none["']/);
   });
+
+  it("focus.css defines focus-visible rules for ApiDetailPage tabs", () => {
+    const focusCss = read("src/styles/focus.css");
+    expect(focusCss).toMatch(/\.api-detail-tabs\s*\[role="tab"\]:focus-visible/);
+  });
+
+  it("focus.css defines focus-visible rules for ApiDetailPage breadcrumb links", () => {
+    const focusCss = read("src/styles/focus.css");
+    expect(focusCss).toMatch(/\.api-detail-page\s*\.breadcrumb\s*a:focus-visible/);
+  });
+
+  it("focus.css defines focus-visible rules for ApiDetailPage SubscribeButton", () => {
+    const focusCss = read("src/styles/focus.css");
+    expect(focusCss).toMatch(/\.api-detail-page\s*\.subscribe-button:focus-visible/);
+  });
+
+  it("focus.css defines focus-visible rules for ApiDetailPage hero Back button", () => {
+    const focusCss = read("src/styles/focus.css");
+    expect(focusCss).toMatch(/\.api-detail-hero\s*\.ghost-button:focus-visible/);
+  });
 });

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -132,6 +132,37 @@
     border-radius: 2px;
   }
 
+  /* ── ApiDetailPage: Tabs component buttons ──────────────────────────── */
+  /*
+   * The Tabs component renders role="tab" buttons that sit inside the
+   * sticky tab bar.  These buttons need a visible focus ring so keyboard
+   * users can see which tab is focused before activating it.
+   */
+  .api-detail-tabs [role="tab"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* ── ApiDetailPage: Breadcrumb links ──────────────────────────────────── */
+  .api-detail-page .breadcrumb a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* ── ApiDetailPage: SubscribeButton ───────────────────────────────────── */
+  .api-detail-page .subscribe-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  /* ── ApiDetailPage: Back button in hero ───────────────────────────────── */
+  .api-detail-hero .ghost-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
   /* ── ApiDetailPage: EndpointSaveButton dialog ──────────────────────────── */
   /*
    * The save-to-collection dialog contains its own buttons and inputs that


### PR DESCRIPTION
## Summary

Add visible focus-visible outlines on ApiDetailPage interactive elements for keyboard accessibility.

### Changes
- Added focus-visible rules for Tabs component buttons within ApiDetailPage
- Added focus-visible rules for Breadcrumb links in ApiDetailPage
- Added focus-visible rules for SubscribeButton
- Added focus-visible rules for Back button in hero section
- Updated focus-layer contract tests for new rules

Closes #571