### PR TITLE
fix: add aria-live region for ApiCard status changes

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -350,3 +350,85 @@ describe("ApiCard responsiveness", () => {
   });
 });
 
+describe("ApiCard — aria-live region", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinnedApisStore._reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a live region with correct ARIA attributes", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+    expect(liveRegion).toBeTruthy();
+    expect(liveRegion.getAttribute("role")).toBe("status");
+    expect(liveRegion.getAttribute("aria-live")).toBe("polite");
+    expect(liveRegion.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("announces when favorite is added", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+    expect(liveRegion.textContent).toBe("");
+
+    fireEvent.click(screen.getByLabelText("Add to favorites"));
+    expect(liveRegion.textContent).toBe("Added to favorites");
+  });
+
+  it("announces when favorite is removed", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+
+    fireEvent.click(screen.getByLabelText("Add to favorites"));
+    expect(liveRegion.textContent).toBe("Added to favorites");
+
+    fireEvent.click(screen.getByLabelText("Remove from favorites"));
+    expect(liveRegion.textContent).toBe("Removed from favorites");
+  });
+
+  it("announces pin to dashboard", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+
+    fireEvent.click(screen.getByLabelText(/Pin api-1 to dashboard/));
+    expect(liveRegion.textContent).toBe("Pinned api-1 to dashboard");
+  });
+
+  it("announces unpin from dashboard", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+
+    fireEvent.click(screen.getByLabelText(/Pin api-1 to dashboard/));
+    fireEvent.click(screen.getByLabelText(/Unpin api-1 from dashboard/));
+    expect(liveRegion.textContent).toBe("Unpinned api-1 from dashboard");
+  });
+
+  it("announces added to comparison", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+
+    fireEvent.click(screen.getByLabelText(/Add.*to comparison/i));
+    expect(liveRegion.textContent).toBe("Added Stellar Metering API to comparison");
+  });
+
+  it("announces removed from comparison", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+
+    fireEvent.click(screen.getByLabelText(/Add.*to comparison/i));
+    fireEvent.click(screen.getByLabelText(/Remove.*from comparison/i));
+    expect(liveRegion.textContent).toBe("Removed Stellar Metering API from comparison");
+  });
+
+  it("visually hides the live region while keeping it accessible", () => {
+    render(<ApiCard api={mockApi} />);
+    const liveRegion = screen.getByTestId("api-card-live-region");
+    expect(liveRegion.style.position).toBe("absolute");
+    expect(liveRegion.style.overflow).toBe("hidden");
+    expect(liveRegion.style.clip).toMatch(/rect/);
+  });
+});
+

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -119,9 +119,10 @@ interface FavoriteButtonProps {
   isFavorite: boolean;
   onToggle: (id: string) => void;
   prefersReducedMotion?: boolean;
+  onStatusChange?: (message: string) => void;
 }
 
