### PR TITLE
feat(breadcrumb): middle-ellipsis truncation for long path segments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import MarketplacePage from "./pages/MarketplacePage";
 import ThemePlayground from "./pages/ThemePlayground";
 import DesignSystemDocs from "./pages/DesignSystemDocs";
 import A11yAudit from "./pages/A11yAudit";
+import RateLimitCard from "./pages/RateLimitCard";
 import { ShortcutsModal } from "./components/ShortcutsModal";
 import { ToastProvider } from "./components/Toast";
 
@@ -110,6 +111,7 @@ const APP_ROUTES = {
   themePlayground: "/theme-playground",
   designSystem: "/design-system/docs",
   serverError: "/500",
+  rateLimitCard: "/rate-limit",
 } as const;
 
 function createMockHash() {
@@ -657,6 +659,8 @@ function App() {
             <Route path={APP_ROUTES.serverError} element={<ServerError onRetry={handleServerRetry} onGoHome={() => navigate(APP_ROUTES.dashboard)} />} />
 
             <Route path="/a11y-audit" element={<A11yAudit />} />
+
+            <Route path={APP_ROUTES.rateLimitCard} element={<RateLimitCard />} />
 
             <Route path="*" element={<NotFound onGoHome={() => navigate(APP_ROUTES.dashboard)} />} />
           </Routes>

--- a/src/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import Breadcrumb from "./Breadcrumb";
+import Breadcrumb, { truncateMiddle } from "./Breadcrumb";
 
 const longBreadcrumb = [
   { label: "Marketplace", href: "/marketplace" },
@@ -162,5 +162,193 @@ describe("Breadcrumb", () => {
     render(<Breadcrumb items={longBreadcrumb} />);
     const link = screen.getByRole("link", { name: "Marketplace" });
     expect(link.classList.contains("link-nav")).toBe(true);
+  });
+});
+
+// ── truncateMiddle unit tests ─────────────────────────────────────────────────
+
+describe("truncateMiddle", () => {
+  it("returns the string unchanged when max is 0 (feature disabled)", () => {
+    expect(truncateMiddle("Hello World", 0)).toBe("Hello World");
+  });
+
+  it("returns the string unchanged when max < 8 (not enough budget)", () => {
+    expect(truncateMiddle("Hello World", 7)).toBe("Hello World");
+    expect(truncateMiddle("Hello World", 1)).toBe("Hello World");
+  });
+
+  it("returns the string unchanged when it already fits", () => {
+    expect(truncateMiddle("Short", 10)).toBe("Short");
+    expect(truncateMiddle("Exactly10!", 10)).toBe("Exactly10!");
+  });
+
+  it("truncates long strings to exactly `max` characters (including the ellipsis)", () => {
+    const result = truncateMiddle("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10);
+    // budget = 9 chars of content, endLen = 4, startLen = 5
+    // → "ABCDE…WXYZ" = 10 chars
+    expect([...result].length).toBe(10);
+    expect(result).toBe("ABCDE\u2026WXYZ");
+  });
+
+  it("uses a real Unicode ellipsis character (U+2026), not three full stops", () => {
+    const result = truncateMiddle("A very long label that must be shortened", 12);
+    expect(result).toContain("\u2026");
+    expect(result).not.toContain("...");
+  });
+
+  it("preserves the start and end of the label", () => {
+    const label = "GrantFox Wave Compute API – Stellar Edition";
+    const result = truncateMiddle(label, 28);
+    // label.length = 43 (includes em-dash), budget=27, endLen=13, startLen=14
+    // start → "GrantFox Wave " (14 chars), end → "ellar Edition" (13 chars)
+    expect(result.startsWith("GrantFox Wave ")).toBe(true);
+    expect(result.endsWith("ellar Edition")).toBe(true);
+    expect([...result].length).toBe(28);
+  });
+
+  it("handles odd budget by giving one extra character to the start", () => {
+    // label = "0123456789ABCDEF" (16 chars), max=10
+    // budget = 9, endLen = floor(9/2) = 4, startLen = 5
+    // start → label.slice(0, 5)  = "01234"
+    // end   → label.slice(16-4)  = "CDEF"   ← last 4 chars of the string
+    const result = truncateMiddle("0123456789ABCDEF", 10);
+    expect(result).toBe("01234\u2026CDEF");
+    expect([...result].length).toBe(10);
+  });
+});
+
+// ── Breadcrumb middle-ellipsis integration tests ──────────────────────────────
+
+const LONG_LABEL_1 = "GrantFox Wave Compute API – Stellar Edition";
+const LONG_LABEL_2 = "Rate Limits & Throttling Policies";
+
+const truncatedBreadcrumb = [
+  { label: "Marketplace", href: "/marketplace" },
+  { label: LONG_LABEL_1, href: "/marketplace/grantfox" },
+  { label: LONG_LABEL_2, href: "/marketplace/grantfox/rate-limits" },
+  {
+    label: "Current Plan Configuration",
+    href: "/marketplace/grantfox/rate-limits/config",
+    isCurrent: true,
+  },
+];
+
+describe("Breadcrumb – middle-ellipsis (maxLabelLength)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders full labels when maxLabelLength is omitted (default 0)", () => {
+    render(<Breadcrumb items={truncatedBreadcrumb} />);
+    // All middle crumbs are hidden on desktop (breadcrumb-middle) but still in DOM
+    const links = screen.getAllByRole("link");
+    const allText = links.map((l) => l.textContent);
+    // Marketplace is the first crumb link; rest are hidden/middle
+    expect(allText).toContain("Marketplace");
+  });
+
+  it("truncates long middle-item labels with a middle-ellipsis", () => {
+    const { container } = render(
+      <Breadcrumb items={truncatedBreadcrumb} maxLabelLength={28} />,
+    );
+
+    // Open the popover to expose middle items in the DOM
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+    if (!button) throw new Error("Expected ellipsis button");
+    fireEvent.click(button);
+
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('[role="menuitem"]'),
+    );
+
+    // Both middle labels should be truncated (shorter than originals and contain …)
+    for (const menuItem of menuItems) {
+      const text = menuItem.textContent ?? "";
+      expect(text).toContain("\u2026");
+      expect([...text].length).toBe(28);
+    }
+  });
+
+  it("preserves full labels in title and aria-label on truncated popover items", () => {
+    const { container } = render(
+      <Breadcrumb items={truncatedBreadcrumb} maxLabelLength={28} />,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+    if (!button) throw new Error("Expected ellipsis button");
+    fireEvent.click(button);
+
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('[role="menuitem"]'),
+    );
+
+    expect(menuItems[0].getAttribute("title")).toBe(LONG_LABEL_1);
+    expect(menuItems[0].getAttribute("aria-label")).toBe(LONG_LABEL_1);
+    expect(menuItems[1].getAttribute("title")).toBe(LONG_LABEL_2);
+    expect(menuItems[1].getAttribute("aria-label")).toBe(LONG_LABEL_2);
+  });
+
+  it("does NOT add aria-label when the label fits without truncation", () => {
+    const shortItems = [
+      { label: "Home", href: "/" },
+      { label: "Settings", href: "/settings" },
+      { label: "Profile", href: "/settings/profile", isCurrent: true },
+    ];
+    const { container } = render(
+      <Breadcrumb items={shortItems} maxLabelLength={28} />,
+    );
+    // First item is a link and its label is short — should have no aria-label override
+    const homeLink = container.querySelector<HTMLAnchorElement>(
+      ".breadcrumb-link",
+    );
+    expect(homeLink).not.toBeNull();
+    expect(homeLink?.getAttribute("aria-label")).toBeNull();
+  });
+
+  it("truncates the current-page crumb label when it is too long", () => {
+    const items = [
+      { label: "Marketplace", href: "/marketplace" },
+      {
+        label: "A Very Long Current Page Title Indeed",
+        href: "/current",
+        isCurrent: true,
+      },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={20} />);
+
+    // The current crumb is a <span> with aria-current="page"
+    const current = document.querySelector<HTMLSpanElement>(
+      '[aria-current="page"]',
+    );
+    expect(current).not.toBeNull();
+    // Visual text should be truncated
+    expect(current?.textContent).toContain("\u2026");
+    expect([...(current?.textContent ?? "")].length).toBe(20);
+    // Full text preserved in title and aria-label
+    expect(current?.getAttribute("title")).toBe(
+      "A Very Long Current Page Title Indeed",
+    );
+    expect(current?.getAttribute("aria-label")).toBe(
+      "A Very Long Current Page Title Indeed",
+    );
+  });
+
+  it("short labels remain unchanged when maxLabelLength is set", () => {
+    const items = [
+      { label: "Home", href: "/" },
+      { label: "Short", href: "/short", isCurrent: true },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={28} />);
+
+    const current = document.querySelector<HTMLSpanElement>(
+      '[aria-current="page"]',
+    );
+    expect(current?.textContent).toBe("Short");
+    // No aria-label override needed
+    expect(current?.getAttribute("aria-label")).toBeNull();
   });
 });

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -8,25 +8,81 @@ type BreadcrumbItem = {
 };
 
 type BreadcrumbProps = {
-  items: BreadcrumbItem[];
+  items: ReadonlyArray<BreadcrumbItem>;
+  /**
+   * When greater than 0 any individual crumb label that exceeds this character
+   * count will be visually shortened using a middle-ellipsis (e.g.
+   * "Very Long … Label Here").  The full text is always preserved in the
+   * element's `title` attribute and, for non-current links, as the accessible
+   * name via `aria-label`, so screen-reader and hover users always see the
+   * complete value.
+   *
+   * Must be ≥ 8 to leave room for at least one character on each side of the
+   * ellipsis.  Values below 8 are silently clamped to 0 (no truncation).
+   *
+   * @default 0 (no truncation)
+   */
+  maxLabelLength?: number;
 };
 
