### PR TITLE
feat(RiskGauge): add themed empty-state illustration for risk assessm…

### DIFF
--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -15,7 +15,7 @@ describe("EmptyState", () => {
   });
 
   describe("variants", () => {
-    const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error"];
+    const variants: EmptyStateVariant[] = ["empty", "api-detail", "filtered", "error", "plan-badge", "risk-gauge"];
 
     it.each(variants)("renders the %s variant illustration", (variant) => {
       render(<EmptyState variant={variant} />);
@@ -31,6 +31,8 @@ describe("EmptyState", () => {
         "api-detail": /API not found/i,
         filtered: /No results found/i,
         error: /Failed to load APIs/i,
+        "plan-badge": /No plan selected/i,
+        "risk-gauge": /No risk data yet/i,
       };
       expect(screen.getByText(titles[variant])).toBeTruthy();
     });

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -82,7 +82,8 @@ export type EmptyStateVariant =
   | "api-detail"
   | "filtered"
   | "error"
-  | "plan-badge";
+  | "plan-badge"
+  | "risk-gauge";
 export type EmptyStateSize = "default" | "compact";
 
 export interface EmptyStateProps {
@@ -325,6 +326,75 @@ function EmptyIllustration({
     );
   }
 
+  if (variant === "risk-gauge") {
+    const cx = 32;
+    const cy = 34;
+    const r = 20;
+    const startAngle = -210;
+    const endAngle = 30;
+
+    function polar(angle: number, radius: number) {
+      const rad = ((angle - 90) * Math.PI) / 180;
+      return { x: cx + radius * Math.cos(rad), y: cy + radius * Math.sin(rad) };
+    }
+
+    const arcStart = polar(startAngle, r);
+    const arcEnd = polar(endAngle, r);
+    const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+
+    return (
+      <svg
+        width={box}
+        height={box}
+        viewBox="0 0 64 64"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {/* Gauge arc track */}
+        <path
+          d={`M ${arcStart.x} ${arcStart.y} A ${r} ${r} 0 ${largeArc} 1 ${arcEnd.x} ${arcEnd.y}`}
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth * 0.7}
+          opacity="0.35"
+        />
+        {/* Gauge arc fill (lower half — safer zone) */}
+        <path
+          d={`M ${cx} ${cy} L ${arcStart.x} ${arcStart.y} A ${r} ${r} 0 0 1 ${cx} ${cy + 6} Z`}
+          stroke="var(--accent)"
+          strokeWidth={accentStroke * 0.5}
+          opacity="0.5"
+        />
+        {/* Needle */}
+        <line
+          x1={cx}
+          y1={cy}
+          x2={cx + 3}
+          y2={cy - r + 4}
+          stroke="var(--accent)"
+          strokeWidth={accentStroke}
+        />
+        <circle cx={cx} cy={cy} r={3} stroke="var(--accent)" strokeWidth={accentStroke} />
+        {/* Shield outline behind the gauge */}
+        <path
+          d="M32 6l14 7v12c0 10.5-5.6 19.2-14 23-8.4-3.8-14-12.5-14-23V13l14-7z"
+          stroke="var(--muted)"
+          strokeWidth={strokeWidth * 0.8}
+          opacity="0.6"
+        />
+        {/* Decorative sparkle dots */}
+        <circle cx="16" cy="12" r="1.5" fill="var(--accent)" stroke="none" />
+        <circle cx="48" cy="14" r="1.25" fill="var(--accent)" stroke="none" />
+        <path
+          d="M52 48l2 2M54 52l1.5 1.5"
+          stroke="var(--accent)"
+          strokeWidth={accentStroke}
+        />
+      </svg>
+    );
+  }
+
   return (
     <svg
       width={box}
@@ -375,6 +445,10 @@ function EmptyIllustration({
  *               Shows a medal-and-ribbon illustration with a "Choose a plan" CTA
  *               so users can select a tier (free/pro/enterprise) and begin receiving
  *               calls.  Used by the PlanBadge page (issue #529).
+ * - risk-gauge: No risk assessment data is available yet.
+ *               Shows a shield-and-gauge illustration with a "Run assessment" CTA
+ *               so users can evaluate their API risk profile.  Used by the
+ *               RiskGauge page (issue #664).
  *
  * Sizes:
  * - default:  Full-size layout for result areas (48px padding, 80px illustration).
@@ -449,6 +523,18 @@ export default function EmptyState({
         size === "compact"
           ? "Choose a plan to unlock API access."
           : "This API doesn't have a plan attached yet. Select a plan tier to set rate limits and start receiving calls.",
+    },
+    /**
+     * risk-gauge variant — shown on the RiskGauge page when no risk
+     * assessment data is available yet.  The CTA guides users toward
+     * running their first risk assessment (issue #664).
+     */
+    "risk-gauge": {
+      title: "No risk data yet",
+      message:
+        size === "compact"
+          ? "Run an assessment to evaluate your API risk profile."
+          : "Run a risk assessment to evaluate your API's security, reliability, and compliance posture.",
     },
   };
 

--- a/src/pages/RiskGauge.test.tsx
+++ b/src/pages/RiskGauge.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RiskGaugePage from "./RiskGauge";
+import React from "react";
+
+vi.mock("../hooks/useDocumentTitle", () => ({
+  default: () => {},
+}));
+
+describe("RiskGaugePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the page header", () => {
+    render(<RiskGaugePage />);
+    expect(screen.getByText("Risk Assessment")).toBeTruthy();
+    expect(screen.getByText("API Risk Profile")).toBeTruthy();
+  });
+
+  it("renders empty state when no assessment data is available", () => {
+    render(<RiskGaugePage />);
+    expect(screen.getByText("No risk data yet")).toBeTruthy();
+    expect(screen.getByText("Run assessment")).toBeTruthy();
+  });
+
+  it("renders risk-gauge variant empty state with themed illustration", () => {
+    const { container } = render(<RiskGaugePage />);
+    const emptyState = container.querySelector('[data-testid="empty-state-risk-gauge"]');
+    expect(emptyState).toBeTruthy();
+    const svg = emptyState?.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("displays assessment results after clicking Run assessment", () => {
+    render(<RiskGaugePage />);
+    const runBtn = screen.getByText("Run assessment");
+    fireEvent.click(runBtn);
+    expect(screen.getByText("Breakdown")).toBeTruthy();
+    expect(screen.getByText("Re-assess")).toBeTruthy();
+    expect(screen.getByText("Clear results")).toBeTruthy();
+  });
+
+  it("shows metric rows after assessment runs", () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    expect(screen.getByText("Reliability")).toBeTruthy();
+    expect(screen.getByText("Security")).toBeTruthy();
+    expect(screen.getByText("Compliance")).toBeTruthy();
+    expect(screen.getByText("Latency")).toBeTruthy();
+  });
+
+  it("returns to empty state after clearing results", () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    expect(screen.queryByText("No risk data yet")).toBeNull();
+    fireEvent.click(screen.getByText("Clear results"));
+    expect(screen.getByText("No risk data yet")).toBeTruthy();
+    expect(screen.getByText("Run assessment")).toBeTruthy();
+  });
+
+  it("re-runs assessment when Re-assess is clicked", () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    fireEvent.click(screen.getByText("Re-assess"));
+    // Should still show results after re-assessment
+    expect(screen.getByText("Breakdown")).toBeTruthy();
+  });
+
+  it("renders accessible progress bars for metrics", () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    const progressbars = document.querySelectorAll('[role="progressbar"]');
+    expect(progressbars.length).toBe(4);
+    progressbars.forEach((bar) => {
+      expect(bar.getAttribute("aria-valuemin")).toBe("0");
+      expect(bar.getAttribute("aria-valuemax")).toBe("100");
+    });
+  });
+
+  it("renders gauge SVG with correct ARIA label", () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    const gauge = document.querySelector('[role="img"]');
+    expect(gauge).toBeTruthy();
+    expect(gauge?.getAttribute("aria-label")).toContain("Risk score");
+  });
+});

--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useId, useState } from "react";
+import EmptyState from "../components/EmptyState";
+import useDocumentTitle from "../hooks/useDocumentTitle";
+
+export type RiskLevel = "low" | "moderate" | "high" | "critical";
+
+export interface RiskAssessment {
+  score: number;
+  level: RiskLevel;
+  reliability: number;
+  security: number;
+  compliance: number;
+  latency: number;
+  notes: string;
+}
+
+const RISK_LABELS: Record<RiskLevel, string> = {
+  low: "Low Risk",
+  moderate: "Moderate Risk",
+  high: "High Risk",
+  critical: "Critical Risk",
+};
+
+const RISK_COLORS: Record<RiskLevel, string> = {
+  low: "#22c55e",
+  moderate: "#eab308",
+  high: "#f97316",
+  critical: "#ef4444",
+};
+
+function riskLevel(score: number): RiskLevel {
+  if (score < 25) return "low";
+  if (score < 50) return "moderate";
+  if (score < 75) return "high";
+  return "critical";
+}
+
+const ANGLE_RANGE = 240;
+const ANGLE_OFFSET = -210;
+
+function polar(angle: number, radius: number, cx: number, cy: number) {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return { x: cx + radius * Math.cos(rad), y: cy + radius * Math.sin(rad) };
+}
+
+function GaugeArc({
+  score,
+  size = 160,
+}: {
+  score: number;
+  size?: number;
+}) {
+  const cx = size / 2;
+  const cy = size / 2 + 6;
+  const r = size * 0.38;
+  const strokeW = size * 0.08;
+  const level = riskLevel(score);
+  const color = RISK_COLORS[level];
+
+  const angle = ANGLE_OFFSET + (score / 100) * ANGLE_RANGE;
+  const start = polar(ANGLE_OFFSET, r, cx, cy);
+  const end = polar(angle, r, cx, cy);
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={`Risk score: ${score} out of 100, ${RISK_LABELS[level]}`}
+      style={{ display: "block" }}
+    >
+      {/* Background arc */}
+      <path
+        d={`M ${start.x} ${start.y} A ${r} ${r} 0 1 1 ${polar(ANGLE_OFFSET + ANGLE_RANGE, r, cx, cy).x} ${polar(ANGLE_OFFSET + ANGLE_RANGE, r, cx, cy).y}`}
+        stroke="var(--line)"
+        strokeWidth={strokeW}
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.25"
+      />
+      {/* Filled arc */}
+      <path
+        d={`M ${start.x} ${start.y} A ${r} ${r} 0 ${angle > 0 ? 0 : 0} 1 ${end.x} ${end.y}`}
+        stroke={color}
+        strokeWidth={strokeW}
+        fill="none"
+        strokeLinecap="round"
+      />
+      {/* Score text */}
+      <text
+        x={cx}
+        y={cy - 4}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="var(--text)"
+        fontSize={size * 0.2}
+        fontWeight="700"
+        fontFamily="var(--font-family)"
+      >
+        {score}
+      </text>
+      <text
+        x={cx}
+        y={cy + size * 0.1}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={color}
+        fontSize={size * 0.065}
+        fontWeight="600"
+        fontFamily="var(--font-family)"
+      >
+        {RISK_LABELS[level]}
+      </text>
+    </svg>
+  );
+}
+
+function MetricRow({
+  label,
+  value,
+  max = 100,
+}: {
+  label: string;
+  value: number;
+  max?: number;
+}) {
+  const pct = Math.min(Math.max(value, 0), max);
+  const barPct = (pct / max) * 100;
+  const id = useId();
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+      }}
+    >
+      <span
+        id={id}
+        style={{
+          width: "90px",
+          flexShrink: 0,
+          color: "var(--muted)",
+          fontSize: "0.8125rem",
+          fontWeight: 600,
+        }}
+      >
+        {label}
+      </span>
+      <div
+        role="progressbar"
+        aria-labelledby={id}
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuetext={`${label}: ${pct} out of ${max}`}
+        style={{
+          flex: 1,
+          height: "8px",
+          borderRadius: "4px",
+          background: "var(--line)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${barPct}%`,
+            height: "100%",
+            borderRadius: "4px",
+            background: pct >= 75 ? "var(--danger)" : pct >= 50 ? "var(--warning)" : "var(--accent)",
+            transition: "width 400ms ease",
+          }}
+        />
+      </div>
+      <span
+        style={{
+          width: "48px",
+          textAlign: "right",
+          color: "var(--text)",
+          fontSize: "0.875rem",
+          fontWeight: 600,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {pct}
+      </span>
+    </div>
+  );
+}
+
+export default function RiskGaugePage() {
+  useDocumentTitle(
+    "Risk Assessment – Callora",
+    "Evaluate your API security, reliability, and compliance risk profile."
+  );
+
+  const [assessment, setAssessment] = useState<RiskAssessment | null>(null);
+
+  const runAssessment = useCallback(() => {
+    setAssessment({
+      score: 34,
+      level: "moderate",
+      reliability: 88,
+      security: 72,
+      compliance: 65,
+      latency: 42,
+      notes: "Overall API health is acceptable. Consider improving compliance documentation and monitoring endpoint latency.",
+    });
+  }, []);
+
+  const clearAssessment = useCallback(() => {
+    setAssessment(null);
+  }, []);
+
+  return (
+    <div
+      className="risk-gauge-page"
+      style={{ padding: "clamp(16px, 4vw, 32px) 0" }}
+    >
+      <header style={{ marginBottom: "32px", padding: "0 4px" }}>
+        <p className="eyebrow">API Risk Profile</p>
+        <h1
+          style={{
+            margin: "0 0 12px",
+            fontSize: "clamp(1.8rem, 3vw, 2.4rem)",
+            fontWeight: "700",
+            color: "var(--text)",
+          }}
+        >
+          Risk Assessment
+        </h1>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "1rem",
+            color: "var(--muted)",
+            lineHeight: "1.65",
+            maxWidth: "600px",
+          }}
+        >
+          Evaluate your API&apos;s security, reliability, and compliance posture.
+          Run an assessment to identify areas for improvement.
+        </p>
+      </header>
+
+      {assessment === null ? (
+        <section
+          className="surface"
+          aria-labelledby="risk-gauge-empty-heading"
+          style={{ borderRadius: "16px", overflow: "hidden" }}
+        >
+          <EmptyState
+            variant="risk-gauge"
+            title="No risk data yet"
+            message="Run a risk assessment to evaluate your API's security, reliability, and compliance posture."
+            action={{
+              label: "Run assessment",
+              onClick: runAssessment,
+            }}
+          />
+        </section>
+      ) : (
+        <section
+          className="surface"
+          style={{
+            borderRadius: "16px",
+            padding: "clamp(20px, 3vw, 32px)",
+            display: "grid",
+            gap: "28px",
+          }}
+          aria-label="Risk assessment results"
+        >
+          {/* Gauge + Summary */}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "24px",
+              alignItems: "center",
+            }}
+          >
+            <GaugeArc score={assessment.score} />
+            <div style={{ flex: 1, minWidth: "200px" }}>
+              <p
+                style={{
+                  margin: "0 0 8px",
+                  fontSize: "0.9375rem",
+                  color: "var(--muted)",
+                  lineHeight: "1.6",
+                }}
+              >
+                {assessment.notes}
+              </p>
+            </div>
+          </div>
+
+          {/* Metric breakdown */}
+          <div
+            style={{
+              display: "grid",
+              gap: "14px",
+            }}
+          >
+            <h2
+              style={{
+                margin: 0,
+                fontSize: "0.875rem",
+                fontWeight: 700,
+                color: "var(--muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+              }}
+            >
+              Breakdown
+            </h2>
+            <MetricRow label="Reliability" value={assessment.reliability} />
+            <MetricRow label="Security" value={assessment.security} />
+            <MetricRow label="Compliance" value={assessment.compliance} />
+            <MetricRow label="Latency" value={assessment.latency} />
+          </div>
+
+          {/* Actions */}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "12px",
+              justifyContent: "flex-end",
+              borderTop: "1px solid var(--line)",
+              paddingTop: "20px",
+            }}
+          >
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={clearAssessment}
+              aria-label="Clear assessment results"
+            >
+              Clear results
+            </button>
+            <button
+              type="button"
+              className="primary-button"
+              onClick={runAssessment}
+              aria-label="Re-run risk assessment"
+            >
+              Re-assess
+            </button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION

- Add 'risk-gauge' variant to EmptyState with shield-and-gauge SVG illustration matching the v7 line-art design language
- Create RiskGauge page with arc gauge visualization, risk score, level labelling (low/moderate/high/critical), and four metric breakdown rows (reliability, security, compliance, latency)
- Empty state shows themed illustration and 'Run assessment' CTA; results view includes accessible progress bars and re-assess action
- Add 9 focused tests for RiskGauge page and extend EmptyState tests to cover the new variant

Closes #664 