### PR TITLE
fix: ApiDetailPage color-blind patterns

### DIFF
--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -769,6 +769,155 @@ const TOC: TocSection[] = [
 
 ---
 
+### StatusBadge
+
+Color-blind-safe status indicator used wherever an API or system health state
+must be communicated visually. Each variant combines a **color token** with a
+**unique SVG background pattern** so the badge is distinguishable by texture
+alone — satisfying WCAG 1.4.1 (Use of Color) for deuteranopia, protanopia, and
+tritanopia users.
+
+**Source:** `src/components/StatusBadge.tsx`
+**Styles (patterns):** `src/styles/patterns.css`
+**Tokens:** `src/styles/tokens.css`
+
+**Props:**
+
+| Prop         | Type            | Default             | Description                                                          |
+| ------------ | --------------- | ------------------- | -------------------------------------------------------------------- |
+| `status`     | `StatusVariant` | (required)          | Which status variant to render (see table below).                    |
+| `label?`     | `string`        | per-variant default | Override the visible text. Defaults to a human-readable status name. |
+| `className?` | `string`        | —                   | Extra CSS class(es) forwarded to the root `<span>`.                  |
+
+**`StatusVariant` values:**
+
+| Variant       | Default label | Pattern            | CSS class                | Token prefix         |
+| ------------- | ------------- | ------------------ | ------------------------ | -------------------- |
+| `operational` | Operational   | None (solid)       | `sb-pattern-operational` | `--sb-operational-*` |
+| `success`     | Operational   | None (solid)       | `sb-pattern-success`     | `--sb-success-*`     |
+| `degraded`    | Degraded      | ╱ opposite stripes | `sb-pattern-degraded`    | `--sb-degraded-*`    |
+| `warning`     | Degraded      | ╱ opposite stripes | `sb-pattern-warning`     | `--sb-warning-*`     |
+| `maintenance` | Maintenance   | ╳ crosshatch       | `sb-pattern-maintenance` | `--sb-maintenance-*` |
+| `down`        | Down          | ╲ diagonal stripes | `sb-pattern-down`        | `--sb-down-*`        |
+| `error`       | Error         | ╲ diagonal stripes | `sb-pattern-error`       | `--sb-error-*`       |
+| `pending`     | Pending       | • dot grid         | `sb-pattern-pending`     | `--sb-pending-*`     |
+
+**`apiStatusToVariant` helper:**
+
+When consuming an `APIItem` from the data layer, its `status` field is one of
+`"operational" | "degraded" | "maintenance"`. Use the exported helper to convert
+it to a `StatusVariant` before passing it to `<StatusBadge>`:
+
+```tsx
+import { StatusBadge, apiStatusToVariant } from '../components/StatusBadge';
+
+// api.status: "operational" | "degraded" | "maintenance" | undefined
+<StatusBadge status={apiStatusToVariant(api.status)} />
+```
+
+Mapping table:
+
+| `APIItem.status` | `StatusVariant` |
+| ---------------- | --------------- |
+| `"operational"`  | `"operational"` |
+| `"degraded"`     | `"degraded"`    |
+| `"maintenance"`  | `"maintenance"` |
+| `undefined`      | `"pending"`     |
+
+**Design tokens (all three per-variant properties must be defined for both themes):**
+
+```css
+/* dark theme — maintenance variant (purple) */
+[data-theme="dark"] {
+  --sb-maintenance-bg:     rgba(167, 139, 250, 0.14);
+  --sb-maintenance-fg:     #a78bfa;
+  --sb-maintenance-border: rgba(167, 139, 250, 0.35);
+}
+
+/* light theme */
+[data-theme="light"] {
+  --sb-maintenance-bg:     rgba(124, 58, 237, 0.1);
+  --sb-maintenance-fg:     #5b21b6;
+  --sb-maintenance-border: rgba(124, 58, 237, 0.25);
+}
+```
+
+**Pattern CSS (crosshatch example — `src/styles/patterns.css`):**
+
+The crosshatch (╳) is rendered as two overlaid SVG line sets via
+`background-image` multi-layer syntax:
+
+```css
+.sb-pattern-maintenance {
+  background-image:
+    url("data:image/svg+xml,…"),  /* ╲ diagonal pass */
+    url("data:image/svg+xml,…");  /* ╱ diagonal pass */
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}
+```
+
+The pattern layers on top of the solid `background-color` set by the token,
+using `stroke-opacity: 0.2` to stay subtle at badge scale.
+
+**Visual Spec:**
+
+- Display: `inline-flex`, `align-items: center`, `gap: 0.375em`
+- Padding: `0.2em 0.6em`, border-radius: `0.375em`
+- Font: 0.75 rem, weight 600, letter-spacing 0.02em
+- Dot indicator: 0.5em circle using `--sb-<status>-fg`, `aria-hidden`
+- Background: token `--sb-<status>-bg` + SVG pattern overlay (patterns.css)
+- Border: `1px solid var(--sb-<status>-border)`
+
+**Accessibility:**
+
+- `role="img"` — treats the badge as a non-interactive image rather than live text.
+- `aria-label` — the visible text label (defaults to variant name, overridable via `label` prop).
+- `aria-description` — includes the pattern name, e.g.  
+  `"Pattern-based status badge: Maintenance with crosshatch pattern"`.  
+  This ensures screen readers convey the texture-based cue even when the SVG is invisible.
+- `data-status` / `data-pattern` — data attributes for E2E selectors and QA tooling.
+- Dot indicator carries `aria-hidden="true"` so it is not double-announced.
+
+**Where it is used — ApiDetailPage:**
+
+`ApiDetailPage` renders `<StatusBadge>` in two places:
+
+1. **Hero title area** (`.api-detail-title`) — shown immediately below the API
+   name and provider/price meta line for at-a-glance visibility.
+2. **Sidebar "API Health" section** — replaces the previous plain-text
+   `"● Operational"` string, surfacing both pattern and color cues with full
+   accessibility semantics.
+
+Both placements read from `api.status` via `apiStatusToVariant()`.
+
+**Usage Examples:**
+
+```tsx
+// Direct variant
+<StatusBadge status="operational" />
+<StatusBadge status="maintenance" />
+<StatusBadge status="degraded" label="Partial outage" />
+
+// From APIItem data (preferred pattern in ApiDetailPage)
+import { StatusBadge, apiStatusToVariant } from '../components/StatusBadge';
+
+<StatusBadge status={apiStatusToVariant(api.status)} />
+```
+
+**Adding a new variant:**
+
+1. Add the variant string to the `StatusVariant` union in `StatusBadge.tsx`.
+2. Add entries to `DEFAULT_LABELS`, `PATTERN_DESCRIPTIONS`, and `PATTERN_KEYS`.
+3. Add a `.sb-pattern-<variant>` CSS rule in `src/styles/patterns.css` using an
+   SVG data URI pattern distinct from all existing ones.
+4. Add `--sb-<variant>-bg`, `--sb-<variant>-fg`, and `--sb-<variant>-border`
+   tokens to both `[data-theme="dark"]` and `[data-theme="light"]` blocks in
+   `src/styles/tokens.css`.
+5. Update this documentation section.
+
+---
+
 ### SearchBar
 
 Search input with clear button and keyboard shortcuts.

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { StatusBadge } from './StatusBadge';
+import { StatusBadge, apiStatusToVariant } from './StatusBadge';
 import type { StatusVariant } from './StatusBadge';
 
 afterEach(cleanup);
@@ -108,5 +108,54 @@ describe('StatusBadge', () => {
     expect(badge.getAttribute('data-status')).toBe('error');
     expect(badge.getAttribute('data-pattern')).toBe('stripes');
     expect(badge.getAttribute('aria-description')).toContain('diagonal stripes');
+  });
+
+  // ── maintenance variant ───────────────────────────────────────────────────
+
+  it('renders with default label "Maintenance" for the maintenance variant', () => {
+    render(<StatusBadge status="maintenance" />);
+    expect(screen.getByRole('img', { name: 'Maintenance' })).toBeTruthy();
+  });
+
+  it('applies the sb-pattern-maintenance CSS class for the crosshatch pattern', () => {
+    render(<StatusBadge status="maintenance" />);
+    const badge = screen.getByRole('img', { name: 'Maintenance' });
+    expect(badge.classList.contains('sb-pattern-maintenance')).toBe(true);
+  });
+
+  it('exposes crosshatch pattern semantics in data-pattern and aria-description', () => {
+    render(<StatusBadge status="maintenance" />);
+    const badge = screen.getByRole('img', { name: 'Maintenance' }) as HTMLElement;
+    expect(badge.getAttribute('data-status')).toBe('maintenance');
+    expect(badge.getAttribute('data-pattern')).toBe('crosshatch');
+    expect(badge.getAttribute('aria-description')).toContain('crosshatch pattern');
+  });
+
+  it('applies the maintenance design-token colors', () => {
+    render(<StatusBadge status="maintenance" />);
+    const badge = screen.getByRole('img', { name: 'Maintenance' }) as HTMLElement;
+    expect(badge.style.backgroundColor).toBe('var(--sb-maintenance-bg)');
+    expect(badge.style.color).toBe('var(--sb-maintenance-fg)');
+    expect(badge.style.border).toContain('var(--sb-maintenance-border)');
+  });
+
+  // ── apiStatusToVariant helper ─────────────────────────────────────────────
+
+  describe('apiStatusToVariant', () => {
+    it('maps "operational" → "operational"', () => {
+      expect(apiStatusToVariant('operational')).toBe('operational');
+    });
+
+    it('maps "degraded" → "degraded"', () => {
+      expect(apiStatusToVariant('degraded')).toBe('degraded');
+    });
+
+    it('maps "maintenance" → "maintenance"', () => {
+      expect(apiStatusToVariant('maintenance')).toBe('maintenance');
+    });
+
+    it('maps undefined → "pending" (safe fallback)', () => {
+      expect(apiStatusToVariant(undefined)).toBe('pending');
+    });
   });
 });

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -27,7 +27,8 @@ export type StatusVariant =
   | 'operational'
   | 'degraded'
   | 'down'
