### PR TITLE
fix: ApiCard skeleton parity for FWC26 campaign

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act, within } from "@testing-library/react";
-import ApiCard from "./ApiCard";
+import ApiCard, { ApiCardSkeleton } from "./ApiCard";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React from "react";
 import type { APIItem } from "../data/mockApis";
@@ -295,10 +295,15 @@ describe("ApiCard responsiveness", () => {
   const mockApi: APIItem = {
     id: "api-resp",
     name: "Responsive API",
-    endpoint: "/api/resp",
+    endpoints: ["/api/resp"],
     description: "Responsive test API.",
     tags: ["test"],
     pricePerRequest: 0,
+    provider: {
+      name: "",
+      url: undefined,
+      avatar: undefined
+    }
   };
 
   function mockViewportWidth(isMobile: boolean) {
@@ -347,6 +352,23 @@ describe("ApiCard responsiveness", () => {
     
     const card = screen.getByRole("button", { name: /View details for Responsive API/i });
     expect(card.className).not.toContain("api-card--compact");
+  });
+});
+
+describe("ApiCardSkeleton", () => {
+  it("renders the skeleton correctly with appropriate classes", () => {
+    const { container } = render(<ApiCardSkeleton />);
+    
+    const article = container.querySelector("article.api-card-skeleton");
+    expect(article).toBeTruthy();
+    
+    const tags = container.querySelector(".api-marketplace-card-tags");
+    expect(tags).toBeTruthy();
+    
+    const footer = container.querySelector(".api-marketplace-card-footer");
+    expect(footer).toBeTruthy();
+    
+    expect(screen.getByLabelText("Loading API")).toBeTruthy();
   });
 });
 

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -42,7 +42,7 @@ export function ApiCardSkeleton() {
       }}
     >
       <span className="sr-only">Loading API</span>
-      <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <div className="api-marketplace-card-header" style={{ display: "flex", gap: 12, alignItems: "center" }}>
         <Skeleton tone="stellar" width={56} height={56} borderRadius={10} />
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
@@ -60,6 +60,8 @@ export function ApiCardSkeleton() {
         <div
           style={{
             textAlign: "right",
+            paddingRight: 36,
+            flexShrink: 0,
             display: "flex",
             flexDirection: "column",
             alignItems: "flex-end",
@@ -71,13 +73,28 @@ export function ApiCardSkeleton() {
         </div>
       </div>
 
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+      <div className="api-marketplace-card-tags" style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
         <Skeleton tone="stellar" width={45} height={24} borderRadius={8} />
         <Skeleton tone="stellar" width={55} height={24} borderRadius={8} />
         <Skeleton tone="stellar" width={40} height={24} borderRadius={8} />
       </div>
 
       <div
+        style={{
+          marginTop: 10,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <Skeleton tone="stellar" width={50} height={12} />
+        <Skeleton tone="stellar" width={90} height={28} />
+      </div>
+
+      <div
+        className="api-marketplace-card-footer"
         style={{
           marginTop: "auto",
           display: "flex",
@@ -100,6 +117,7 @@ export function ApiCardSkeleton() {
             justifyContent: "space-between",
             alignItems: "center",
             gap: 12,
+            flexWrap: "wrap",
           }}
         >
           <Skeleton tone="stellar" width={100} height={36} borderRadius={14} />

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -4,9 +4,7 @@ export const DENSITY_STORAGE_KEY = 'callora.density';
 
 const VALID: DensityPreference[] = ['comfortable', 'compact'];
 
-export const DENSITY_STORAGE_KEY = 'callora.density';
-
-export function readDensityPreference(): DensityPreference {
+export const readDensityPreference = (): DensityPreference => {
   try {
     const stored = localStorage.getItem(DENSITY_STORAGE_KEY);
     if (stored && (VALID as string[]).includes(stored)) {


### PR DESCRIPTION
### Description
This PR addresses the UI/UX issue by updating the `ApiCardSkeleton` to achieve strict shape and height parity with the final `ApiCard` component. 

Previously, the skeleton was missing certain structural blocks and inline spacing properties, causing a layout shift when the final API data loaded. 

### Changes Made
- **Layout Parity:** Added the missing "Last 24h" Sparkline placeholder row to the skeleton.
- **Structural Alignment:** Applied `paddingRight: 36`, `flexShrink: 0`, and `flexWrap: "wrap"` to mirroring elements in the skeleton to match the final component's exact dimensions.
- **Class Mapping:** Added `api-marketplace-card-header`, `api-marketplace-card-tags`, and `api-marketplace-card-footer` class names to the skeleton so any cascading CSS styles map 1:1.
- **Tests:** Added a focused `describe("ApiCardSkeleton")` test suite to `ApiCard.test.tsx` to verify the skeleton renders correctly with its expected structural classes.

### Acceptance Criteria Completed
- [x] Implementation matches the description (Skeleton matches the final `ApiCard` height and shape)
- [x] Tests added and passing
- [x] Responsive across all breakpoints (inheriting `ApiCard` classes)

### Testing Instructions
1. Run the test suite: `npm run test` to verify the new `ApiCardSkeleton` tests pass.
2. In the UI, artificially trigger a loading state for the marketplace cards (or throttle network speed) to verify that transitioning from the `ApiCardSkeleton` to the final `ApiCard` results in zero layout shift.

### Related Issue
Closes #403