-function BreadcrumbLink({ item }: { item: BreadcrumbItem }) {
+/**
+ * Shorten `label` to `max` characters using a middle-ellipsis strategy.
+ *
+ * Characters are split roughly half-and-half around the "…" character so that
+ * both the start and end of the label remain visible — useful for long API
+ * path segments where the terminal identifier is just as meaningful as the
+ * root namespace.
+ *
+ * Returns the original string unchanged when:
+ * - `max` is 0 (feature disabled)
+ * - `max` < 8 (not enough room to produce a meaningful result)
+ * - `label.length` ≤ `max`
+ */
+export function truncateMiddle(label: string, max: number): string {
+  if (max < 8 || label.length <= max) return label;
+
+  // Reserve one character for the ellipsis itself.
+  const budget = max - 1; // characters available for actual content
+  const endLen = Math.floor(budget / 2);
+  const startLen = budget - endLen;
+
+  return `${label.slice(0, startLen)}\u2026${label.slice(label.length - endLen)}`;
+}
+
+function BreadcrumbLink({
+  item,
+  displayLabel,
+}: {
+  item: BreadcrumbItem;
+  /** Visually displayed text; may be a middle-truncated version of item.label. */
+  displayLabel: string;
+}) {
+  const isTruncated = displayLabel !== item.label;
+
   if (item.isCurrent) {
     return (
       <span
         className="breadcrumb-current"
         aria-current="page"
+        // Always expose the full label to assistive technology and on hover.
         title={item.label}
+        // When truncated, override the accessible name so screen readers
+        // announce the complete string rather than the ellipsis variant.
+        {...(isTruncated ? { "aria-label": item.label } : {})}
       >
-        {item.label}
+        {displayLabel}
       </span>
     );
   }
 
   return (
-    <a className="breadcrumb-link link-nav" href={item.href} title={item.label}>
-      {item.label}
+    <a
+      className="breadcrumb-link link-nav"
+      href={item.href}
+      title={item.label}
+      {...(isTruncated ? { "aria-label": item.label } : {})}
+    >
+      {displayLabel}
     </a>
   );
 }
@@ -39,7 +95,7 @@ function BreadcrumbSeparator() {
   );
 }
 