-  | 'pending';
+  | 'pending'
+  | 'maintenance';
 
 const DEFAULT_LABELS: Record<StatusVariant, string> = {
   success: 'Operational',
@@ -37,6 +38,7 @@ const DEFAULT_LABELS: Record<StatusVariant, string> = {
   warning: 'Degraded',
   degraded: 'Degraded',
   pending: 'Pending',
+  maintenance: 'Maintenance',
 };
 
 const PATTERN_DESCRIPTIONS: Record<StatusVariant, string> = {
@@ -47,6 +49,7 @@ const PATTERN_DESCRIPTIONS: Record<StatusVariant, string> = {
   warning: 'opposite diagonal stripes',
   degraded: 'opposite diagonal stripes',
   pending: 'dot pattern',
+  maintenance: 'crosshatch pattern',
 };
 
 const PATTERN_KEYS: Record<StatusVariant, string> = {
@@ -57,7 +60,29 @@ const PATTERN_KEYS: Record<StatusVariant, string> = {
   warning: 'opposite-stripes',
   degraded: 'opposite-stripes',
   pending: 'dots',
+  maintenance: 'crosshatch',
 };
+
+/**
+ * Map an APIItem.status value (from mockApis.ts) to the StatusBadge variant.
+ *
+ * APIItem.status uses "maintenance" which is a first-class variant that maps
+ * directly; the other two values share names with existing StatusVariants.
+ */
+export function apiStatusToVariant(
+  status: 'operational' | 'degraded' | 'maintenance' | undefined,
+): StatusVariant {
+  switch (status) {
+    case 'operational':
+      return 'operational';
+    case 'degraded':
+      return 'degraded';
+    case 'maintenance':
+      return 'maintenance';
+    default:
+      return 'pending';
+  }
+}
 
 /** Small circle indicator rendered before the text label. */
 function Dot({ status }: { status: StatusVariant }) {

--- a/src/pages/ApiDetailPage.test.tsx
+++ b/src/pages/ApiDetailPage.test.tsx
@@ -484,4 +484,142 @@ describe("ApiDetailPage", () => {
       expect(docPanel.tabIndex).toBe(0);
     });
   });
+
+  // ── StatusBadge integration ───────────────────────────────────────────────
+  //
+  // These tests verify that ApiDetailPage renders pattern-fill color-blind-safe
+  // StatusBadge components instead of plain-text status strings wherever the
+  // API health status is displayed.  All three APIItem.status values
+  // ("operational", "degraded", "maintenance") must map to the correct badge.
+
+  describe("StatusBadge integration (color-blind pattern fills)", () => {
+    it("renders a StatusBadge in the sidebar API Health section for an operational API", () => {
+      // weather-001 has status="operational"
+      window.history.pushState({}, "", "/details/weather-001");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      // The page renders two badges (hero + sidebar). Both must be correct.
+      const badges = screen.getAllByRole("img", { name: "Operational" });
+      expect(badges.length).toBeGreaterThanOrEqual(2);
+
+      // Every badge must carry the pattern class
+      badges.forEach((badge) => {
+        expect(badge.classList.contains("sb-pattern-operational")).toBe(true);
+        expect(badge.getAttribute("data-status")).toBe("operational");
+        expect(badge.getAttribute("data-pattern")).toBe("baseline");
+      });
+    });
+
+    it("renders a StatusBadge in the hero title area for an operational API", () => {
+      window.history.pushState({}, "", "/details/weather-001");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      // The hero badge is in .api-detail-title
+      const titleArea = document.querySelector(".api-detail-title");
+      expect(titleArea).toBeTruthy();
+      const heroBadge = titleArea?.querySelector('[role="img"]');
+      expect(heroBadge).toBeTruthy();
+      expect(heroBadge?.getAttribute("data-status")).toBe("operational");
+    });
+
+    it("renders a StatusBadge with degraded variant for a degraded API", () => {
+      // pay-qr has status="degraded"
+      window.history.pushState({}, "", "/details/pay-qr");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Degraded" });
+      expect(badges.length).toBeGreaterThanOrEqual(2);
+      badges.forEach((badge) => {
+        expect(badge.classList.contains("sb-pattern-degraded")).toBe(true);
+        expect(badge.getAttribute("data-status")).toBe("degraded");
+        expect(badge.getAttribute("data-pattern")).toBe("opposite-stripes");
+      });
+    });
+
+    it("renders a StatusBadge with maintenance variant for a maintenance API", () => {
+      // msg-01 has status="maintenance"
+      window.history.pushState({}, "", "/details/msg-01");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Maintenance" });
+      expect(badges.length).toBeGreaterThanOrEqual(2);
+      badges.forEach((badge) => {
+        expect(badge.classList.contains("sb-pattern-maintenance")).toBe(true);
+        expect(badge.getAttribute("data-status")).toBe("maintenance");
+        expect(badge.getAttribute("data-pattern")).toBe("crosshatch");
+      });
+    });
+
+    it("StatusBadge exposes pattern semantics in aria-description for non-color status cues", () => {
+      window.history.pushState({}, "", "/details/msg-01");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Maintenance" });
+      badges.forEach((badge) => {
+        expect(badge.getAttribute("aria-description")).toContain("crosshatch pattern");
+      });
+    });
+
+    it("StatusBadge for degraded API exposes opposite diagonal stripes in aria-description", () => {
+      window.history.pushState({}, "", "/details/pay-qr");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Degraded" });
+      badges.forEach((badge) => {
+        expect(badge.getAttribute("aria-description")).toContain("opposite diagonal stripes");
+      });
+    });
+
+    it("does NOT render the raw '● Operational' text string in the sidebar", () => {
+      window.history.pushState({}, "", "/details/weather-001");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      // The old plain-text sentinel must be gone; the badge provides semantics via aria-label
+      expect(screen.queryByText("● Operational")).toBeNull();
+    });
+
+    it("StatusBadge dot indicator is hidden from assistive technology", () => {
+      window.history.pushState({}, "", "/details/weather-001");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      // Check the sidebar badge specifically (inside .api-detail-sidebar)
+      const sidebar = document.querySelector(".api-detail-sidebar") as HTMLElement;
+      expect(sidebar).toBeTruthy();
+      const badge = sidebar.querySelector('[role="img"][data-status="operational"]') as HTMLElement;
+      expect(badge).toBeTruthy();
+      const dot = badge.querySelector('span[aria-hidden="true"]');
+      expect(dot).not.toBeNull();
+    });
+
+    it("applies correct CSS token background to the maintenance badge", () => {
+      window.history.pushState({}, "", "/details/msg-01");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Maintenance" }) as HTMLElement[];
+      badges.forEach((badge) => {
+        expect(badge.style.backgroundColor).toBe("var(--sb-maintenance-bg)");
+        expect(badge.style.color).toBe("var(--sb-maintenance-fg)");
+      });
+    });
+
+    it("applies correct CSS token background to the degraded badge", () => {
+      window.history.pushState({}, "", "/details/pay-qr");
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const badges = screen.getAllByRole("img", { name: "Degraded" }) as HTMLElement[];
+      badges.forEach((badge) => {
+        expect(badge.style.backgroundColor).toBe("var(--sb-degraded-bg)");
+      });
+    });
+  });
 });

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -24,6 +24,7 @@ import MOCK_APIS from "../data/mockApis";
 import KbdHint from "../components/KbdHint";
 import { SHORTCUTS } from "../hooks/useGlobalShortcuts";
 import PlanBadge from "../components/PlanBadge";
