### PR TITLE
feat(frontend): add EndpointSummary page and expand collapsibles on p…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import MarketplacePage from "./pages/MarketplacePage";
 import ThemePlayground from "./pages/ThemePlayground";
 import DesignSystemDocs from "./pages/DesignSystemDocs";
 import A11yAudit from "./pages/A11yAudit";
+import EndpointSummary from "./pages/EndpointSummary";
 import { ShortcutsModal } from "./components/ShortcutsModal";
 import { ToastProvider } from "./components/Toast";
 
@@ -110,6 +111,7 @@ const APP_ROUTES = {
   themePlayground: "/theme-playground",
   designSystem: "/design-system/docs",
   serverError: "/500",
+  endpointSummary: "/endpoint-summary",
 } as const;
 
 function createMockHash() {
@@ -266,6 +268,7 @@ function App() {
     [APP_ROUTES.billing]: "Billing – Callora",
     "/api-usage": "API Usage – Callora",
     [APP_ROUTES.landing]: "Callora",
+    [APP_ROUTES.endpointSummary]: "Endpoint Summary – Callora",
   };
   const routeDescriptionMap: Record<string, string> = {
     [APP_ROUTES.marketplace]: "Explore APIs on the Callora marketplace, discover and integrate APIs for your applications.",
@@ -273,6 +276,7 @@ function App() {
     [APP_ROUTES.billing]: "Manage your USDC vault, deposit funds, and view transaction status.",
     "/api-usage": "Monitor API usage, request stats, and view call history.",
     [APP_ROUTES.landing]: "Callora - Programmable API Access, pay-per-call billing, and on-chain settlement.",
+    [APP_ROUTES.endpointSummary]: "Quick reference list of all API endpoints on Callora.",
   };
   const currentTitle = routeTitleMap[location.pathname] ?? "Callora";
   const currentDescription = routeDescriptionMap[location.pathname];
@@ -658,6 +662,7 @@ function App() {
 
             <Route path="/a11y-audit" element={<A11yAudit />} />
 
+            <Route path={APP_ROUTES.endpointSummary} element={<EndpointSummary />} />
             <Route path="*" element={<NotFound onGoHome={() => navigate(APP_ROUTES.dashboard)} />} />
           </Routes>
         </main>

--- a/src/index.css
+++ b/src/index.css
@@ -5050,6 +5050,18 @@ code,
     font-size: 0.85em;
     color: #444;
   }
+
+  /* Expand EndpointSummary collapsibles when printing */
+  .endpoint-summary-content--collapsed {
+    display: block !important;
+  }
+  .endpoint-summary-trigger .chevron-icon {
+    display: none !important;
+  }
+  .endpoint-summary-card {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
 }
 
 /* Share Snapshot Button */

--- a/src/pages/EndpointSummary.test.tsx
+++ b/src/pages/EndpointSummary.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import EndpointSummary from "./EndpointSummary";
+
+// Mock useDocumentTitle hook
+vi.mock("../hooks/useDocumentTitle", () => ({
+  default: vi.fn(),
+}));
+
+describe("EndpointSummary Page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the Endpoint Summary page header", () => {
+    render(
+      <MemoryRouter>
+        <EndpointSummary />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Endpoint Summary")).toBeTruthy();
+    expect(screen.getByText(/Quick reference list of all API endpoints/i)).toBeTruthy();
+  });
+
+  it("toggles the expanded state of endpoint cards when clicked", () => {
+    render(
+      <MemoryRouter>
+        <EndpointSummary />
+      </MemoryRouter>
+    );
+
+    // Get the trigger for the first endpoint
+    const triggers = screen.getAllByRole("button");
+    // Find the one that acts as a trigger (contains method/url/etc)
+    const endpointTrigger = triggers.find((btn) =>
+      btn.classList.contains("endpoint-summary-trigger")
+    );
+
+    expect(endpointTrigger).toBeTruthy();
+    if (!endpointTrigger) return;
+
+    // Toggle collapse/expand
+    const initialExpanded = endpointTrigger.getAttribute("aria-expanded") === "true";
+    fireEvent.click(endpointTrigger);
+    const postClickExpanded = endpointTrigger.getAttribute("aria-expanded") === "true";
+
+    expect(postClickExpanded).toBe(!initialExpanded);
+  });
+
+  it("calls window.print when the print button is clicked", () => {
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+    render(
+      <MemoryRouter>
+        <EndpointSummary />
+      </MemoryRouter>
+    );
+
+    const printButton = screen.getByRole("button", { name: /Print Summary/i });
+    expect(printButton).toBeTruthy();
+    fireEvent.click(printButton);
+
+    expect(printSpy).toHaveBeenCalled();
+    printSpy.mockRestore();
+  });
+});

--- a/src/pages/EndpointSummary.tsx
+++ b/src/pages/EndpointSummary.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import useDocumentTitle from "../hooks/useDocumentTitle";
+import { MOCK_APIS } from "../data/mockApis";
+import { API_BASE_URL } from "../config/constants";
+
+export default function EndpointSummary(): JSX.Element {
+  useDocumentTitle(
+    "Endpoint Summary – Callora",
+    "Summary of all endpoints available on Callora."
+  );
+
+  // Flatten all endpoints from all mock APIs
+  const allEndpoints = MOCK_APIS.flatMap((api) =>
+    (api.endpoints || []).map((ep) => ({
+      ...ep,
+      apiName: api.name,
+    }))
+  );
+
+  // Track expanded cards
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(
+    new Set(allEndpoints.slice(0, 3).map((ep) => ep.id)) // Expand first 3 by default
+  );
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="endpoint-summary-page" style={{ padding: "24px 0" }}>
+      <header className="no-print" style={{ marginBottom: "32px", padding: "0 4px" }}>
+        <p className="eyebrow">API Documentation</p>
+        <h1
+          style={{
+            margin: "0 0 12px",
+            fontSize: "clamp(1.8rem, 3vw, 2.4rem)",
+            fontWeight: "700",
+            color: "var(--text)",
+          }}
+        >
+          Endpoint Summary
+        </h1>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "1rem",
+            color: "var(--muted)",
+            lineHeight: "1.65",
+            maxWidth: "600px",
+          }}
+        >
+          Quick reference list of all API endpoints. Click any card to view parameters and details.
+        </p>
+        <button
+          type="button"
+          className="primary-button no-print"
+          style={{ marginTop: "16px" }}
+          onClick={() => window.print()}
+        >
+          Print Summary
+        </button>
+      </header>
+
+      <section style={{ display: "grid", gap: "16px" }}>
+        {allEndpoints.map((ep) => {
+          const isExpanded = expandedIds.has(ep.id);
+          return (
+            <div
+              key={ep.id}
+              className="preview-card endpoint-summary-card"
+              style={{ padding: 0, overflow: "hidden" }}
+            >
+              <button
+                type="button"
+                className="endpoint-summary-trigger"
+                onClick={() => toggleExpand(ep.id)}
+                aria-expanded={isExpanded}
+                style={{
+                  width: "100%",
+                  textAlign: "left",
+                  background: "var(--surface-soft)",
+                  border: "none",
+                  padding: "16px 24px",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  cursor: "pointer",
+                  color: "var(--text)",
+                }}
+              >
+                <div>
+                  <span className="eyebrow" style={{ display: "block", marginBottom: "4px" }}>
+                    {ep.apiName}
+                  </span>
+                  <div style={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap" }}>
+                    <span className={`method-badge method-badge--${(ep.method || "get").toLowerCase()}`}>
+                      {ep.method}
+                    </span>
+                    <strong style={{ fontSize: "16px" }}>{ep.title}</strong>
+                    <code style={{ fontSize: "13px", color: "var(--muted)" }}>{ep.url}</code>
+                  </div>
+                </div>
+                <span
+                  className="chevron-icon"
+                  style={{
+                    transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+                    transition: "transform 0.2s",
+                    display: "inline-block",
+                  }}
+                >
+                  ▼
+                </span>
+              </button>
+
+              <div
+                className={`endpoint-summary-content ${
+                  isExpanded ? "endpoint-summary-content--expanded" : "endpoint-summary-content--collapsed"
+                }`}
+                style={{
+                  padding: "24px",
+                  borderTop: "1px solid var(--line)",
+                }}
+              >
+                <h4 style={{ margin: "0 0 12px 0", fontSize: "14px" }}>Request Parameters</h4>
+                {ep.params && ep.params.length > 0 ? (
+                  <div className="endpoint-table-wrap">
+                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
+                      <thead>
+                        <tr
+                          style={{
+                            textAlign: "left",
+                            color: "var(--muted)",
+                            borderBottom: "1px solid var(--line)",
+                          }}
+                        >
+                          <th style={{ padding: "8px 0" }}>Parameter</th>
+                          <th>Type</th>
+                          <th>Required</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {ep.params.map((p: any) => (
+                          <tr key={p.name} style={{ borderBottom: "1px solid var(--line)" }}>
+                            <td
+                              style={{
+                                padding: "12px 0",
+                                fontFamily: "monospace",
+                                color: "var(--accent)",
+                              }}
+                            >
+                              {p.name}
+                            </td>
+                            <td>
+                              <span className="type-tag">{p.type}</span>
+                            </td>
+                            <td>{p.required ? "Yes" : "Optional"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p style={{ color: "var(--muted)", fontSize: "13px" }}>No parameters required.</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/src/print.test.ts
+++ b/src/print.test.ts
@@ -38,6 +38,11 @@ describe("print stylesheet contract", () => {
     expect(css).toMatch(/pre[\s\S]*?white-space:\s*pre-wrap\s*!important/);
     expect(css).toMatch(/pre[\s\S]*?overflow:\s*visible\s*!important/);
   });
+
+  it("forces EndpointSummary collapsibles to expand on print", () => {
+    expect(css).toMatch(/\.endpoint-summary-content--collapsed\s*\{[\s\S]*?display:\s*block\s*!important/);
+    expect(css).toMatch(/\.endpoint-summary-trigger\s+\.chevron-icon\s*\{[\s\S]*?display:\s*none\s*!important/);
+  });
 });
 
 describe("no-print markup", () => {

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,41 @@
+/* Print styles for Callora Frontend */
+@media print {
+  /* Hide interactive components and chrome */
+  .no-print,
+  .topbar,
+  .app-footer,
+  .primary-button,
+  .ghost-button,
+  .icon-button,
+  button.endpoint-summary-trigger .chevron-icon {
+    display: none !important;
+  }
+
+  /* Force light theme tokens */
+  :root,
+  html,
+  body {
+    --page-bg: #f5f7fa !important;
+    --surface: #ffffff !important;
+    --text: #1a2332 !important;
+    --muted: #64748b !important;
+    background: #ffffff !important;
+    color: #1a2332 !important;
+  }
+
+  /* Force all collapsible summaries to expand on print */
+  .endpoint-summary-content--collapsed {
+    display: block !important;
+  }
+
+  /* Prevent page breaks inside cards */
+  .endpoint-summary-card {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
+
+  /* Clean table formatting */
+  .endpoint-table-wrap table {
+    width: 100% !important;
+  }
+}


### PR DESCRIPTION
## Description
Closes #565

This PR adds the `EndpointSummary` page, registers its route in `App.tsx`, and introduces print style overrides that hide the web shell chrome and automatically expand all collapsible endpoint detail cards on print.

### Key Changes
1. **EndpointSummary Page**: Created `src/pages/EndpointSummary.tsx` showing a clean list of all API endpoints and their parameters using accessible, collapsible headers (`aria-expanded` and semantic structures).
2. **Route Configuration**: Registered `/endpoint-summary` under `APP_ROUTES` in `src/App.tsx`, alongside its document title and SEO description metadata.
3. **Print Stylesheet (`print.css`)**: Created `src/styles/print.css` containing dedicated CSS layout overrides for printing the EndpointSummary.
4. **Main Stylesheet Integration**: Appended print overrides directly to `@media print` in `src/index.css` to comply with the project contract and pass all stylesheet assertions.
5. **Contract Tests**: Added tests in `src/print.test.ts` verifying that the custom print rules exist in `index.css`.
6. **Focused Page Tests**: Added `src/pages/EndpointSummary.test.tsx` verifying component mount states, collapse/expand toggles, and printing trigger behavior.

## Verification
- Verified all TypeScript files compile cleanly.

### Testing Instructions
To run unit and style contract tests:
1. Update dependencies:
   ```bash
   npm install
