### PR TITLE
feat: endpoint hover preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - **Global Command Palette**: Instantly jump to views, search APIs by name, cycle/toggle light & dark themes, or trigger vault deposits. Use `Cmd+K` on macOS or `Ctrl+K` on Windows/Linux to open.
 - **Pattern-based status badges**: Status indicators now use distinct textures in addition to color so they remain understandable for color-blind users and in grayscale displays.
 - **Smooth theme transition**: Light/dark switches animate color tokens (background, text, border) over 240 ms instead of snapping. The transition is gated behind a `theme-transitions-ready` class that ThemeProvider adds after the first paint, preventing any flash on load. Animated elements (toasts, skeletons, spinners) are automatically excluded. Use the `.no-theme-transition` escape hatch on any element that must opt out.
+- **Endpoint hover preview**: On the API Detail documentation tab, hovering or focusing an individual endpoint card header reveals a compact floating panel showing the HTTP method badge, endpoint URL, parameter table (name / type / required), and an optional response-shape snippet. Keyboard accessible (Escape dismisses); all colours from design tokens. See `src/components/EndpointPreview.tsx`.
 
 ## Keyboard shortcuts
 
@@ -107,6 +108,8 @@ callora-frontend/
 │   │   ├── CommandPalette_MANUAL_TEST_PLAN.md
 │   │   ├── Dashboard.tsx
 │   │   ├── EmptyState.tsx
+│   │   ├── EndpointGroupHover.tsx
+│   │   ├── EndpointPreview.tsx
 │   │   ├── FiltersSidebar.tsx
 │   │   ├── NotFound.tsx
 │   │   ├── SearchBar.tsx

--- a/docs/UI-Design-System.md
+++ b/docs/UI-Design-System.md
@@ -451,6 +451,94 @@ Interactive documentation helper that previews endpoint groups on hover and keyb
 
 ---
 
+### EndpointPreview
+
+Per-endpoint floating schema preview. Wraps an individual endpoint card header and reveals a compact panel — method badge, URL, parameter table, and optional response shape — when the user hovers or focuses the header row.
+
+Complements `EndpointGroupHover` (group-level overview) by providing **schema-level detail** for each endpoint without requiring navigation to the full docs.
+
+**Props:**
+
+| Prop       | Type                    | Description                                                                                  |
+| ---------- | ----------------------- | -------------------------------------------------------------------------------------------- |
+| `endpoint` | `EndpointPreviewData`   | The endpoint whose schema should be previewed. See type definition below.                    |
+| `children` | `React.ReactNode`       | Content that acts as the hover/focus trigger — typically an endpoint card header row.        |
+
+**`EndpointPreviewData` type:**
+
+```ts
+type EndpointPreviewData = {
+  id: string;
+  title: string;
+  url: string;
+  method: string;           // e.g. "GET", "POST"
+  params: {
+    name: string;
+    type: string;
+    required?: boolean;
+  }[];
+  response?: string;        // Optional JSON response-shape snippet
+  group?: string;
+};
+```
+
+**Visual Spec:**
+
+- Panel: `preview-card` base class, `340px` wide, positioned below the trigger via `top: calc(100% + 6px)`, `z-index: 100`
+- Top-line row: uppercase "Schema preview" eyebrow label (accent colour) + HTTP method badge
+- Endpoint title (`font-weight: 700`) followed by the URL as a `<code>` element
+- **Parameters table**: Name (`var(--accent)` monospace), Type (`.type-tag` chip), Required (Yes/No)
+- Up to 5 parameters shown; excess parameters are replaced with "+N more parameters — see full docs"
+- **Response shape** (optional): `<pre>` block with `var(--surface-soft)` background, `max-height: 120px`, scroll on overflow
+- `pointer-events: none` on the panel — the panel is read-only and must not capture mouse events
+
+**States:**
+
+- Default (closed): No panel; trigger has no `aria-describedby`
+- Hover / Focus (open): Panel appears; trigger gains `aria-describedby` pointing at the panel
+- Escape: Panel closes; focus returns to the trigger trigger without reopening the panel (guarded by a `suppressNextFocus` flag)
+
+**Accessibility (WCAG 2.1 AA):**
+
+- Trigger `div` carries `role="button"`, `tabIndex={0}`, and `aria-label="Preview schema for <title>"`
+- While open: `aria-describedby` on the trigger links to the panel's `id` (generated via `useId`)
+- Panel has `role="tooltip"` and `aria-label="<title> schema preview"` for screen readers
+- Escape key dismisses the panel from any keyboard state
+- Focus ring via `:focus-visible` at `2px solid var(--accent)`, `3px offset`
+- All colours from design tokens — both themes work automatically
+
+**Usage:**
+
+```tsx
+import EndpointPreview from "../components/EndpointPreview";
+
+// Inside a documentation endpoint list:
+{endpoints.map((ep) => (
+  <div key={ep.id} className="preview-card">
+    <EndpointPreview endpoint={ep}>
+      {/* This content becomes the hover/focus trigger */}
+      <div className="endpoint-card-header">
+        <span className={`method-badge method-badge--${ep.method.toLowerCase()}`}>
+          {ep.method}
+        </span>
+        <strong>{ep.title}</strong>
+      </div>
+    </EndpointPreview>
+
+    {/* Full parameter table below, as before */}
+    <div style={{ padding: 24 }}>…</div>
+  </div>
+))}
+```
+
+**Files:**
+
+- Component: `src/components/EndpointPreview.tsx`
+- Tests: `src/components/EndpointPreview.test.tsx` (20 tests)
+- Styles: CSS block in `src/index.css` (`.endpoint-preview__*` classes)
+
+---
+
 ### FiltersSidebar
 
 Sidebar for filtering marketplace results. Rendered inside the desktop layout and also embedded inside the `FiltersBottomSheet` on mobile.

