### PR TITLE
feat(frontend): add sticky bottom SubscribeCTA bar on scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5441,3 +5441,113 @@ code,
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
+
+/* ============================================================
+   SubscribeCTA — sticky bottom action bar appearing on scroll
+   BEM block: .subscribe-cta-bar
+   ============================================================ */
+.subscribe-cta-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 24px;
+  background: rgba(255, 255, 255, 0.85);
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  border-top: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transform: translateY(100%);
+  transition:
+    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    background var(--transition-speed),
+    border-color var(--transition-speed);
+  box-shadow: 0 -4px 20px -4px rgba(0, 0, 0, 0.08);
+}
+
+.subscribe-cta-bar--visible {
+  transform: translateY(0);
+}
+
+/* Dark mode overrides for shadow contrast */
+[data-theme="dark"] .subscribe-cta-bar {
+  box-shadow: 0 -4px 25px -4px rgba(0, 0, 0, 0.35);
+}
+
+.subscribe-cta-bar__container {
+  width: 100%;
+  max-width: 1100px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.subscribe-cta-bar__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.subscribe-cta-bar__title-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.subscribe-cta-bar__title {
+  font-size: 1rem;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.subscribe-cta-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.subscribe-cta-bar__price-group {
+  text-align: right;
+}
+
+.subscribe-cta-bar__price-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  display: block;
+}
+
+.subscribe-cta-bar__price {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* Responsive adjustments for smaller screens */
+@media (max-width: 640px) {
+  .subscribe-cta-bar {
+    padding: 12px 16px;
+  }
+  
+  .subscribe-cta-bar__container {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+  
+  .subscribe-cta-bar__info {
+    align-items: center;
+  }
+  
+  .subscribe-cta-bar__actions {
+    justify-content: space-between;
+  }
+}
+

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -17,6 +17,7 @@ import { ApiDetailStickyTOC, type TocSection } from "../components/ApiDetailStic
 import { CheckIcon } from "../components/icons";
 import { copyToClipboard, getInsomniaImportUrl, getPostmanImportUrl } from "../utils/postman";
 import SubscribeButton from "../components/SubscribeButton";
+import SubscribeCTA from "./SubscribeCTA";
 import { useToast } from "../components/Toast";
 import { useCollections } from "../state/collectionsStore";
 import RelatedApisRail from "../components/RelatedApisRail";
@@ -1127,6 +1128,12 @@ print(response.json())`;
         {/* /api-detail-shell */}
       </div>
       {/* /api-detail-container */}
+      <SubscribeCTA
+        apiName={api.name}
+        pricePerRequest={api.pricePerRequest ?? 0}
+        onSubscribe={() => showToast(`Subscribed to ${api.name}!`, "success")}
+        observeElementSelector=".api-hero__cta--detail"
+      />
     </div>
   );
 }

--- a/src/pages/SubscribeCTA.test.tsx
+++ b/src/pages/SubscribeCTA.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SubscribeCTA from "./SubscribeCTA";
+
+// Mock IntersectionObserver
+let observerCallback: any = null;
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+
+Object.defineProperty(window, "IntersectionObserver", {
+  writable: true,
+  value: vi.fn().mockImplementation((cb) => {
+    observerCallback = cb;
+    return {
+      observe: observeMock,
+      unobserve: vi.fn(),
+      disconnect: disconnectMock,
+    };
+  }),
+});
+
+describe("SubscribeCTA Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observerCallback = null;
+    // Set up a mock element in the document to satisfy querySelector
+    const dummyCta = document.createElement("div");
+    dummyCta.className = "api-hero__cta--detail";
+    document.body.appendChild(dummyCta);
+  });
+
+  it("renders API details and the subscribe button correctly", () => {
+    render(
+      <SubscribeCTA
+        apiName="WeatherSim API"
+        pricePerRequest={0.01}
+        observeElementSelector=".api-hero__cta--detail"
+      />
+    );
+
+    expect(screen.getByText("WeatherSim API")).toBeTruthy();
+    expect(screen.getByText("$0.01")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Subscribe to WeatherSim API/i })).toBeTruthy();
+  });
+
+  it("becomes visible when the observed element goes out of view", () => {
+    const { container } = render(
+      <SubscribeCTA
+        apiName="WeatherSim API"
+        pricePerRequest={0.01}
+        observeElementSelector=".api-hero__cta--detail"
+      />
+    );
+
+    const ctaBar = container.querySelector(".subscribe-cta-bar");
+    expect(ctaBar?.classList.contains("subscribe-cta-bar--visible")).toBe(false);
+
+    // Simulate hero section scrolling out of view (isIntersecting = false)
+    expect(observerCallback).toBeTruthy();
+    act(() => {
+      observerCallback([{ isIntersecting: false }]);
+    });
+
+    expect(ctaBar?.classList.contains("subscribe-cta-bar--visible")).toBe(true);
+  });
+
+  it("hides when the observed element scrolls back into view", () => {
+    const { container } = render(
+      <SubscribeCTA
+        apiName="WeatherSim API"
+        pricePerRequest={0.01}
+        observeElementSelector=".api-hero__cta--detail"
+      />
+    );
+
+    const ctaBar = container.querySelector(".subscribe-cta-bar");
+
+    // Make visible first
+    act(() => {
+      observerCallback([{ isIntersecting: false }]);
+    });
+    expect(ctaBar?.classList.contains("subscribe-cta-bar--visible")).toBe(true);
+
+    // Scroll back into view (isIntersecting = true)
+    act(() => {
+      observerCallback([{ isIntersecting: true }]);
+    });
+    expect(ctaBar?.classList.contains("subscribe-cta-bar--visible")).toBe(false);
+  });
+});

--- a/src/pages/SubscribeCTA.tsx
+++ b/src/pages/SubscribeCTA.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import SubscribeButton from "../components/SubscribeButton";
+import { formatPrice } from "../utils/format";
+
+type Props = {
+  /** Name of the API. */
+  apiName: string;
+  /** Cost per request. */
+  pricePerRequest: number;
+  /** Subscribe button callback. */
+  onSubscribe?: () => void;
+  /** The CSS selector of the hero element to observe for scrolling out of view. */
+  observeElementSelector?: string;
+};
+
+export default function SubscribeCTA({
+  apiName,
+  pricePerRequest,
+  onSubscribe,
+  observeElementSelector = ".api-hero__cta",
+}: Props): JSX.Element {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const target = document.querySelector(observeElementSelector);
+    if (!target) {
+      // Fallback: If target not found, toggle on scroll offset
+      const handleScroll = () => {
+        setIsVisible(window.scrollY > 250);
+      };
+      window.addEventListener("scroll", handleScroll);
+      return () => window.removeEventListener("scroll", handleScroll);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Bar is visible when the main hero CTA is NOT in view (intersecting ratio is 0)
+        setIsVisible(!entry.isIntersecting);
+      },
+      { threshold: 0 }
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [observeElementSelector]);
+
+  return (
+    <div
+      className={`subscribe-cta-bar no-print ${
+        isVisible ? "subscribe-cta-bar--visible" : ""
+      }`}
+      role="region"
+      aria-label={`${apiName} Subscription Sticky Bar`}
+    >
+      <div className="subscribe-cta-bar__container">
+        <div className="subscribe-cta-bar__info">
+          <span className="subscribe-cta-bar__title-label">Currently Viewing</span>
+          <strong className="subscribe-cta-bar__title">{apiName}</strong>
+        </div>
+
+        <div className="subscribe-cta-bar__actions">
+          <div className="subscribe-cta-bar__price-group">
+            <span className="subscribe-cta-bar__price-label">Price per call</span>
+            <div className="subscribe-cta-bar__price">
+              ${formatPrice(pricePerRequest)}
+            </div>
+          </div>
+
+          <SubscribeButton
+            apiName={apiName}
+            onSubscribe={onSubscribe}
+            className="subscribe-cta-bar__button"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Closes #568

This PR implements a sticky bottom action bar (`SubscribeCTA`) on the API detail page that dynamically slides into view when the user scrolls past the main hero action buttons.

### Key Changes
1. **SubscribeCTA Component**: Created `src/pages/SubscribeCTA.tsx` which uses the `IntersectionObserver` API to monitor the visibility of the main hero CTA row. When the hero buttons scroll out of view, the sticky bar slides up from the bottom.
2. **ApiDetailPage Integration**: Imported and mounted the `<SubscribeCTA>` component inside the root container of `src/pages/ApiDetailPage.tsx`.
3. **Styling and Layout**: Added BEM-based styling in `src/index.css` for `.subscribe-cta-bar`. It features:
   - Modern glassmorphism blur backdrop (`backdrop-filter: blur(12px)`).
   - High-contrast, theme-aware translucent background (`color-mix` utility mapping to `--surface`).
   - Clean BEM structure and responsive column-stacking on narrow screens (< 640px).
   - Automatically hides when printing (using the `no-print` helper).
4. **Focused Unit Tests**: Created `src/pages/SubscribeCTA.test.tsx` which mocks the `IntersectionObserver` API and asserts that the bar's visibility toggles correctly as target intersections change.

## Verification
- Verified all TypeScript files compile cleanly.

### Testing Instructions
To run unit tests:
1. Update dependencies:
   ```bash
   npm install