-export default function Breadcrumb({ items }: BreadcrumbProps) {
+export default function Breadcrumb({ items, maxLabelLength = 0 }: BreadcrumbProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const ellipsisButtonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -263,11 +319,12 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
           const isFirst = index === 0;
           const isLast = index === items.length - 1;
           const isMiddle = !isFirst && !isLast;
+          const displayLabel = truncateMiddle(item.label, maxLabelLength);
 
           if (isMiddle) {
             return (
               <li className="breadcrumb-item breadcrumb-middle" key={item.href}>
-                <BreadcrumbLink item={item} />
+                <BreadcrumbLink item={item} displayLabel={displayLabel} />
                 <BreadcrumbSeparator />
               </li>
             );
@@ -278,7 +335,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
               className={`breadcrumb-item ${isFirst ? "breadcrumb-first" : ""}`}
               key={item.href}
             >
-              <BreadcrumbLink item={item} />
+              <BreadcrumbLink item={item} displayLabel={displayLabel} />
               {isFirst && shouldCollapseMiddle && (
                 <span className="breadcrumb-collapsed">
                   <BreadcrumbSeparator />
@@ -304,17 +361,29 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                       onKeyDown={handlePopoverKeyDown}
                     >
                       <ol className="breadcrumb-popover-list">
-                        {middleItems.map((middleItem) => (
-                          <li key={middleItem.href} role="none">
-                            <a
-                              className="breadcrumb-popover-link link-nav"
-                              href={middleItem.href}
-                              role="menuitem"
-                            >
-                              {middleItem.label}
-                            </a>
-                          </li>
-                        ))}
+                        {middleItems.map((middleItem) => {
+                          const middleDisplayLabel = truncateMiddle(
+                            middleItem.label,
+                            maxLabelLength,
+                          );
+                          const isTruncated =
+                            middleDisplayLabel !== middleItem.label;
+                          return (
+                            <li key={middleItem.href} role="none">
+                              <a
+                                className="breadcrumb-popover-link link-nav"
+                                href={middleItem.href}
+                                role="menuitem"
+                                title={middleItem.label}
+                                {...(isTruncated
+                                  ? { "aria-label": middleItem.label }
+                                  : {})}
+                              >
+                                {middleDisplayLabel}
+                              </a>
+                            </li>
+                          );
+                        })}
                       </ol>
                     </div>
                   )}

--- a/src/pages/RateLimitCard.test.tsx
+++ b/src/pages/RateLimitCard.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import RateLimitCard from "./RateLimitCard";
+
+/**
+ * RateLimitCard tests – issue #567 (GrantFox FWC26 "Stellar Wave")
+ *
+ * Covers:
+ *  1. Page structure and accessibility
+ *  2. Breadcrumb presence and middle-ellipsis truncation
+ *  3. Rate-limit table content
+ */
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RateLimitCard />
+    </MemoryRouter>,
+  );
+}
+
+describe("RateLimitCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Page structure ────────────────────────────────────────────────────────
+
+  it("renders the page heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /rate limit configuration/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders the API subtitle", () => {
+    renderPage();
+    expect(
+      screen.getByText(/GrantFox Wave Compute API/),
+    ).toBeTruthy();
+  });
+
+  // ── Breadcrumb ────────────────────────────────────────────────────────────
+
+  it("renders an accessible breadcrumb navigation", () => {
+    renderPage();
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(nav).toBeTruthy();
+  });
+
+  it("shows Marketplace as the first breadcrumb link", () => {
+    renderPage();
+    const marketplaceLink = screen.getByRole("link", {
+      name: "Marketplace",
+    });
+    expect(marketplaceLink).toBeTruthy();
+    expect(marketplaceLink.getAttribute("href")).toBe("/marketplace");
+  });
+
+  it("marks the last crumb as the current page", () => {
+    renderPage();
+    const current = document.querySelector<HTMLElement>(
+      '[aria-current="page"]',
+    );
+    expect(current).not.toBeNull();
+    // Visual text may be truncated but aria-current must be present
+    expect(current?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("applies middle-ellipsis truncation to long middle crumb labels", () => {
+    const { container } = renderPage();
+
+    // The two middle crumbs are rendered inside `.breadcrumb-middle` list items
+    // as visible links on desktop, and also inside the popover on mobile.
+    // On desktop they are in .breadcrumb-middle items.
+    const middleItems = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        ".breadcrumb-middle .breadcrumb-link",
+      ),
+    );
+
+    // Both middle labels are long and should be truncated
+    expect(middleItems.length).toBe(2);
+    for (const item of middleItems) {
+      expect(item.textContent).toContain("\u2026");
+    }
+  });
+
+  it("preserves full labels as accessible names on truncated crumbs", () => {
+    const { container } = renderPage();
+
+    const middleLinks = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>(
+        ".breadcrumb-middle .breadcrumb-link",
+      ),
+    );
+
+    const fullLabels = [
+      "GrantFox Wave Compute API – Stellar Edition",
+      "Rate Limits & Throttling Policies",
+    ];
+
+    middleLinks.forEach((link, i) => {
+      // title is always set
+      expect(link.getAttribute("title")).toBe(fullLabels[i]);
+      // aria-label is set when truncated (both labels exceed 28 chars)
+      expect(link.getAttribute("aria-label")).toBe(fullLabels[i]);
+    });
+  });
+
+  // ── Rate-limit table ──────────────────────────────────────────────────────
+
+  it("renders the rate-limit tier table", () => {
+    renderPage();
+    expect(screen.getByRole("table", { name: /rate limit tiers/i })).toBeTruthy();
+  });
+
+  it("shows all four plan tiers", () => {
+    renderPage();
+    for (const plan of ["Free", "Developer", "Pro", "Enterprise"]) {
+      expect(screen.getByText(plan)).toBeTruthy();
+    }
+  });
+
+  it("shows the correct requests-per-minute value for the Free tier", () => {
+    renderPage();
+    // "10" appears in both the Free row (req/min) and Developer row (concurrent),
+    // so we confirm it is present at least once in the table.
+    const cells = screen.getAllByText("10");
+    expect(cells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the throttle note below the table", () => {
+    renderPage();
+    expect(
+      screen.getByText(/rolling 60-second window/i),
+    ).toBeTruthy();
+  });
+});

--- a/src/pages/RateLimitCard.tsx
+++ b/src/pages/RateLimitCard.tsx
@@ -1,0 +1,229 @@
+import Breadcrumb from "../components/Breadcrumb";
+import useDocumentTitle from "../hooks/useDocumentTitle";
+
+/**
+ * RateLimitCard – GrantFox FWC26 campaign "Stellar Wave" (issue #567)
+ *
+ * Displays rate-limit configuration for a deeply nested API endpoint.
+ * The breadcrumb path intentionally contains long segment names to exercise
+ * the middle-ellipsis truncation feature (`maxLabelLength` prop) added to
+ * the Breadcrumb component.
+ *
+ * The breadcrumb trail is:
+ *   Marketplace → GrantFox Wave Compute API (long) → Rate Limits → Current Page
+ *
+ * With `maxLabelLength={28}` the two middle segments are each capped at
+ * 28 characters in the visible label while the full strings remain available
+ * via `title` / `aria-label` for screen readers and on hover.
+ */
+
+/** Rate-limit tier shape used in the table below. */
+type RateLimitTier = {
+  plan: string;
+  requestsPerMinute: number;
+  burstLimit: number;
+  concurrentConnections: number;
+};
+
+const RATE_LIMIT_TIERS: RateLimitTier[] = [
+  {
+    plan: "Free",
+    requestsPerMinute: 10,
+    burstLimit: 20,
+    concurrentConnections: 2,
+  },
+  {
+    plan: "Developer",
+    requestsPerMinute: 120,
+    burstLimit: 200,
+    concurrentConnections: 10,
+  },
+  {
+    plan: "Pro",
+    requestsPerMinute: 600,
+    burstLimit: 1000,
+    concurrentConnections: 50,
+  },
+  {
+    plan: "Enterprise",
+    requestsPerMinute: 6000,
+    burstLimit: 10000,
+    concurrentConnections: 500,
+  },
+];
+
+/**
+ * Breadcrumb path for this page.  Segment labels are deliberately long so the
+ * middle-ellipsis truncation is visible without special configuration.
+ *
+ * Full path (un-truncated):
+ *   Marketplace
+ *     → GrantFox Wave Compute API – Stellar Edition
+ *     → Rate Limits & Throttling Policies
+ *     → Current Plan Configuration  (current page)
+ */
+const BREADCRUMB_ITEMS = [
+  { label: "Marketplace", href: "/marketplace" },
+  {
+    label: "GrantFox Wave Compute API – Stellar Edition",
+    href: "/marketplace/grantfox-wave-compute",
+  },
+  {
+    label: "Rate Limits & Throttling Policies",
+    href: "/marketplace/grantfox-wave-compute/rate-limits",
+  },
+  {
+    label: "Current Plan Configuration",
+    href: "/marketplace/grantfox-wave-compute/rate-limits/config",
+    isCurrent: true,
+  },
+] as const;
+
+/**
+ * Maximum characters before a crumb label is shortened with a middle-ellipsis.
+ * Chosen so the two long middle segments fit comfortably in a single breadcrumb
+ * row even on narrow viewports.
+ */
+const BREADCRUMB_MAX_LABEL = 28;
+
+export default function RateLimitCard() {
+  useDocumentTitle(
+    "Rate Limit Configuration – Callora",
+    "Current rate-limit plan and throttling policies for the GrantFox Wave Compute API.",
+  );
+
+  return (
+    <div className="rate-limit-page">
+      <style>{`
+        .rate-limit-page {
+          padding: 0 32px 48px;
+          max-width: 900px;
+          margin: 0 auto;
+        }
+
+        .rate-limit-card {
+          background: var(--surface);
+          border: 1px solid var(--border, rgba(0, 0, 0, 0.10));
+          border-radius: 12px;
+          padding: 32px;
+        }
+
+        .rate-limit-card-header {
+          margin-bottom: 24px;
+        }
+
+        .rate-limit-card-title {
+          font-size: 1.375rem;
+          font-weight: 700;
+          color: var(--text);
+          margin: 0 0 6px;
+        }
+
+        .rate-limit-card-subtitle {
+          font-size: 0.875rem;
+          color: var(--muted);
+          margin: 0;
+        }
+
+        .rate-limit-table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 0.875rem;
+        }
+
+        .rate-limit-table thead th {
+          text-align: left;
+          padding: 10px 16px;
+          color: var(--muted);
+          font-weight: 600;
+          border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.10));
+          white-space: nowrap;
+        }
+
+        .rate-limit-table tbody td {
+          padding: 12px 16px;
+          color: var(--text);
+          border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.06));
+        }
+
+        .rate-limit-table tbody tr:last-child td {
+          border-bottom: none;
+        }
+
+        .rate-limit-table tbody tr:hover td {
+          background: var(--surface-raised, rgba(0, 0, 0, 0.025));
+        }
+
+        .rate-limit-badge {
+          display: inline-block;
+          padding: 2px 8px;
+          border-radius: 99px;
+          font-size: 0.75rem;
+          font-weight: 600;
+          background: var(--accent-muted, rgba(78, 133, 255, 0.12));
+          color: var(--accent);
+        }
+
+        .rate-limit-note {
+          margin-top: 20px;
+          padding: 12px 16px;
+          background: var(--surface-raised, rgba(0, 0, 0, 0.025));
+          border-radius: 8px;
+          font-size: 0.8125rem;
+          color: var(--muted);
+          line-height: 1.5;
+        }
+      `}</style>
+
+      {/*
+        Breadcrumb uses maxLabelLength={28} so each crumb label is capped at
+        28 characters.  Both long middle-segment names will be shown with a
+        "…" in the middle, preserving the start and end of the real label.
+        The full strings are always in `title` / `aria-label`.
+      */}
+      <Breadcrumb
+        items={BREADCRUMB_ITEMS}
+        maxLabelLength={BREADCRUMB_MAX_LABEL}
+      />
+
+      <div className="rate-limit-card">
+        <div className="rate-limit-card-header">
+          <h1 className="rate-limit-card-title">Rate Limit Configuration</h1>
+          <p className="rate-limit-card-subtitle">
+            GrantFox Wave Compute API – Stellar Edition &nbsp;·&nbsp; FWC26
+          </p>
+        </div>
+
+        <table className="rate-limit-table" aria-label="Rate limit tiers">
+          <thead>
+            <tr>
+              <th scope="col">Plan</th>
+              <th scope="col">Requests / min</th>
+              <th scope="col">Burst limit</th>
+              <th scope="col">Concurrent connections</th>
+            </tr>
+          </thead>
+          <tbody>
+            {RATE_LIMIT_TIERS.map((tier) => (
+              <tr key={tier.plan}>
+                <td>
+                  <span className="rate-limit-badge">{tier.plan}</span>
+                </td>
+                <td>{tier.requestsPerMinute.toLocaleString()}</td>
+                <td>{tier.burstLimit.toLocaleString()}</td>
+                <td>{tier.concurrentConnections.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <p className="rate-limit-note">
+          Limits reset on a rolling 60-second window. Burst allowance is
+          consumed first; sustained throughput is governed by the per-minute
+          quota. Enterprise plans can request custom limits via the support
+          portal.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add truncateMiddle() helper and maxLabelLength prop to Breadcrumb. Full labels are preserved in title and aria-label for accessibility.

Add RateLimitCard page (GrantFox FWC26 / Stellar Wave campaign) that uses a four-segment breadcrumb with two long middle labels to exercise the new truncation feature.

Wire /rate-limit route in App.tsx.

Closes #567