--- a/src/components/EndpointPreview.test.tsx
+++ b/src/components/EndpointPreview.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import EndpointPreview, { type EndpointPreviewData } from "./EndpointPreview";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const FULL_ENDPOINT: EndpointPreviewData = {
+  id: "forecast",
+  title: "Get Forecast",
+  url: "/v1/forecast",
+  method: "GET",
+  params: [
+    { name: "lat", type: "number", required: true },
+    { name: "lon", type: "number", required: true },
+    { name: "units", type: "string", required: false },
+  ],
+  response: '{ "temp_c": 12.3, "conditions": "rain" }',
+};
+
+const NO_PARAMS_ENDPOINT: EndpointPreviewData = {
+  id: "ping",
+  title: "Health Check",
+  url: "/v1/ping",
+  method: "GET",
+  params: [],
+};
+
+const POST_ENDPOINT: EndpointPreviewData = {
+  id: "alerts-create",
+  title: "Create Alert",
+  url: "/v1/alerts",
+  method: "POST",
+  params: [
+    { name: "threshold", type: "number", required: true },
+    { name: "channel", type: "string", required: false },
+  ],
+};
+
+/** Endpoint with more params than MAX_PREVIEW_PARAMS (5) to test overflow. */
+const MANY_PARAMS_ENDPOINT: EndpointPreviewData = {
+  id: "search",
+  title: "Search Records",
+  url: "/v1/search",
+  method: "GET",
+  params: [
+    { name: "q", type: "string", required: true },
+    { name: "page", type: "number", required: false },
+    { name: "limit", type: "number", required: false },
+    { name: "sort", type: "string", required: false },
+    { name: "filter", type: "string", required: false },
+    { name: "lang", type: "string", required: false },
+    { name: "region", type: "string", required: false },
+  ],
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function renderPreview(
+  endpoint: EndpointPreviewData,
+  children = <div>Trigger content</div>,
+) {
+  return render(
+    <EndpointPreview endpoint={endpoint}>{children}</EndpointPreview>,
+  );
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("EndpointPreview", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Initial state ─────────────────────────────────────────────────────────
+
+  it("does not show the panel initially", () => {
+    renderPreview(FULL_ENDPOINT);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("renders the trigger wrapper with an accessible aria-label", () => {
+    renderPreview(FULL_ENDPOINT);
+    expect(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    ).toBeTruthy();
+  });
+
+  // ── Hover (pointer) interaction ───────────────────────────────────────────
+
+  it("shows the panel on mouseEnter and hides it on mouseLeave", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    // Use the wrapper div (endpoint-preview__wrapper) which carries the handlers.
+    const wrapper = screen
+      .getByRole("button", { name: /preview schema for get forecast/i })
+      .closest(".endpoint-preview__wrapper") as HTMLElement;
+
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  // ── Keyboard (focus) interaction ──────────────────────────────────────────
+
+  it("shows the panel when the trigger receives focus", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for get forecast/i,
+    });
+    fireEvent.focus(trigger);
+
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+  });
+
+  it("links the trigger to the panel via aria-describedby while open", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for get forecast/i,
+    });
+    fireEvent.focus(trigger);
+
+    const panel = screen.getByRole("tooltip");
+    expect(trigger.getAttribute("aria-describedby")).toBe(panel.id);
+  });
+
+  it("has no aria-describedby when the panel is closed", () => {
+    renderPreview(FULL_ENDPOINT);
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for get forecast/i,
+    });
+    expect(trigger.getAttribute("aria-describedby")).toBeNull();
+  });
+
+  it("closes on Escape and clears aria-describedby", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for get forecast/i,
+    });
+    fireEvent.focus(trigger);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(trigger.getAttribute("aria-describedby")).toBeNull();
+  });
+
+  // ── Panel content: method badge ───────────────────────────────────────────
+
+  it("shows the method badge with the correct class", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for get forecast/i,
+    });
+    fireEvent.focus(trigger);
+
+    // The method badge text is visible inside the panel.
+    const badges = screen.getAllByText("GET");
+    // At least one badge inside the tooltip panel
+    const panel = screen.getByRole("tooltip");
+    expect(panel.querySelector(".method-badge--get")).toBeTruthy();
+  });
+
+  it("shows the correct method badge class for POST endpoints", () => {
+    renderPreview(POST_ENDPOINT);
+
+    const trigger = screen.getByRole("button", {
+      name: /preview schema for create alert/i,
+    });
+    fireEvent.focus(trigger);
+
+    const panel = screen.getByRole("tooltip");
+    expect(panel.querySelector(".method-badge--post")).toBeTruthy();
+  });
+
+  // ── Panel content: endpoint title and URL ─────────────────────────────────
+
+  it("displays the endpoint title in the panel", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    const panel = screen.getByRole("tooltip");
+    expect(panel).toHaveTextContent("Get Forecast");
+  });
+
+  it("displays the endpoint URL in the panel", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    const panel = screen.getByRole("tooltip");
+    expect(panel).toHaveTextContent("/v1/forecast");
+  });
+
+  // ── Panel content: parameters ─────────────────────────────────────────────
+
+  it("renders the parameters table when params are present", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    expect(screen.getByText("lat")).toBeTruthy();
+    expect(screen.getByText("lon")).toBeTruthy();
+    expect(screen.getByText("units")).toBeTruthy();
+  });
+
+  it("marks required parameters correctly", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    // lat and lon are required; units is not
+    const requiredCells = screen.getAllByText("Yes");
+    expect(requiredCells).toHaveLength(2);
+
+    const optionalCells = screen.getAllByText("No");
+    expect(optionalCells).toHaveLength(1);
+  });
+
+  it("shows type tags for each parameter", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    const panel = screen.getByRole("tooltip");
+    expect(panel).toHaveTextContent("number");
+    expect(panel).toHaveTextContent("string");
+  });
+
+  it("shows 'No parameters' message when the endpoint has no params", () => {
+    renderPreview(NO_PARAMS_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for health check/i }),
+    );
+
+    expect(screen.getByText("No parameters.")).toBeTruthy();
+  });
+
+  it("caps the visible parameter rows at 5 and shows an overflow notice", () => {
+    renderPreview(MANY_PARAMS_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for search records/i }),
+    );
+
+    // First 5 params are visible; 6th and 7th are hidden
+    expect(screen.getByText("q")).toBeTruthy();
+    expect(screen.getByText("page")).toBeTruthy();
+    expect(screen.getByText("limit")).toBeTruthy();
+    expect(screen.getByText("sort")).toBeTruthy();
+    expect(screen.getByText("filter")).toBeTruthy();
+    // "lang" and "region" should NOT appear
+    expect(screen.queryByText("lang")).toBeNull();
+    expect(screen.queryByText("region")).toBeNull();
+
+    // Overflow notice mentions 2 hidden params
+    expect(screen.getByText(/\+2 more parameters — see full docs/i)).toBeTruthy();
+  });
+
+  // ── Panel content: response snippet ──────────────────────────────────────
+
+  it("shows the response shape snippet when provided", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    expect(
+      screen.getByText(/temp_c.*conditions/s),
+    ).toBeTruthy();
+  });
+
+  it("does not render a response section when response is absent", () => {
+    renderPreview(POST_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for create alert/i }),
+    );
+
+    expect(screen.queryByText("Response shape")).toBeNull();
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  it("gives the panel an accessible aria-label that includes the endpoint title", () => {
+    renderPreview(FULL_ENDPOINT);
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: /preview schema for get forecast/i }),
+    );
+
+    const panel = screen.getByRole("tooltip");
+    expect(panel.getAttribute("aria-label")).toMatch(/get forecast schema preview/i);
+  });
+
+  it("renders children inside the trigger zone", () => {
+    renderPreview(
+      FULL_ENDPOINT,
+      <span data-testid="inner-child">Header content</span>,
+    );
+
+    expect(screen.getByTestId("inner-child")).toBeTruthy();
+  });
+});

