### PR TITLE
feat(status): add color-blind-safe patterns on SearchInput status chips #532

### DIFF
--- a/src/pages/DesignSystemDocs.tsx
+++ b/src/pages/DesignSystemDocs.tsx
@@ -335,7 +335,7 @@ const COMPONENT_DOCS: ComponentDoc[] = [
     id: "status-chip",
     name: "Status Chip",
     description:
-      "Inline badge that surfaces transaction or system state at a glance. Colour is token-driven; text always carries the label so colour is never the sole indicator.",
+      "Inline badge that surfaces transaction or system state at a glance. Colour is token-driven; text always carries the label so colour is never the sole indicator. Each variant also carries a unique SVG background pattern (dots, cross-hatch, or diagonal stripes) so the state remains distinguishable to color-blind users (WCAG 1.4.1).",
     tokens: ["--success", "--danger", "--warning", "--radius-full"],
     props: [
       {

--- a/src/patterns.test.ts
+++ b/src/patterns.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("status-chip color-blind-safe patterns", () => {
+  const patterns = read("src/styles/patterns.css");
+
+  const variants = [
+    { cls: ".status-chip.input", pattern: "dots", baseline: false },
+    { cls: ".status-chip.approving", pattern: "cross-hatch", baseline: false },
+    { cls: ".status-chip.pending", pattern: "stripes", baseline: false },
+    { cls: ".status-chip.confirmed", pattern: "none", baseline: true },
+    { cls: ".status-chip.failed", pattern: "stripes", baseline: false },
+  ];
+
+  it("defines a pattern rule for every .status-chip variant", () => {
+    for (const v of variants) {
+      expect(patterns).toMatch(new RegExp(`${v.cls.replace(".", "\\.")}\\s*\\{`));
+    }
+  });
+
+  it("uses background-image:none for the confirmed baseline", () => {
+    expect(patterns).toMatch(/\.status-chip\.confirmed\s*\{[^}]*background-image:\s*none/s);
+  });
+
+  it("uses inline SVG data URIs for all patterned variants", () => {
+    for (const v of variants) {
+      if (v.baseline) continue;
+      expect(patterns).toMatch(
+        new RegExp(`${v.cls.replace(".", "\\.")}\\s*\\{[^}]*url\\("data:image/svg\\+xml`)
+      );
+    }
+  });
+
+  it("applies currentColor in SVG so patterns adapt to theme tokens", () => {
+    expect(patterns).toMatch(/\.status-chip\.input\s*\{[^}]*currentColor/s);
+    expect(patterns).toMatch(/\.status-chip\.failed\s*\{[^}]*currentColor/s);
+  });
+
+  it("includes a descriptive comment block for the .status-chip section", () => {
+    expect(patterns).toMatch(/\.status-chip color-blind-safe patterns/);
+    expect(patterns).toMatch(/WCAG 1\.4\.1/);
+  });
+});

--- a/src/styles/patterns.css
+++ b/src/styles/patterns.css
@@ -45,3 +45,43 @@
   background-size: 8px 8px;
   background-repeat: repeat;
 }
+
+/* ── .status-chip color-blind-safe patterns ─────────────────────────────────
+   Applied alongside the existing background-color on each .status-chip
+   variant so the state is identifiable by shape alone (WCAG 1.4.1).
+
+   Mapping:
+     input     — small dots      (neutral / starting)
+     approving — cross-hatch     (work in progress)
+     pending   — ╱╱╱ stripes     (waiting)
+     confirmed — solid fill      (baseline reference, no pattern)
+     failed    — ╲╲╲ stripes     (blocked / error)
+   ──────────────────────────────────────────────────────────────────────── */
+
+.status-chip.input {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Ccircle cx='4' cy='4' r='1' fill='currentColor' fill-opacity='0.25'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}
+
+.status-chip.approving {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 0L8 8M8 0L0 8' stroke='currentColor' stroke-width='0.75' stroke-opacity='0.22'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}
+
+.status-chip.pending {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cline x1='0' y1='8' x2='8' y2='0' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='4' y1='8' x2='8' y2='4' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='0' y1='4' x2='4' y2='0' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}
+
+.status-chip.confirmed {
+  background-image: none;
+}
+
+.status-chip.failed {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='6'%3E%3Cline x1='0' y1='0' x2='6' y2='6' stroke='currentColor' stroke-width='1' stroke-opacity='0.25'/%3E%3Cline x1='3' y1='0' x2='6' y2='3' stroke='currentColor' stroke-width='1' stroke-opacity='0.25'/%3E%3Cline x1='0' y1='3' x2='3' y2='6' stroke='currentColor' stroke-width='1' stroke-opacity='0.25'/%3E%3C/svg%3E");
+  background-size: 6px 6px;
+  background-repeat: repeat;
+}


### PR DESCRIPTION
$## Overview

This PR adds color-blind-safe SVG background patterns to `.status-chip` variants so the transaction status remains distinguishable by texture alone, satisfying WCAG 1.4.1 (Use of Color).

## Related Issue

Closes #532

## Changes

### [ADD] Color-blind-safe patterns in `src/styles/patterns.css`

- **input** — dot grid (`currentColor`, neutral / starting feel)
- **approving** — cross-hatch (`currentColor`, work-in-progress feel)
- **pending** — forward diagonal stripes (`currentColor`, waiting)
- **confirmed** — solid baseline (no pattern, baseline reference)
- **failed** — reverse diagonal stripes (`currentColor`, blocked / error)

Patterns are applied as a second `background-image` layer on top of the existing token-driven `background-color`. All SVGs use `currentColor` so they adapt automatically to light / dark theme token values without additional CSS custom properties.

### [ADD] Focused tests in `src/patterns.test.ts`

- Verifies every `.status-chip` variant has a CSS rule.
- Verifies `confirmed` uses `background-image: none`.
- Verifies all patterned variants use inline SVG data URIs.
- Verifies `currentColor` is used so patterns adapt to theme tokens.
- Verifies the descriptive comment block and WCAG 1.4.1 reference.

### [MODIFY] `src/pages/DesignSystemDocs.tsx`

- Updated Status Chip description to document the new pattern overlay.

## Verification Results

\`\`\`text
npm test -- src/patterns.test.ts
✅ 5/5 passed

npm test -- src/components/StatusBadge.test.tsx
✅ 19/19 passed
\`\`\`

Acceptance Criteria

Status

Status chips are distinguishable without relying on color alone

✅ Each variant has a unique SVG pattern (dots, cross-hatch, or stripes) applied via CSS

Patterns are documented and tested

✅ Added `src/patterns.test.ts` with focused contract tests; updated DesignSystemDocs description

Repo lint/style/security posture preserved

✅ No new dependencies; patterns are inline SVG data URIs; no external assets