+import { StatusBadge, apiStatusToVariant } from "../components/StatusBadge";
 
 /**
  * ApiDetailPage
@@ -622,6 +623,11 @@ print(response.json())`;
                     <a href={api.provider?.url}>{api.provider?.name}</a> ·{" "}
                     <strong style={{ color: "var(--accent-strong)" }}>{`$${formatPrice(api.pricePerRequest ?? 0)}`}</strong> per request
                   </div>
+                  {api.status && (
+                    <div style={{ marginTop: 8 }}>
+                      <StatusBadge status={apiStatusToVariant(api.status)} />
+                    </div>
+                  )}
                 </div>
                 <div className="api-detail-provider">
                   Published by{" "}
@@ -1071,7 +1077,6 @@ print(response.json())`;
                   <h4 style={{ marginTop: 0 }}>API Health</h4>
                   <div style={{ display: "grid", gap: 16, marginTop: 20 }}>
                     {[
-                      { label: "Status", value: "● Operational", color: "var(--success)" },
                       { label: "Region", value: "Global (Edge)", color: "var(--text)" },
                       { label: "CORS", value: "Supported", color: "var(--success)" },
                     ].map(({ label, value, color }) => (
@@ -1080,6 +1085,10 @@ print(response.json())`;
                         <span style={{ fontSize: 14, color, fontWeight: label !== "Region" ? 600 : undefined }}>{value}</span>
                       </div>
                     ))}
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                      <span style={{ fontSize: 14, color: "var(--muted)" }}>Status</span>
+                      <StatusBadge status={apiStatusToVariant(api.status)} />
+                    </div>
                   </div>
                 </div>
 

--- a/src/styles/patterns.css
+++ b/src/styles/patterns.css
@@ -45,3 +45,14 @@
   background-size: 8px 8px;
   background-repeat: repeat;
 }
+
+/* Maintenance: crosshatch (╲ + ╱ combined) — visually distinct from both
+   stripes variants and dots; conveys "scheduled work in progress".
+   Using two SVG line sets overlaid via comma-separated background-image. */
+.sb-pattern-maintenance {
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cline x1='0' y1='0' x2='8' y2='8' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='4' y1='0' x2='8' y2='4' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='0' y1='4' x2='4' y2='8' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3C/svg%3E"),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cline x1='8' y1='0' x2='0' y2='8' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='4' y1='0' x2='0' y2='4' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='8' y1='4' x2='4' y2='8' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -104,6 +104,11 @@
   --sb-pending-bg: rgba(78, 133, 255, 0.14);
   --sb-pending-fg: #4e85ff;
   --sb-pending-border: rgba(78, 133, 255, 0.35);
+
+  /* maintenance — purple/violet tint (distinct from blue-pending and amber-degraded) */
+  --sb-maintenance-bg: rgba(167, 139, 250, 0.14);
+  --sb-maintenance-fg: #a78bfa;
+  --sb-maintenance-border: rgba(167, 139, 250, 0.35);
 }
 
 [data-theme="light"] {
@@ -134,4 +139,9 @@
   --sb-pending-bg: rgba(37, 99, 235, 0.1);
   --sb-pending-fg: #1e40af;
   --sb-pending-border: rgba(37, 99, 235, 0.25);
+
+  /* maintenance — lighter purple for light theme */
+  --sb-maintenance-bg: rgba(124, 58, 237, 0.1);
+  --sb-maintenance-fg: #5b21b6;
+  --sb-maintenance-border: rgba(124, 58, 237, 0.25);
 }


### PR DESCRIPTION
- Add maintenance StatusVariant to StatusBadge (crosshatch pattern)
- Export apiStatusToVariant() helper mapping APIItem.status to StatusVariant
- Add --sb-maintenance-* design tokens (dark + light themes)
- Add .sb-pattern-maintenance CSS crosshatch pattern to patterns.css
- Replace plain-text '● Operational' in ApiDetailPage sidebar with StatusBadge
- Add StatusBadge to ApiDetailPage hero title area
- 10 focused integration tests in ApiDetailPage.test.tsx
- 8 new unit tests in StatusBadge.test.tsx (maintenance variant + helper)
- Update docs/UI-Design-System.md with full StatusBadge section

Satisfies WCAG 1.4.1 (Use of Color): all statuses now distinguishable by texture as well as color (deuteranopia/protanopia/tritanopia safe).

closes #468 