--- a/src/components/EndpointPreview.tsx
+++ b/src/components/EndpointPreview.tsx
@@ -1,0 +1,224 @@
+/**
+ * EndpointPreview.tsx
+ *
+ * A floating hover-and-focus preview card for an individual API endpoint.
+ * Shows the HTTP method badge, URL, parameter table (name / type / required),
+ * and an optional response-shape snippet — all without navigating away from
+ * the endpoint list.
+ *
+ * Accessibility (WCAG 2.1 AA):
+ * - The trigger row receives `aria-describedby` pointing at the preview panel
+ *   while the preview is open.
+ * - The preview itself has `role="tooltip"` so assistive technology announces
+ *   it as supplementary information rather than as a live region.
+ * - `pointer-events: none` on the panel prevents mouse trapping.
+ * - Pressing Escape closes the preview and returns focus-state cleanly.
+ * - Colours come exclusively from design tokens, so both light and dark themes
+ *   are covered automatically.
+ *
+ * Usage:
+ * ```tsx
+ * <EndpointPreview endpoint={ep} id={`preview-${ep.id}`}>
+ *   <div className="endpoint-card-header">…</div>
+ * </EndpointPreview>
+ * ```
+ */
+
+import { useId, useRef, useState } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type EndpointParam = {
+  name: string;
+  type: string;
+  required?: boolean;
+};
+
+export type EndpointPreviewData = {
+  id: string;
+  title: string;
+  url: string;
+  method: string;
+  params: EndpointParam[];
+  response?: string;
+  group?: string;
+};
+
+type EndpointPreviewProps = {
+  /** The endpoint whose schema should be shown in the preview panel. */
+  endpoint: EndpointPreviewData;
+  /**
+   * The content that acts as the hover/focus trigger — typically an endpoint
+   * card header row.  Receives `aria-describedby` while the preview is open.
+   */
+  children: React.ReactNode;
+};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Maximum number of parameters displayed in the compact preview table. */
+const MAX_PREVIEW_PARAMS = 5;
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function EndpointPreview({
+  endpoint,
+  children,
+}: EndpointPreviewProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const triggerRef = useRef<HTMLDivElement>(null);
+  /**
+   * When the user presses Escape we suppress the next focus event so that
+   * calling `.focus()` to return keyboard position does not immediately
+   * re-open the panel.
+   */
+  const suppressNextFocus = useRef(false);
+
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && open) {
+      suppressNextFocus.current = true;
+      hide();
+      // Return focus to the trigger so keyboard users aren't stranded.
+      triggerRef.current?.focus();
+    }
+  };
+
+  const visibleParams = endpoint.params.slice(0, MAX_PREVIEW_PARAMS);
+  const hiddenParamCount = endpoint.params.length - visibleParams.length;
+  const methodLower = (endpoint.method || "get").toLowerCase();
+
+  return (
+    <div
+      className="endpoint-preview__wrapper"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+    >
+      {/* ── Trigger zone ───────────────────────────────────────────────── */}
+      <div
+        ref={triggerRef}
+        className="endpoint-preview__trigger"
+        aria-describedby={open ? panelId : undefined}
+        onFocus={() => {
+          if (suppressNextFocus.current) {
+            suppressNextFocus.current = false;
+            return;
+          }
+          show();
+        }}
+        onBlur={(event) => {
+          // Only close if focus has left the entire wrapper subtree.
+          if (!event.currentTarget.parentElement?.contains(event.relatedTarget)) {
+            hide();
+          }
+        }}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        role="button"
+        aria-label={`Preview schema for ${endpoint.title}`}
+      >
+        {children}
+      </div>
+
+      {/* ── Preview panel ──────────────────────────────────────────────── */}
+      {open && (
+        <div
+          id={panelId}
+          role="tooltip"
+          className="endpoint-preview__panel preview-card"
+          aria-label={`${endpoint.title} schema preview`}
+          /**
+           * pointer-events: none ensures hovering over the panel itself does
+           * not re-trigger onMouseLeave on the wrapper, which would close the
+           * preview unexpectedly.  The panel is read-only so interaction is
+           * not required.
+           */
+          style={{ pointerEvents: "none" }}
+        >
+          {/* Top-line: eyebrow label + method badge */}
+          <div className="endpoint-preview__topline">
+            <span className="endpoint-preview__eyebrow">Schema preview</span>
+            <span
+              className={`method-badge method-badge--${methodLower}`}
+              aria-label={`${endpoint.method} method`}
+            >
+              {endpoint.method.toUpperCase()}
+            </span>
+          </div>
+
+          {/* Endpoint title and URL */}
+          <p className="endpoint-preview__title">{endpoint.title}</p>
+          <code className="endpoint-preview__url">{endpoint.url}</code>
+
+          {/* Parameter table */}
+          {endpoint.params.length > 0 ? (
+            <div className="endpoint-preview__params">
+              <h6 className="endpoint-preview__section-label">Parameters</h6>
+              <table className="endpoint-preview__table">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Required</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleParams.map((param) => (
+                    <tr key={param.name}>
+                      <td>
+                        <code className="endpoint-preview__param-name">
+                          {param.name}
+                        </code>
+                      </td>
+                      <td>
+                        <span className="type-tag">{param.type}</span>
+                      </td>
+                      <td>
+                        {param.required ? (
+                          <span
+                            className="endpoint-preview__required"
+                            aria-label="required"
+                          >
+                            Yes
+                          </span>
+                        ) : (
+                          <span
+                            className="endpoint-preview__optional"
+                            aria-label="optional"
+                          >
+                            No
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {hiddenParamCount > 0 && (
+                <p className="endpoint-preview__overflow">
+                  +{hiddenParamCount} more parameter
+                  {hiddenParamCount === 1 ? "" : "s"} — see full docs
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="endpoint-preview__no-params">No parameters.</p>
+          )}
+
+          {/* Response snippet (optional) */}
+          {endpoint.response && (
+            <div className="endpoint-preview__response">
+              <h6 className="endpoint-preview__section-label">Response shape</h6>
+              <pre className="endpoint-preview__response-pre">
+                <code>{endpoint.response}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2591,6 +2591,159 @@ code,
   font-size: 0.8125rem;
 }
 
+/* ── EndpointPreview ────────────────────────────────────────────────────────
+   Per-endpoint hover/focus preview card that overlays the endpoint card
+   header.  Uses design tokens throughout so both themes work automatically.
+   ─────────────────────────────────────────────────────────────────────────── */
+.endpoint-preview__wrapper {
+  position: relative;
+}
+
+.endpoint-preview__trigger {
+  /* Remove native focus ring — the :focus-visible ring from focus.css
+     applies automatically via the global selector. */
+  outline: none;
+  border-radius: inherit;
+  cursor: default;
+}
+
+.endpoint-preview__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
+.endpoint-preview__panel {
+  position: absolute;
+  /* Offset below the trigger header row */
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 100;
+  width: 340px;
+  max-width: calc(100vw - 32px);
+  padding: 16px;
+  /* Shadow from existing design system */
+  box-shadow: var(--shadow, 0 24px 80px rgba(3, 8, 22, 0.45));
+}
+
+.endpoint-preview__topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.endpoint-preview__eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.endpoint-preview__title {
+  margin: 0 0 4px;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.endpoint-preview__url {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  margin-bottom: 14px;
+  overflow-wrap: anywhere;
+}
+
+.endpoint-preview__section-label {
+  margin: 0 0 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.endpoint-preview__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.endpoint-preview__table th {
+  text-align: left;
+  padding: 4px 6px 6px 0;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.75rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.endpoint-preview__table td {
+  padding: 7px 6px 7px 0;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+
+.endpoint-preview__table tr:last-child td {
+  border-bottom: none;
+}
+
+.endpoint-preview__param-name {
+  color: var(--accent);
+  font-size: 0.8125rem;
+}
+
+.endpoint-preview__required {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--danger, #ff7d8d);
+}
+
+.endpoint-preview__optional {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.endpoint-preview__overflow {
+  margin: 8px 0 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.endpoint-preview__no-params {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.endpoint-preview__response {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.endpoint-preview__response-pre {
+  margin: 0;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--surface-soft);
+  overflow-x: auto;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--text);
+  max-height: 120px;
+}
+
+.endpoint-preview__params {
+  /* keeps the params section from stretching the panel too tall */
+}
+
 .api-detail-plan-price {
   font-size: 2rem;
   font-weight: 800;

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -12,6 +12,7 @@ import { formatPrice } from "../utils/format";
 import { Icons } from "../utils/icons";
 import { API_BASE_URL, LOADING_DELAY_MS } from "../config/constants";
 import EndpointGroupHover, { type EndpointGroupPreview } from "../components/EndpointGroupHover";
+import EndpointPreview from "../components/EndpointPreview";
 import RatingHistogram from "../components/RatingHistogram";
 import { ApiDetailStickyTOC, type TocSection } from "../components/ApiDetailStickyTOC";
 import { CheckIcon } from "../components/icons";
@@ -744,44 +745,51 @@ print(response.json())`;
                       <div style={{ display: "grid", gap: 20, marginTop: 16 }}>
                         {documentationEndpoints.map((ep: ApiEndpoint, idx) => (
                           <div key={ep.id} className="preview-card" style={{ padding: 0, overflow: "hidden" }}>
-                            <div className="endpoint-card-header">
-                              <div className="endpoint-title-row">
-                                <span className={`method-badge method-badge--${(ep.method || "get").toLowerCase()}`}>{ep.method}</span>
-                                <strong style={{ fontSize: 15 }}>{ep.title}</strong>
-                              </div>
-                              <div className="endpoint-header-actions">
-                                <code className="endpoint-url">{ep.url}</code>
-                                <div className="endpoint-client-buttons">
-                                  <button
-                                    type="button"
-                                    className="icon-button"
-                                    aria-label="Copy Postman import URL"
-                                    title="Open in Postman"
-                                    onClick={() => {
-                                      const url = getPostmanImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
-                                      copyToClipboard(url).then((ok) => showToast(ok ? "Postman import URL copied" : "Failed to copy", ok ? "success" : "error"));
-                                    }}
-                                  >
-                                    <Icons.ExternalLink size={14} />
-                                    <span>Postman</span>
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className="icon-button"
-                                    aria-label="Copy Insomnia import URL"
-                                    title="Open in Insomnia"
-                                    onClick={() => {
-                                      const url = getInsomniaImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
-                                      copyToClipboard(url).then((ok) => showToast(ok ? "Insomnia import URL copied" : "Failed to copy", ok ? "success" : "error"));
-                                    }}
-                                  >
-                                    <Icons.ExternalLink size={14} />
-                                    <span>Insomnia</span>
-                                  </button>
-                                  <EndpointSaveButton endpointId={ep.id} />
+                            {/*
+                              EndpointPreview wraps the card header so that hovering
+                              or focusing it shows a floating schema preview (params,
+                              types, response shape) without navigating away.
+                            */}
+                            <EndpointPreview endpoint={ep}>
+                              <div className="endpoint-card-header">
+                                <div className="endpoint-title-row">
+                                  <span className={`method-badge method-badge--${(ep.method || "get").toLowerCase()}`}>{ep.method}</span>
+                                  <strong style={{ fontSize: 15 }}>{ep.title}</strong>
+                                </div>
+                                <div className="endpoint-header-actions">
+                                  <code className="endpoint-url">{ep.url}</code>
+                                  <div className="endpoint-client-buttons">
+                                    <button
+                                      type="button"
+                                      className="icon-button"
+                                      aria-label="Copy Postman import URL"
+                                      title="Open in Postman"
+                                      onClick={() => {
+                                        const url = getPostmanImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
+                                        copyToClipboard(url).then((ok) => showToast(ok ? "Postman import URL copied" : "Failed to copy", ok ? "success" : "error"));
+                                      }}
+                                    >
+                                      <Icons.ExternalLink size={14} />
+                                      <span>Postman</span>
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="icon-button"
+                                      aria-label="Copy Insomnia import URL"
+                                      title="Open in Insomnia"
+                                      onClick={() => {
+                                        const url = getInsomniaImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
+                                        copyToClipboard(url).then((ok) => showToast(ok ? "Insomnia import URL copied" : "Failed to copy", ok ? "success" : "error"));
+                                      }}
+                                    >
+                                      <Icons.ExternalLink size={14} />
+                                      <span>Insomnia</span>
+                                    </button>
+                                    <EndpointSaveButton endpointId={ep.id} />
+                                  </div>
                                 </div>
                               </div>
-                            </div>
+                            </EndpointPreview>
 
                             <div style={{ padding: 24 }}>
                               {/* id anchors only on first endpoint card */}

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -4,8 +4,6 @@ export const DENSITY_STORAGE_KEY = 'callora.density';
 
 const VALID: DensityPreference[] = ['comfortable', 'compact'];
 
-export const DENSITY_STORAGE_KEY = 'callora.density';
-
 export function readDensityPreference(): DensityPreference {
   try {
     const stored = localStorage.getItem(DENSITY_STORAGE_KEY);


### PR DESCRIPTION
On the API Detail documentation tab, hovering or focusing an individual endpoint card header now reveals a compact floating panel showing:
- HTTP method badge (uses existing .method-badge--* classes)
- Endpoint URL
- Parameter table (name / type / required), capped at 5 rows with an overflow notice for longer lists
- Optional response-shape snippet

Keyboard accessible: Tab to focus, Escape to dismiss (suppresses the subsequent focus event so the panel does not immediately reopen). aria-describedby links the trigger to the panel while it is open. All colours use design tokens so both themes work automatically.

Changes:
- src/components/EndpointPreview.tsx (new) — component + types
- src/components/EndpointPreview.test.tsx (new) — 20 focused tests
- src/pages/ApiDetailPage.tsx — import + wrap each endpoint card header
- src/index.css — .endpoint-preview__* CSS block
- README.md — feature bullet + project layout entry
- docs/UI-Design-System.md — full component spec section
- src/utils/density.ts — fix pre-existing duplicate export (build blocker)

Tests: 66/66 files, 919/919 tests passing
Build: vite build succeeds (1884 modules transformed)

closes #359