### PR TITLE
fix(ApiCard): polish skeleton for height/spacing/shape parity with fi…

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -347,20 +347,62 @@ describe("ApiCard reduced motion", () => {
 describe("ApiCard skeleton", () => {
   it("includes sparkline placeholder to match final card layout", () => {
     render(<ApiCard loading />);
-    // The skeleton should have the sparkline section (24h label + sparkline area)
     const cards = document.querySelectorAll(".api-card-skeleton");
     expect(cards.length).toBe(1);
-    // Verify the skeleton is rendered (not the actual card)
     expect(screen.getByText("Loading API")).toBeTruthy();
   });
 
-  it("includes WhyApi placeholder to match comfortable-mode card shape", () => {
+  it("renders color stripe placeholder matching final card identity stripe", () => {
     const { container } = render(<ApiCard loading />);
-    // The skeleton renders multiple Skeleton blocks — one for the WhyApi section
+    const stripe = container.querySelector('[aria-hidden="true"]')?.closest('span');
+    expect(stripe?.style?.borderRadius).toContain("radius-lg");
+  });
+
+  it("renders action button placeholders at expected positions", () => {
+    const { container } = render(<ApiCard loading />);
+    // 4 absolute-positioned button placeholders (bookmark, pin, favorite, compare)
+    const placeholders = container.querySelectorAll('.skeleton--stellar');
+    // We should have many skeletons; the absolute ones are at z-index 1
+    const absoluteWrappers = container.querySelectorAll('[style*="z-index: 1"]');
+    expect(absoluteWrappers.length).toBe(4);
+  });
+
+  it("renders only one sparkline section (no duplicate)", () => {
+    const { container } = render(<ApiCard loading />);
+    // There should be exactly one sparkline section with width 90
+    const sparklines = container.querySelectorAll('.skeleton--stellar');
+    const width90 = Array.from(sparklines).filter(
+      (el) => (el as HTMLElement).style.width === '90px'
+    );
+    expect(width90.length).toBe(1);
+  });
+
+  it("renders WhyApi placeholder in comfortable mode", () => {
+    const { container } = render(<ApiCard loading />);
+    // In comfortable mode there should be skeleton lines for WhyApi (height 14px)
+    const height14 = container.querySelectorAll('.skeleton--stellar[style*="height: 14px"]');
+    // Description lines + WhyApi lines + stat labels
+    expect(height14.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("hides WhyApi placeholder in compact mode", () => {
+    const { container } = render(<ApiCard loading density="compact" />);
+    // In compact mode, WhyApi is not rendered — fewer total skeletons than comfortable
     const skeletons = container.querySelectorAll(".skeleton--stellar");
-    // Title, provider, description lines, tags, WhyApi lines, sparkline label,
-    // sparkline, 3 stat labels, 3 stat values, CTA, rating
-    expect(skeletons.length).toBeGreaterThanOrEqual(12);
+    // Compact has ~21 skeletons vs comfortable ~26
+    expect(skeletons.length).toBeLessThan(24);
+  });
+
+  it("applies compact class when density is compact", () => {
+    render(<ApiCard loading density="compact" />);
+    const card = document.querySelector('.api-card-skeleton');
+    expect(card?.className).toContain('api-card--compact');
+  });
+
+  it("does not apply compact class in comfortable mode", () => {
+    render(<ApiCard loading density="comfortable" />);
+    const card = document.querySelector('.api-card-skeleton');
+    expect(card?.className).not.toContain('api-card--compact');
   });
 
   it("uses tone stellar for themed skeleton appearance", () => {

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -28,23 +28,61 @@ import { colorFromId } from "../utils/colorFromId";
 
 // ─── Skeleton ────────────────────────────────────────────────────────────────
 
-export function ApiCardSkeleton() {
+export function ApiCardSkeleton({ density = "comfortable" }: { density?: "comfortable" | "compact" } = {}) {
+  const isCompact = density === "compact";
+
   return (
     <article
-      className="preview-card api-marketplace-card api-card-skeleton"
+      className={`preview-card api-marketplace-card api-card-skeleton${isCompact ? " api-card--compact" : ""}`}
       aria-busy="true"
       aria-label="Loading API"
       style={{
-        padding: 12,
+        padding: isCompact ? 10 : 12,
         display: "flex",
         flexDirection: "column",
-        minHeight: 220,
-        gap: 8,
+        minHeight: isCompact ? 188 : 220,
+        gap: isCompact ? 6 : 8,
         border: "1px solid rgba(255,255,255,0.03)",
         pointerEvents: "none",
+        position: "relative",
       }}
     >
       <span className="sr-only">Loading API</span>
+
+      {/* Color stripe placeholder — matches the final card's identity stripe */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: 4,
+          height: "100%",
+          borderRadius: "var(--radius-lg) 0 0 var(--radius-lg)",
+          background: "color-mix(in srgb, var(--accent) 12%, transparent)",
+        }}
+      />
+
+      {/* Bookmark button placeholder */}
+      <div style={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}>
+        <Skeleton tone="stellar" width={32} height={32} borderRadius="50%" />
+      </div>
+
+      {/* Pin button placeholder */}
+      <div style={{ position: "absolute", top: 48, right: 8, zIndex: 1 }}>
+        <Skeleton tone="stellar" width={32} height={32} borderRadius="50%" />
+      </div>
+
+      {/* Favorite button placeholder */}
+      <div style={{ position: "absolute", top: 8, left: 8, zIndex: 1 }}>
+        <Skeleton tone="stellar" width={32} height={32} borderRadius="50%" />
+      </div>
+
+      {/* Compare button placeholder */}
+      <div style={{ position: "absolute", top: 8, left: 48, zIndex: 1 }}>
+        <Skeleton tone="stellar" width={60} height={28} borderRadius={8} />
+      </div>
+
       <div className="api-marketplace-card-header" style={{ display: "flex", gap: 12, alignItems: "center" }}>
         <Skeleton tone="stellar" width={56} height={56} borderRadius={10} />
 
@@ -54,10 +92,12 @@ export function ApiCardSkeleton() {
             <Skeleton tone="stellar" width="20%" height={12} />
           </div>
 
-          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            <Skeleton tone="stellar" width="90%" height={14} />
-            <Skeleton tone="stellar" width="70%" height={14} />
-          </div>
+          {!isCompact && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <Skeleton tone="stellar" width="90%" height={14} />
+              <Skeleton tone="stellar" width="70%" height={14} />
+            </div>
+          )}
         </div>
 
         <div
@@ -84,10 +124,12 @@ export function ApiCardSkeleton() {
 
       {/* WhyApi placeholder — matches the real card's rationale section
           that appears in comfortable mode. */}
-      <div style={{ marginTop: 2, display: "flex", flexDirection: "column", gap: 4 }}>
-        <Skeleton tone="stellar" width="35%" height={12} />
-        <Skeleton tone="stellar" width="80%" height={12} />
-      </div>
+      {!isCompact && (
+        <div style={{ marginTop: 2, display: "flex", flexDirection: "column", gap: 4 }}>
+          <Skeleton tone="stellar" width="35%" height={14} />
+          <Skeleton tone="stellar" width="80%" height={14} />
+        </div>
+      )}
 
       {/* Sparkline section — matches the real card's 24h sparkline
           that appears between tags and stats. */}
@@ -101,20 +143,6 @@ export function ApiCardSkeleton() {
         }}
       >
         <Skeleton tone="stellar" width={52} height={12} />
-        <Skeleton tone="stellar" width={90} height={28} />
-      </div>
-
-      <div
-        style={{
-          marginTop: 10,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 12,
-          flexWrap: "wrap",
-        }}
-      >
-        <Skeleton tone="stellar" width={50} height={12} />
         <Skeleton tone="stellar" width={90} height={28} />
       </div>
 
@@ -583,7 +611,7 @@ export default function ApiCard({
   activeTag?: string | null;
   onBrowse?: () => void;
 }) {
-  if (loading) return <ApiCardSkeleton />;
+  if (loading) return <ApiCardSkeleton density={density} />;
   if (!api) {
     return (
       <EmptyState

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,79 +1,5 @@
 import React from "react";
 
-export default function EmptyState({
-  title = "Nothing here",
-  description,
-  ctaLabel = "Browse APIs",
-  onCta,
-}: {
-  title?: string;
-  description?: string;
-  ctaLabel?: string;
-  onCta?: () => void;
-}) {
-  return (
-    <div
-      role="region"
-      aria-label={title}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: 20,
-        minHeight: 220,
-        gap: 12,
-        textAlign: "center",
-      }}
-    >
-      <svg
-        width="120"
-        height="80"
-        viewBox="0 0 120 80"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <defs>
-          <linearGradient id="g" x1="0" x2="1">
-            <stop offset="0" stopColor="#6EE7B7" />
-            <stop offset="1" stopColor="#60A5FA" />
-          </linearGradient>
-        </defs>
-        <rect x="6" y="10" width="108" height="56" rx="8" fill="url(#g)" opacity="0.14" />
-        <g fill="none" stroke="currentColor" strokeWidth="1.5" opacity="0.9">
-          <path d="M18 54c8-10 22-18 42-18s34 8 42 18" strokeLinecap="round" strokeLinejoin="round" />
-          <circle cx="36" cy="34" r="6" />
-          <circle cx="84" cy="28" r="6" />
-        </g>
-      </svg>
-
-      <h3 style={{ margin: 0, fontSize: 18 }}>{title}</h3>
-
-      {description ? (
-        <p style={{ margin: 0, color: "var(--muted)", maxWidth: 420 }}>{description}</p>
-      ) : (
-        <p style={{ margin: 0, color: "var(--muted)", maxWidth: 420 }}>There are no APIs to show right now.</p>
-      )}
-
-      <button
-        onClick={onCta}
-        style={{
-          marginTop: 8,
-          background: "var(--accent, #4E85FF)",
-          color: "white",
-          border: "none",
-          borderRadius: 8,
-          padding: "8px 14px",
-          fontWeight: 700,
-          cursor: "pointer",
-        }}
-      >
-        {ctaLabel}
-      </button>
-    </div>
-  );
-}
-import React from "react";
 import ExternalLink from "./ExternalLink";
 import { EmptyStateSkeleton } from "./Skeleton";
 
@@ -90,12 +16,18 @@ export interface EmptyStateProps {
   size?: EmptyStateSize;
   title?: string;
   message?: string;
+  /** @deprecated Use `message` instead */
+  description?: string;
   onClearFilters?: () => void;
   onRetry?: () => void | Promise<void>;
   action?: {
     label: string;
     onClick: () => void;
   };
+  /** @deprecated Use `action` instead */
+  ctaLabel?: string;
+  /** @deprecated Use `action.onClick` instead */
+  onCta?: () => void;
   loading?: boolean;
 }
 
@@ -402,16 +334,22 @@ export default function EmptyState({
   size = "default",
   title,
   message,
+  description,
   onClearFilters,
   onRetry,
   action,
+  ctaLabel,
+  onCta,
   loading = false,
 }: EmptyStateProps) {
+  const resolvedMessage = message ?? description;
+  const resolvedAction = action ?? (ctaLabel && onCta ? { label: ctaLabel, onClick: onCta } : undefined);
+
   if (loading) {
     return (
       <EmptyStateSkeleton
         size={size}
-        hasAction={!!action || (variant === "filtered" && !!onClearFilters) || (variant === "error" && !!onRetry)}
+        hasAction={!!resolvedAction || (variant === "filtered" && !!onClearFilters) || (variant === "error" && !!onRetry)}
       />
     );
   }
@@ -453,7 +391,7 @@ export default function EmptyState({
   };
 
   const finalTitle = title ?? defaults[variant].title;
-  const finalMessage = message ?? defaults[variant].message;
+  const finalMessage = resolvedMessage ?? defaults[variant].message;
   const [isRetrying, setIsRetrying] = React.useState(false);
 
   const handleRetry = async () => {
@@ -565,29 +503,14 @@ export default function EmptyState({
 
       <p style={messageStyle}>{finalMessage}</p>
 
-      {action && (
+      {resolvedAction && (
         <button
           className={isCompact ? "ghost-button" : "primary-button"}
-          onClick={action.onClick}
+          onClick={resolvedAction.onClick}
           style={buttonStyle}
           type="button"
         >
-          {action.label}
-        </button>
-      )}
-
-      {secondaryAction && (
-        <button
-          className="ghost-button"
-          onClick={secondaryAction.onClick}
-          style={{
-            ...buttonStyle,
-            minHeight: isCompact ? "32px" : "40px",
-          }}
-          type="button"
-          data-testid="empty-state-secondary-action"
-        >
-          {secondaryAction.label}
+          {resolvedAction.label}
         </button>
       )}
 


### PR DESCRIPTION
…nal card

- Add identity color stripe placeholder matching the real card
- Add absolute-positioned action button placeholders (bookmark, pin, favorite, compare) to prevent layout shift on first paint
- Remove duplicate sparkline section (only one in final card)
- Accept density prop and conditionally hide description/WhyApi in compact mode for consistent skeleton-to-card transition
- Pass density from ApiCard to ApiCardSkeleton

EmptyState fix: resolve duplicate export default and secondaryAction ReferenceError by merging the two EmptyState versions and adding backward-compat props (description, ctaLabel, onCta).

Closes #540