-function FavoriteButton({ endpointId, isFavorite, onToggle, prefersReducedMotion = false }: FavoriteButtonProps) {
+function FavoriteButton({ endpointId, isFavorite, onToggle, prefersReducedMotion = false, onStatusChange }: FavoriteButtonProps) {
   const btnRef = useRef<HTMLButtonElement>(null);
 
   const handleMouseEnter = prefersReducedMotion
@@ -138,6 +139,7 @@ function FavoriteButton({ endpointId, isFavorite, onToggle, prefersReducedMotion
       onClick={(e) => {
         e.stopPropagation();
         onToggle(endpointId);
+        onStatusChange?.(!isFavorite ? "Added to favorites" : "Removed from favorites");
       }}
       style={{
         position: "absolute",
@@ -183,9 +185,10 @@ function FavoriteButton({ endpointId, isFavorite, onToggle, prefersReducedMotion
 interface BookmarkButtonProps {
   endpointId: string;
   prefersReducedMotion?: boolean;
+  onStatusChange?: (message: string) => void;
 }
 
-function BookmarkButton({ endpointId, prefersReducedMotion = false }: BookmarkButtonProps) {
+function BookmarkButton({ endpointId, prefersReducedMotion = false, onStatusChange }: BookmarkButtonProps) {
   const {
     collections,
     isEndpointSaved,
@@ -229,8 +232,10 @@ function BookmarkButton({ endpointId, prefersReducedMotion = false }: BookmarkBu
   const handleToggleCollection = (colId: string) => {
     if (savedIn.has(colId)) {
       removeEndpointFromCollection(colId, endpointId);
+      onStatusChange?.("Removed from collection");
     } else {
       addEndpointToCollection(colId, endpointId);
+      onStatusChange?.("Saved to collection");
     }
   };
 
@@ -246,9 +251,10 @@ function BookmarkButton({ endpointId, prefersReducedMotion = false }: BookmarkBu
     const trimmed = newName.trim();
     if (!trimmed) return;
     createCollectionWithEndpoint(trimmed, endpointId);
+    onStatusChange?.(`Created collection "${trimmed}" and saved endpoint`);
     setNewName("");
     setShowNew(false);
-  }, [newName, createCollectionWithEndpoint, endpointId]);
+  }, [newName, createCollectionWithEndpoint, endpointId, onStatusChange]);
 
   const handleNewKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
@@ -422,7 +428,7 @@ function BookmarkButton({ endpointId, prefersReducedMotion = false }: BookmarkBu
 // ─── Pin button ───────────────────────────────────────────────────────────────
 
 /** Quick-menu button that pins/unpins an API to the dashboard. */
-function PinButton({ apiId, prefersReducedMotion = false }: { apiId: string; prefersReducedMotion?: boolean }) {
+function PinButton({ apiId, prefersReducedMotion = false, onStatusChange }: { apiId: string; prefersReducedMotion?: boolean; onStatusChange?: (message: string) => void }) {
   const pinned = usePinnedApis();
   const isPinned = pinned.has(apiId);
 
@@ -431,6 +437,7 @@ function PinButton({ apiId, prefersReducedMotion = false }: { apiId: string; pre
       onClick={(e) => {
         e.stopPropagation();
         pinnedApisStore.toggle(apiId);
+        onStatusChange?.(!isPinned ? `Pinned ${apiId} to dashboard` : `Unpinned ${apiId} from dashboard`);
       }}
       style={{
         position: "absolute",
@@ -523,6 +530,9 @@ export default function ApiCard({
   const isMobile = useMediaQuery("(max-width: 768px)");
   const isDesktop = useMediaQuery("(min-width: 1024px)");
 
+  const [liveMessage, setLiveMessage] = useState("");
+  const announce = useCallback((msg: string) => setLiveMessage(msg), []);
+
   const pricePerCall = api.pricePerCall ?? api.pricePerRequest;
   const avgLatencyMs = api.avgLatencyMs;
   const uptimePercent = api.uptimePercent;
@@ -559,8 +569,10 @@ export default function ApiCard({
     e.stopPropagation();
     if (isCompared) {
       compareStore.removeApi(api.id);
+      announce(`Removed ${api.name} from comparison`);
     } else if (canCompare) {
       compareStore.addApi(api);
+      announce(`Added ${api.name} to comparison`);
     }
   };
 
@@ -662,16 +674,17 @@ export default function ApiCard({
     >
       {menuPos && <ContextMenu x={menuPos.x} y={menuPos.y} onClose={() => setMenuPos(null)} actions={contextActions} />}
       {/* Absolutely-positioned bookmark button in the top-right corner */}
-      <BookmarkButton endpointId={api.id} prefersReducedMotion={prefersReducedMotion} />
+      <BookmarkButton endpointId={api.id} prefersReducedMotion={prefersReducedMotion} onStatusChange={announce} />
 
       {/* Pin/unpin button — below bookmark, top-right */}
-      <PinButton apiId={api.id} prefersReducedMotion={prefersReducedMotion} />
+      <PinButton apiId={api.id} prefersReducedMotion={prefersReducedMotion} onStatusChange={announce} />
       
       <FavoriteButton
         endpointId={api.id}
         isFavorite={isFavorite(api.id)}
         onToggle={toggleFavorite}
         prefersReducedMotion={prefersReducedMotion}
+        onStatusChange={announce}
       />
 
        {/* Compare button - absolutely positioned, top-left */}
@@ -848,6 +861,16 @@ export default function ApiCard({
       </div>
 
       <KbdHint shortcuts={CARD_SHORTCUTS} />
+
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="api-card-live-region"
+        style={{ position: "absolute", width: 1, height: 1, padding: 0, margin: -1, overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap", border: 0 }}
+      >
+        {liveMessage}
+      </div>
     </article>
   );
 }


### PR DESCRIPTION
## Summary

Adds a visually hidden `aria-live="polite"` region to `ApiCard` that announces status changes to screen readers, making favorites, pin, bookmark/collection, and compare toggles accessible to assistive technologies.

Closes #408

## What changed

**`src/components/ApiCard.tsx`**
- Added a visually hidden `<div role="status" aria-live="polite" aria-atomic="true">` inside each `<article>` that updates on every status action.
- Added an `onStatusChange` callback prop to `FavoriteButton`, `BookmarkButton`, and `PinButton`.
- Wired the compare button click handler to announce additions/removals.
- Announcements:
  | Action | Message |
  |--------|---------|
  | Toggle favorite | "Added to favorites" / "Removed from favorites" |
  | Pin / unpin | "Pinned {id} to dashboard" / "Unpinned {id} from dashboard" |
  | Save to collection | "Saved to collection" / "Removed from collection" |
  | Create collection | "Created collection "{name}" and saved endpoint" |
  | Compare toggle | "Added {name} to comparison" / "Removed {name} from comparison" |

**`src/components/ApiCard.test.tsx`**
- New `describe("ApiCard — aria-live region")` block with 7 tests:
  1. Renders live region with correct ARIA attributes (`role`, `aria-live`, `aria-atomic`)
  2. Announces favorite added
  3. Announces favorite removed
  4. Announces pin to dashboard
  5. Announces unpin from dashboard
  6. Announces added to comparison
  7. Confirms visual hiding (clip/overflow/position)

## Why

Screen reader users had no audible feedback when toggling favorite, pin, bookmark, or compare states on API cards. The `aria-live` polite region announces each change non-intrusively, following WAI-ARIA best practices.

## Testing

```bash
npm install
npx vitest run src/components/ApiCard.test.tsx --reporter=verbose
npx vitest run --coverage   # full suite
Checklist
- Implementation matches issue description
- Tests added and passing
- Adheres to repo lint/code style
- No secrets or sensitive data exposed
- Efficient and easy to review