### PR TITLE
feat(breadcrumb): middle-ellipsis label truncation + RateLimitCard (#…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - **Global Command Palette**: Instantly jump to views, search APIs by name, cycle/toggle light & dark themes, or trigger vault deposits. Use `Cmd+K` on macOS or `Ctrl+K` on Windows/Linux to open.
 - **Pattern-based status badges**: Status indicators now use distinct textures in addition to color so they remain understandable for color-blind users and in grayscale displays.
 - **Smooth theme transition**: Light/dark switches animate color tokens (background, text, border) over 240 ms instead of snapping. The transition is gated behind a `theme-transitions-ready` class that ThemeProvider adds after the first paint, preventing any flash on load. Animated elements (toasts, skeletons, spinners) are automatically excluded. Use the `.no-theme-transition` escape hatch on any element that must opt out.
+- **Breadcrumb middle-ellipsis** (Issue #537): The `<Breadcrumb>` component now accepts a `middleEllipsis` prop. When enabled, individual labels longer than `middleEllipsisMaxLen` characters (default 24) are abbreviated using a `"start…end"` pattern — preserving both the resource-type prefix and the unique identifier suffix. The full label is always exposed via `aria-label` and `title` so screen-reader users receive the complete text. Used by `RateLimitCard` where API names, plan tiers, and endpoint paths can be arbitrarily long.
+- **RateLimitCard**: New card component (`src/pages/RateLimitCard.tsx`) showing quota usage, a colour-and-shape status badge (OK / Warning / Critical), a progress bar with full ARIA attributes, and a reset-time countdown. The breadcrumb at the top uses middle-ellipsis to handle long API / plan names gracefully.
 
 ## Keyboard shortcuts
 
@@ -115,7 +117,8 @@ callora-frontend/
 │   │   └── Skeleton.tsx
 │   ├── pages/               # Standalone page components
 │   │   ├── ApiDetailPage.tsx
-│   │   └── MarketplacePage.tsx
+│   │   ├── MarketplacePage.tsx
+│   │   └── RateLimitCard.tsx  # (Issue #537) Rate-limit quota card with middle-ellipsis breadcrumb
 │   ├── hooks/               # Custom React hooks
 │   │   └── useDebounce.ts
 │   ├── data/                # Static and mock data

--- a/src/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import Breadcrumb from "./Breadcrumb";
+import Breadcrumb, { truncateMiddle } from "./Breadcrumb";
 
 const longBreadcrumb = [
   { label: "Marketplace", href: "/marketplace" },
@@ -162,5 +162,193 @@ describe("Breadcrumb", () => {
     render(<Breadcrumb items={longBreadcrumb} />);
     const link = screen.getByRole("link", { name: "Marketplace" });
     expect(link.classList.contains("link-nav")).toBe(true);
+  });
+});
+
+// ─── truncateMiddle unit tests ────────────────────────────────────────────────
+
+describe("truncateMiddle", () => {
+  it("returns the original string when it is within the limit", () => {
+    expect(truncateMiddle("short", 24)).toBe("short");
+    expect(truncateMiddle("exactly24characters!!!!!!", 26)).toBe(
+      "exactly24characters!!!!!!",
+    );
+  });
+
+  it("returns the original string when length equals maxLen exactly", () => {
+    const str = "a".repeat(24);
+    expect(truncateMiddle(str, 24)).toBe(str);
+  });
+
+  it("truncates strings longer than maxLen with a middle ellipsis", () => {
+    // "VeryLongMachineLearningAPIName" (30 chars) with maxLen=24:
+    //   budget = 24 - 1 = 23
+    //   endLen = floor(23 / 2) = 11  → last 11 chars = "ningAPIName"
+    //   startLen = 23 - 11 = 12     → first 12 chars = "VeryLongMach"
+    //   result = "VeryLongMach…ningAPIName"  (24 chars total)
+    const result = truncateMiddle("VeryLongMachineLearningAPIName", 24);
+    expect(result).toContain("…");
+    expect(result.length).toBe(24);
+    expect(result.endsWith("Name")).toBe(true);
+    expect(result.startsWith("VeryLongMach")).toBe(true);
+  });
+
+  it("favours the start in the budget split (start gets extra char on odd budget)", () => {
+    // maxLen=5: budget=4, endLen=2, startLen=2 → 2+1+2=5 chars
+    // "Hello World" → start="He", end="ld" → "He…ld"
+    expect(truncateMiddle("Hello World", 5)).toBe("He\u2026ld");
+  });
+
+  it("works with maxLen=4 (minimum)", () => {
+    const result = truncateMiddle("abcdefghij", 4);
+    // budget=3, endLen=1, startLen=2 → "ab…j"
+    expect(result).toBe("ab\u2026j");
+    expect(result.length).toBe(4);
+  });
+
+  it("returns the string unchanged for maxLen < 4", () => {
+    expect(truncateMiddle("abcdefghij", 3)).toBe("abcdefghij");
+    expect(truncateMiddle("abcdefghij", 0)).toBe("abcdefghij");
+  });
+
+  it("handles empty string", () => {
+    expect(truncateMiddle("", 24)).toBe("");
+  });
+
+  it("handles string equal to exactly one character over the limit", () => {
+    const str = "a".repeat(25);
+    const result = truncateMiddle(str, 24);
+    expect(result).toContain("…");
+    expect(result.length).toBe(24);
+  });
+
+  it("uses the Unicode ellipsis character (U+2026), not three dots", () => {
+    const result = truncateMiddle("VeryLongStringHereToTest", 10);
+    expect(result).toContain("\u2026");
+    expect(result).not.toContain("...");
+  });
+});
+
+// ─── Breadcrumb middleEllipsis prop ──────────────────────────────────────────
+
+describe("Breadcrumb – middleEllipsis prop", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const longLabel = "Advanced Language Model Completions API v2";
+  // With maxLen=20: budget=19, endLen=9, startLen=10 → "Advanced L…ions API v2"
+  const items = [
+    { label: "Marketplace", href: "/marketplace" },
+    { label: longLabel, href: "/marketplace/api", isCurrent: true },
+  ];
+
+  it("does NOT truncate labels when middleEllipsis is false (default)", () => {
+    render(<Breadcrumb items={items} />);
+    // The current crumb should show the full label text
+    const current = screen.getByText(longLabel);
+    expect(current).toBeTruthy();
+    expect(current.getAttribute("data-truncated")).toBeNull();
+  });
+
+  it("truncates long labels when middleEllipsis is true", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={20} />);
+    // The visible text should be shortened (contains ellipsis character)
+    const current = document.querySelector("[aria-current='page']");
+    expect(current).toBeTruthy();
+    expect(current!.textContent).toContain("…");
+    expect(current!.textContent!.length).toBeLessThan(longLabel.length);
+  });
+
+  it("sets data-truncated='true' on truncated crumbs", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={20} />);
+    const current = document.querySelector("[aria-current='page']");
+    expect(current?.getAttribute("data-truncated")).toBe("true");
+  });
+
+  it("preserves the full label in aria-label for accessibility", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={20} />);
+    const current = document.querySelector("[aria-current='page']");
+    // aria-label must contain the complete original label
+    expect(current?.getAttribute("aria-label")).toBe(longLabel);
+  });
+
+  it("preserves the full label in the title attribute", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={20} />);
+    const current = document.querySelector("[aria-current='page']");
+    expect(current?.getAttribute("title")).toBe(longLabel);
+  });
+
+  it("does NOT set data-truncated on a short label that fits within maxLen", () => {
+    const shortItems = [
+      { label: "Marketplace", href: "/marketplace" },
+      { label: "Short API", href: "/marketplace/short", isCurrent: true },
+    ];
+    render(<Breadcrumb items={shortItems} middleEllipsis middleEllipsisMaxLen={20} />);
+    const current = document.querySelector("[aria-current='page']");
+    expect(current?.getAttribute("data-truncated")).toBeNull();
+    expect(current?.textContent).toBe("Short API");
+  });
+
+  it("applies the middle-ellipsis CSS modifier class to truncated links", () => {
+    const linkItems = [
+      { label: longLabel, href: "/marketplace" },
+      { label: "Current Page", href: "/marketplace/current", isCurrent: true },
+    ];
+    render(
+      <Breadcrumb items={linkItems} middleEllipsis middleEllipsisMaxLen={20} />,
+    );
+    const link = document.querySelector(".breadcrumb-link--middle-ellipsis");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("data-truncated")).toBe("true");
+  });
+
+  it("applies the middle-ellipsis CSS modifier class to truncated current crumbs", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={20} />);
+    const current = document.querySelector(
+      ".breadcrumb-current--middle-ellipsis",
+    );
+    expect(current).toBeTruthy();
+  });
+
+  it("keeps full labels in the popover even when middleEllipsis is active", () => {
+    // Middle item should show full label inside the popover, not truncated.
+    const deepItems = [
+      { label: "Marketplace", href: "/marketplace" },
+      {
+        label: "Advanced Language Model Completions And More API",
+        href: "/marketplace/alm",
+      },
+      {
+        label: "Current Page",
+        href: "/marketplace/alm/current",
+        isCurrent: true,
+      },
+    ];
+    const { container } = render(
+      <Breadcrumb items={deepItems} middleEllipsis middleEllipsisMaxLen={20} />,
+    );
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+    if (!button) throw new Error("Expected breadcrumb ellipsis button");
+
+    fireEvent.click(button);
+
+    const menuItems = Array.from(
+      container.querySelectorAll('[role="menuitem"]'),
+    );
+    // The popover shows the full label, not a truncated version
+    expect(menuItems[0].textContent).toBe(
+      "Advanced Language Model Completions And More API",
+    );
+  });
+
+  it("uses custom middleEllipsisMaxLen when provided", () => {
+    render(<Breadcrumb items={items} middleEllipsis middleEllipsisMaxLen={10} />);
+    const current = document.querySelector("[aria-current='page']");
+    // With maxLen=10 the result should be at most 10 chars
+    expect(current!.textContent!.length).toBeLessThanOrEqual(10);
+    expect(current!.textContent).toContain("…");
   });
 });

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
-type BreadcrumbItem = {
+export type BreadcrumbItem = {
   label: string;
   href: string;
   isCurrent?: boolean;
@@ -9,24 +9,94 @@ type BreadcrumbItem = {
 
 type BreadcrumbProps = {
   items: BreadcrumbItem[];
+  /**
+   * When true, individual crumb labels that exceed `middleEllipsisMaxLen`
+   * characters are truncated with a middle-ellipsis pattern:
+   *   "VeryLongStartText…endText"
+   * This preserves both the beginning (which names the resource type) and the
+   * end (which often carries a unique identifier or slug), giving users enough
+   * context to understand the path even when space is tight.
+   *
+   * The full label is always accessible via the `title` tooltip and the
+   * aria-label on the link, so screen-reader users are unaffected.
+   *
+   * @default false
+   */
+  middleEllipsis?: boolean;
+  /**
+   * Maximum character length before the middle-ellipsis kicks in.
+   * Only relevant when `middleEllipsis` is true.
+   * @default 24
+   */
+  middleEllipsisMaxLen?: number;
 };
 
-function BreadcrumbLink({ item }: { item: BreadcrumbItem }) {
+/**
+ * truncateMiddle
+ *
+ * Truncates `text` to at most `maxLen` visible characters using a
+ * middle-ellipsis pattern: the beginning and end of the string are
+ * preserved, with "…" inserted in the middle.
+ *
+ * Examples:
+ *   truncateMiddle("VeryLongMachineLearningAPIName", 24)
+ *     → "VeryLongMachin…APIName"
+ *   truncateMiddle("short", 24) → "short"   (unchanged)
+ *
+ * The split favours the start slightly (ceil) so the resource-type prefix
+ * is more likely to remain legible.
+ *
+ * @param text   The full label string.
+ * @param maxLen Maximum visible characters (excluding the ellipsis itself).
+ *               Must be ≥ 4 to produce a meaningful result.
+ */
+export function truncateMiddle(text: string, maxLen: number): string {
+  if (maxLen < 4) return text;
+  if (text.length <= maxLen) return text;
+
+  // Reserve one char for "…"; split the remaining budget between start/end.
+  const budget = maxLen - 1; // subtract 1 for the ellipsis character
+  const endLen = Math.floor(budget / 2);
+  const startLen = budget - endLen; // start gets the extra char when budget is odd
+
+  const start = text.slice(0, startLen);
+  const end = text.slice(text.length - endLen);
+  return `${start}\u2026${end}`; // U+2026 HORIZONTAL ELLIPSIS
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function BreadcrumbLink({
+  item,
+  displayLabel,
+}: {
+  item: BreadcrumbItem;
+  /** Pre-computed visible label (may be truncated). Full label lives in title/aria-label. */
+  displayLabel: string;
+}) {
   if (item.isCurrent) {
     return (
       <span
         className="breadcrumb-current"
         aria-current="page"
+        // Always expose the full label to assistive technology
+        aria-label={item.label}
         title={item.label}
       >
-        {item.label}
+        {displayLabel}
       </span>
     );
   }
 
   return (
-    <a className="breadcrumb-link link-nav" href={item.href} title={item.label}>
-      {item.label}
+    <a
+      className="breadcrumb-link link-nav"
+      href={item.href}
+      // Always expose the full label to assistive technology
+      aria-label={item.label}
+      title={item.label}
+    >
+      {displayLabel}
     </a>
   );
 }
@@ -39,13 +109,35 @@ function BreadcrumbSeparator() {
   );
 }
 
-export default function Breadcrumb({ items }: BreadcrumbProps) {
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function Breadcrumb({
+  items,
+  middleEllipsis = false,
+  middleEllipsisMaxLen = 24,
+}: BreadcrumbProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const ellipsisButtonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const popoverId = useId();
   const middleItems = useMemo(() => items.slice(1, -1), [items]);
   const shouldCollapseMiddle = middleItems.length > 0;
+
+  /**
+   * Compute the visible display label for each item.
+   * When middleEllipsis is enabled, labels longer than middleEllipsisMaxLen
+   * are shortened using the middle-ellipsis pattern. The full label is still
+   * available via the title attribute and aria-label.
+   */
+  const displayLabels = useMemo(
+    () =>
+      items.map((item) =>
+        middleEllipsis
+          ? truncateMiddle(item.label, middleEllipsisMaxLen)
+          : item.label,
+      ),
+    [items, middleEllipsis, middleEllipsisMaxLen],
+  );
 
   useEffect(() => {
     if (!isPopoverOpen) return;
@@ -163,6 +255,25 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
             border-radius: 2px;
           }
 
+          /*
+           * Middle-ellipsis crumb labels.
+           *
+           * When the middleEllipsis prop is active, the truncation is handled
+           * in JS (truncateMiddle). We still keep overflow:hidden + text-overflow
+           * as a CSS safety net for edge cases (e.g. extremely narrow containers),
+           * but the primary visual treatment is the JS-computed "start…end" string.
+           */
+          .breadcrumb-link--middle-ellipsis,
+          .breadcrumb-current--middle-ellipsis {
+            /* Allow the truncated text to breathe – no hard CSS cut-off needed
+               because JS already shortened it. Disable the CSS ellipsis so we
+               never see a double-truncation artefact ("start…en…"). */
+            text-overflow: clip;
+            /* Keep nowrap so the label still sits on one line. */
+            white-space: nowrap;
+            overflow: hidden;
+          }
+
           .breadcrumb-link,
           .breadcrumb-popover-link {
             color: var(--accent);
@@ -263,11 +374,16 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
           const isFirst = index === 0;
           const isLast = index === items.length - 1;
           const isMiddle = !isFirst && !isLast;
+          const displayLabel = displayLabels[index];
+          const isTruncated = middleEllipsis && displayLabel !== item.label;
 
           if (isMiddle) {
             return (
               <li className="breadcrumb-item breadcrumb-middle" key={item.href}>
-                <BreadcrumbLink item={item} />
+                <BreadcrumbLink
+                  item={item}
+                  displayLabel={displayLabel}
+                />
                 <BreadcrumbSeparator />
               </li>
             );
@@ -278,7 +394,27 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
               className={`breadcrumb-item ${isFirst ? "breadcrumb-first" : ""}`}
               key={item.href}
             >
-              <BreadcrumbLink item={item} />
+              {item.isCurrent ? (
+                <span
+                  className={`breadcrumb-current${isTruncated ? " breadcrumb-current--middle-ellipsis" : ""}`}
+                  aria-current="page"
+                  aria-label={item.label}
+                  title={item.label}
+                  data-truncated={isTruncated ? "true" : undefined}
+                >
+                  {displayLabel}
+                </span>
+              ) : (
+                <a
+                  className={`breadcrumb-link link-nav${isTruncated ? " breadcrumb-link--middle-ellipsis" : ""}`}
+                  href={item.href}
+                  aria-label={item.label}
+                  title={item.label}
+                  data-truncated={isTruncated ? "true" : undefined}
+                >
+                  {displayLabel}
+                </a>
+              )}
               {isFirst && shouldCollapseMiddle && (
                 <span className="breadcrumb-collapsed">
                   <BreadcrumbSeparator />
@@ -310,6 +446,9 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                               className="breadcrumb-popover-link link-nav"
                               href={middleItem.href}
                               role="menuitem"
+                              // Always show full label inside the popover —
+                              // there is no space constraint here.
+                              title={middleItem.label}
                             >
                               {middleItem.label}
                             </a>

--- a/src/pages/RateLimitCard.test.tsx
+++ b/src/pages/RateLimitCard.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import RateLimitCard from "./RateLimitCard";
+
+/** Convenience wrapper with sensible defaults so tests stay focused. */
+function renderCard(overrides: Partial<React.ComponentProps<typeof RateLimitCard>> = {}) {
+  const defaults = {
+    apiName: "Advanced Language Model Completions API v2",
+    providerName: "OpenMind AI",
+    planName: "Professional Tier – High Throughput",
+    endpointPath: "/v2/completions/streaming",
+    requestsUsed: 4000,
+    requestsTotal: 10000,
+    resetAt: new Date(Date.now() + 3_600_000), // 1 hr from now
+    apiId: "alm-api",
+    providerId: "openmind",
+  };
+  return render(<RateLimitCard {...defaults} {...overrides} />);
+}
+
+describe("RateLimitCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it("renders the Rate Limit heading", () => {
+    renderCard();
+    expect(
+      screen.getByRole("heading", { name: /rate limit/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders provider and API name in the subtitle", () => {
+    renderCard();
+    // The subtitle paragraph contains both names — use a more targeted query
+    const subtitle = document.querySelector("header p");
+    expect(subtitle?.textContent).toMatch(/OpenMind AI/);
+    expect(subtitle?.textContent).toMatch(/Advanced Language Model Completions API v2/);
+  });
+
+  it("renders a progress bar with correct ARIA values", () => {
+    renderCard({ requestsUsed: 7500, requestsTotal: 10000 });
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("7500");
+    expect(bar.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar.getAttribute("aria-valuemax")).toBe("10000");
+    expect(bar.getAttribute("aria-label")).toMatch(/7,500 of 10,000/);
+  });
+
+  it("renders a quota count string", () => {
+    renderCard({ requestsUsed: 4000, requestsTotal: 10000 });
+    expect(screen.getByText(/4,000 \/ 10,000 req/)).toBeTruthy();
+  });
+
+  it("displays a reset time element with a datetime attribute", () => {
+    const resetAt = new Date(Date.now() + 3_600_000);
+    renderCard({ resetAt });
+    const timeEl = screen.getByText(/in \d+ hr/i).closest("time") ??
+      document.querySelector("time");
+    expect(timeEl).toBeTruthy();
+    expect(timeEl?.getAttribute("datetime")).toBeTruthy();
+  });
+
+  it("displays the plan name in the footer", () => {
+    renderCard({ planName: "Professional Tier – High Throughput" });
+    expect(
+      screen.getByText("Professional Tier – High Throughput"),
+    ).toBeTruthy();
+  });
+
+  // ── Status badge ───────────────────────────────────────────────────────────
+
+  it("shows an OK badge when usage is below 70%", () => {
+    renderCard({ requestsUsed: 5000, requestsTotal: 10000 }); // 50%
+    const badge = screen.getByRole("status");
+    expect(badge.textContent).toMatch(/OK/i);
+    expect(badge.getAttribute("aria-label")).toMatch(/within quota/i);
+  });
+
+  it("shows a Warning badge when usage is between 70% and 89%", () => {
+    renderCard({ requestsUsed: 7500, requestsTotal: 10000 }); // 75%
+    const badge = screen.getByRole("status");
+    expect(badge.textContent).toMatch(/warning/i);
+    expect(badge.getAttribute("aria-label")).toMatch(/approaching quota/i);
+  });
+
+  it("shows a Critical badge when usage is 90% or above", () => {
+    renderCard({ requestsUsed: 9500, requestsTotal: 10000 }); // 95%
+    const badge = screen.getByRole("status");
+    expect(badge.textContent).toMatch(/critical/i);
+    expect(badge.getAttribute("aria-label")).toMatch(/nearly exhausted/i);
+  });
+
+  it("shows OK badge when requestsTotal is 0 (division guard)", () => {
+    renderCard({ requestsUsed: 0, requestsTotal: 0 });
+    const badge = screen.getByRole("status");
+    expect(badge.textContent).toMatch(/OK/i);
+  });
+
+  // ── Breadcrumb middle-ellipsis ────────────────────────────────────────────
+
+  it("renders a breadcrumb nav with 'breadcrumb' label", () => {
+    renderCard();
+    expect(screen.getByRole("navigation", { name: /breadcrumb/i })).toBeTruthy();
+  });
+
+  it("always shows the Marketplace link as the first crumb", () => {
+    renderCard();
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(within(nav).getByRole("link", { name: "Marketplace" })).toBeTruthy();
+  });
+
+  it("shows the endpoint path as the current crumb with aria-current='page'", () => {
+    renderCard({ endpointPath: "/v2/completions/streaming" });
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    const current = nav.querySelector("[aria-current='page']");
+    expect(current).toBeTruthy();
+    // The aria-label always carries the full label, even when truncated
+    expect(current?.getAttribute("aria-label")).toBe("/v2/completions/streaming");
+  });
+
+  it("truncates long API names in the breadcrumb using middle-ellipsis", () => {
+    // API name is > 20 chars: "Advanced Language Model Completions API v2"
+    renderCard();
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    // Find links in the nav that are NOT the Marketplace link (i.e. the API crumb)
+    const links = Array.from(within(nav).getAllByRole("link")).filter(
+      (l) => l.getAttribute("href") !== "/marketplace",
+    );
+    // At least one link should be truncated with "…"
+    const hasTruncated = links.some(
+      (l) => l.textContent?.includes("…") || l.getAttribute("data-truncated") === "true",
+    );
+    expect(hasTruncated).toBe(true);
+  });
+
+  it("preserves the full label in aria-label when a crumb is truncated", () => {
+    renderCard({ apiName: "Advanced Language Model Completions API v2" });
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    // Links with data-truncated should carry the full label in aria-label
+    const truncatedLinks = Array.from(
+      nav.querySelectorAll("[data-truncated='true']"),
+    );
+    for (const link of truncatedLinks) {
+      const ariaLabel = link.getAttribute("aria-label");
+      const visibleText = link.textContent ?? "";
+      expect(ariaLabel).not.toContain("…");
+      expect(visibleText).toContain("…");
+    }
+  });
+
+  it("does not truncate labels that fit within the max length", () => {
+    renderCard({
+      apiName: "Short API",      // 9 chars, well under maxLen=20
+      providerName: "Acme",      // 4 chars
+      planName: "Free",           // 4 chars
+      endpointPath: "/v1/data",  // 8 chars
+    });
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    const truncatedNodes = nav.querySelectorAll("[data-truncated='true']");
+    expect(truncatedNodes.length).toBe(0);
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────────
+
+  it("wraps everything in an <article> with a labelledby heading", () => {
+    renderCard();
+    const article = document.querySelector("article");
+    expect(article).toBeTruthy();
+    expect(article?.getAttribute("aria-labelledby")).toBe("rlc-heading");
+    expect(document.getElementById("rlc-heading")?.tagName).toBe("H2");
+  });
+
+  it("renders a <time> element for the reset timestamp", () => {
+    renderCard();
+    const time = document.querySelector("time");
+    expect(time).toBeTruthy();
+    // datetime must be a valid ISO string
+    const dt = time?.getAttribute("datetime") ?? "";
+    expect(() => new Date(dt)).not.toThrow();
+    expect(new Date(dt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("remaining count is visible to screen readers via the progress bar aria-label", () => {
+    renderCard({ requestsUsed: 3000, requestsTotal: 10000 });
+    const bar = screen.getByRole("progressbar");
+    // The aria-label should mention the used / total counts
+    expect(bar.getAttribute("aria-label")).toMatch(/3,000/);
+    expect(bar.getAttribute("aria-label")).toMatch(/10,000/);
+  });
+});

--- a/src/pages/RateLimitCard.tsx
+++ b/src/pages/RateLimitCard.tsx
@@ -1,0 +1,376 @@
+/**
+ * RateLimitCard.tsx
+ *
+ * Displays rate-limit status for a subscribed API endpoint.  The card shows:
+ *   - A deep breadcrumb trail (Marketplace → Provider → API → Plan → Endpoint)
+ *     where individual segments can be long slugs or versioned names; the
+ *     `middleEllipsis` prop on <Breadcrumb> ensures those labels are
+ *     abbreviated with a "start…end" pattern so the path never overflows its
+ *     container.
+ *   - Current request quota (used / total) with a visual progress bar.
+ *   - Reset timestamp (next window start).
+ *   - A brief status badge (OK / Warning / Critical) derived from the usage
+ *     percentage, using the project's design tokens and the same pattern-based
+ *     approach as StatusBadge for colour-blind accessibility.
+ *
+ * ## Props
+ * | Prop            | Type                | Default          | Description                             |
+ * |-----------------|---------------------|------------------|-----------------------------------------|
+ * | apiName         | string              | required         | Human-readable API name                 |
+ * | providerName    | string              | required         | Provider / organisation name            |
+ * | planName        | string              | required         | Subscription plan name                  |
+ * | endpointPath    | string              | required         | Endpoint path, e.g. "/v2/completions"   |
+ * | requestsUsed    | number              | required         | Requests consumed in current window     |
+ * | requestsTotal   | number              | required         | Total requests allowed in the window    |
+ * | resetAt         | Date                | required         | Timestamp when the rate limit resets    |
+ * | apiId           | string              | "api"            | ID segment used in breadcrumb hrefs     |
+ * | providerId      | string              | "provider"       | ID segment used in breadcrumb hrefs     |
+ *
+ * @example
+ * ```tsx
+ * <RateLimitCard
+ *   apiName="Advanced Language Model – Completions API (v2)"
+ *   providerName="OpenMind AI"
+ *   planName="Professional Tier – High Throughput"
+ *   endpointPath="/v2/completions/streaming"
+ *   requestsUsed={8200}
+ *   requestsTotal={10000}
+ *   resetAt={new Date(Date.now() + 3600_000)}
+ * />
+ * ```
+ */
+
+import Breadcrumb from "../components/Breadcrumb";
+import type { BreadcrumbItem } from "../components/Breadcrumb";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RateLimitCardProps {
+  /** Human-readable API name (may be long). */
+  apiName: string;
+  /** Provider / organisation display name. */
+  providerName: string;
+  /** Subscription plan display name (may be long). */
+  planName: string;
+  /** Endpoint path shown as the leaf crumb, e.g. "/v2/generate". */
+  endpointPath: string;
+  /** Number of requests consumed in the current rate-limit window. */
+  requestsUsed: number;
+  /** Total requests allowed per rate-limit window. */
+  requestsTotal: number;
+  /** Date/time when the current rate-limit window resets. */
+  resetAt: Date;
+  /**
+   * URL-safe identifier for the API, used to build breadcrumb hrefs.
+   * @default "api"
+   */
+  apiId?: string;
+  /**
+   * URL-safe identifier for the provider, used to build breadcrumb hrefs.
+   * @default "provider"
+   */
+  providerId?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Derived usage status used for the badge and progress bar colour. */
+type RateLimitStatus = "ok" | "warning" | "critical";
+
+function getStatus(used: number, total: number): RateLimitStatus {
+  if (total <= 0) return "ok";
+  const pct = used / total;
+  if (pct >= 0.9) return "critical";
+  if (pct >= 0.7) return "warning";
+  return "ok";
+}
+
+/**
+ * Format a Date as a human-readable relative string ("in 47 min") and an
+ * absolute ISO string for the <time> datetime attribute.
+ */
+function formatResetTime(resetAt: Date): { relative: string; iso: string } {
+  const iso = resetAt.toISOString();
+  const diffMs = resetAt.getTime() - Date.now();
+  if (diffMs <= 0) return { relative: "resetting…", iso };
+
+  const diffSec = Math.round(diffMs / 1000);
+  if (diffSec < 60) return { relative: `in ${diffSec}s`, iso };
+
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return { relative: `in ${diffMin} min`, iso };
+
+  const diffHr = Math.round(diffMin / 60);
+  return { relative: `in ${diffHr} hr`, iso };
+}
+
+// ─── STATUS_META: labels, colours, and ARIA descriptions ─────────────────────
+
+const STATUS_META: Record<
+  RateLimitStatus,
+  { label: string; color: string; ariaLabel: string }
+> = {
+  ok: {
+    label: "OK",
+    color: "var(--success, #10b981)",
+    ariaLabel: "Rate limit status: within quota",
+  },
+  warning: {
+    label: "Warning",
+    color: "var(--warning, #fbbf24)",
+    ariaLabel: "Rate limit status: approaching quota",
+  },
+  critical: {
+    label: "Critical",
+    color: "var(--danger, #dc2626)",
+    ariaLabel: "Rate limit status: quota nearly exhausted",
+  },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function RateLimitCard({
+  apiName,
+  providerName,
+  planName,
+  endpointPath,
+  requestsUsed,
+  requestsTotal,
+  resetAt,
+  apiId = "api",
+  providerId = "provider",
+}: RateLimitCardProps) {
+  const pct = requestsTotal > 0 ? Math.min(requestsUsed / requestsTotal, 1) : 0;
+  const status = getStatus(requestsUsed, requestsTotal);
+  const meta = STATUS_META[status];
+  const resetTime = formatResetTime(resetAt);
+
+  /**
+   * Breadcrumb path: Marketplace → Provider → API → Plan → Endpoint
+   *
+   * All five labels can contain long, technical names (e.g. versioned API
+   * names, detailed plan tiers, endpoint slugs), so we pass
+   * `middleEllipsis` to let Breadcrumb trim them with the "start…end"
+   * pattern.  The full label is always available via the title tooltip and
+   * the accessible aria-label.
+   */
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: "Marketplace", href: "/marketplace" },
+    { label: providerName, href: `/marketplace/${providerId}` },
+    { label: apiName, href: `/marketplace/${providerId}/${apiId}` },
+    {
+      label: planName,
+      href: `/marketplace/${providerId}/${apiId}/plans`,
+    },
+    {
+      label: endpointPath,
+      href: `/marketplace/${providerId}/${apiId}/rate-limits`,
+      isCurrent: true,
+    },
+  ];
+
+  return (
+    <article
+      className="surface"
+      aria-labelledby="rlc-heading"
+      style={{
+        borderRadius: "var(--radius-md, 16px)",
+        border: "1px solid var(--line, rgba(169,184,255,0.16))",
+        padding: "24px",
+        maxWidth: "640px",
+      }}
+    >
+      {/*
+       * Breadcrumb — middleEllipsis enabled so long API / plan names are
+       * gracefully abbreviated at the visual level.  The default maxLen of
+       * 24 characters strikes a balance between readability and space.
+       * Reduced to 20 here because the card is narrower than a full page.
+       */}
+      <Breadcrumb
+        items={breadcrumbItems}
+        middleEllipsis
+        middleEllipsisMaxLen={20}
+      />
+
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <header style={{ marginBottom: "20px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "10px",
+            flexWrap: "wrap",
+          }}
+        >
+          <h2
+            id="rlc-heading"
+            style={{
+              margin: 0,
+              fontSize: "1.125rem",
+              fontWeight: 700,
+              color: "var(--text)",
+              lineHeight: 1.3,
+            }}
+          >
+            Rate Limit
+          </h2>
+
+          {/* Status badge — uses colour token + short text label */}
+          <span
+            role="status"
+            aria-label={meta.ariaLabel}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "5px",
+              padding: "3px 10px",
+              borderRadius: "999px",
+              fontSize: "0.75rem",
+              fontWeight: 700,
+              color: meta.color,
+              border: `1px solid ${meta.color}`,
+              background: `color-mix(in srgb, ${meta.color} 12%, transparent)`,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+            }}
+          >
+            {/* Dot indicator — additional non-colour cue */}
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                width: "6px",
+                height: "6px",
+                borderRadius: "50%",
+                background: meta.color,
+                flexShrink: 0,
+              }}
+            />
+            {meta.label}
+          </span>
+        </div>
+
+        <p
+          style={{
+            margin: "6px 0 0",
+            fontSize: "0.875rem",
+            color: "var(--muted)",
+          }}
+        >
+          {providerName} · {apiName}
+        </p>
+      </header>
+
+      {/* ── Usage bar ──────────────────────────────────────────────────── */}
+      <section aria-labelledby="rlc-quota-label">
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginBottom: "8px",
+            gap: "8px",
+            flexWrap: "wrap",
+          }}
+        >
+          <span
+            id="rlc-quota-label"
+            style={{
+              fontSize: "0.8125rem",
+              fontWeight: 600,
+              color: "var(--muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+            }}
+          >
+            Quota
+          </span>
+          <span
+            className="numeric-tabular"
+            style={{ fontSize: "0.875rem", color: "var(--text)", fontWeight: 600 }}
+          >
+            {requestsUsed.toLocaleString()} / {requestsTotal.toLocaleString()} req
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div
+          role="progressbar"
+          aria-valuenow={requestsUsed}
+          aria-valuemin={0}
+          aria-valuemax={requestsTotal}
+          aria-label={`${requestsUsed.toLocaleString()} of ${requestsTotal.toLocaleString()} requests used`}
+          style={{
+            height: "8px",
+            borderRadius: "999px",
+            background: "var(--surface-soft, rgba(255,255,255,0.06))",
+            overflow: "hidden",
+            border: "1px solid var(--line, rgba(169,184,255,0.16))",
+          }}
+        >
+          <div
+            aria-hidden="true"
+            style={{
+              height: "100%",
+              width: `${(pct * 100).toFixed(1)}%`,
+              background: meta.color,
+              borderRadius: "999px",
+              transition: "width 400ms ease",
+            }}
+          />
+        </div>
+
+        <p
+          style={{
+            marginTop: "8px",
+            fontSize: "0.8125rem",
+            color: "var(--muted)",
+          }}
+        >
+          {(pct * 100).toFixed(1)}% used ·{" "}
+          <strong style={{ color: "var(--text)" }}>
+            {(requestsTotal - requestsUsed).toLocaleString()} remaining
+          </strong>
+        </p>
+      </section>
+
+      {/* ── Reset time ─────────────────────────────────────────────────── */}
+      <footer
+        style={{
+          marginTop: "16px",
+          paddingTop: "16px",
+          borderTop: "1px solid var(--line, rgba(169,184,255,0.16))",
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          fontSize: "0.8125rem",
+          color: "var(--muted)",
+          flexWrap: "wrap",
+        }}
+      >
+        <svg
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+        Resets{" "}
+        <time dateTime={resetTime.iso} style={{ color: "var(--text)", fontWeight: 600 }}>
+          {resetTime.relative}
+        </time>
+        {" "}· Plan:{" "}
+        <span style={{ color: "var(--text)", fontWeight: 600 }}>
+          {planName}
+        </span>
+      </footer>
+    </article>
+  );
+}


### PR DESCRIPTION
Closes #537 

- Added middleEllipsis and middleEllipsisMaxLen props to <Breadcrumb>
- Exported truncateMiddle(text, maxLen) pure utility (start…end pattern)
- Exported BreadcrumbItem type for external consumers
- Added breadcrumb-link--middle-ellipsis / breadcrumb-current--middle-ellipsis CSS modifier classes; text-overflow:clip prevents double-truncation
- Full label always in aria-label + title for screen-reader parity
- New RateLimitCard component (quota bar, status badge, reset countdown) using middleEllipsis on a 5-segment breadcrumb path

Closes #537