### PR TITLE
feat: ApiDetailPage skeleton

### DIFF
--- a/src/ApiUsage.test.tsx.bak
+++ b/src/ApiUsage.test.tsx.bak
@@ -1,5 +1,0 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import ApiUsage from './ApiUsage';
-
-// Mock dependencies

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Routes, Route, NavLink, useNavigate, useLocation } from "react-router-dom";
 import { ThemeToggle } from "./ThemeToggle";
-import ApiUsage from "./ApiUsage";
+import ApiUsage from "./pages/ApiUsage";
 import Dashboard from "./components/Dashboard";
 import MyApis from "./pages/MyApis";
 import RouteProgressBar from "./components/RouteProgressBar";

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, Fragment } from "react";
+import Breadcrumb from "./Breadcrumb";
 
 interface SkeletonProps {
   width?: string | number;
@@ -201,6 +202,87 @@ export function ApiUsageSkeleton() {
             <Skeleton tone="stellar" width="60%" height={14} />
             <Skeleton tone="stellar" width="75%" height={14} />
             <Skeleton tone="stellar" width="40%" height={14} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ApiDetailPageSkeleton({ onBack }: { onBack?: () => void }) {
+  return (
+    <div
+      className="api-detail-page"
+      aria-busy="true"
+      aria-label="API detail loading shell"
+    >
+      <div className="api-detail-container">
+        <Breadcrumb
+          items={[
+            { label: "Marketplace", href: "/marketplace" },
+            { label: "Loading…", href: "", isCurrent: true },
+          ]}
+        />
+        <div className="api-detail-shell">
+          <div className="api-detail-hero">
+            <div className="api-detail-heading">
+              <button className="ghost-button no-print" onClick={onBack} type="button">
+                Back
+              </button>
+              <div className="api-detail-brand" style={{ display: "flex", gap: 12, alignItems: "center" }}>
+                <Skeleton tone="stellar" width={56} height={56} borderRadius={10} />
+                <div className="api-detail-title" style={{ flex: 1, display: "grid", gap: 8 }}>
+                  <Skeleton tone="stellar" width="60%" height={32} />
+                  <Skeleton tone="stellar" width="40%" height={16} />
+                </div>
+              </div>
+            </div>
+            <div className="api-detail-price-panel" style={{ display: "grid", gap: 8 }}>
+              <Skeleton tone="stellar" width={100} height={32} />
+              <Skeleton tone="stellar" width={120} height={14} />
+              <Skeleton tone="stellar" width="100%" height={44} borderRadius={8} />
+            </div>
+          </div>
+
+          <div className="api-detail-content-grid">
+            <div className="content-left">
+              <nav className="api-detail-tabs no-print" style={{ display: "flex", gap: 24, marginBottom: 16 }}>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton tone="stellar" key={i} width={80} height={20} />
+                ))}
+              </nav>
+              <div className="api-detail-metrics" style={{ display: "flex", gap: 16 }}>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="stat-card-skeleton" style={{ padding: 20, flex: 1, display: "grid", gap: 12 }}>
+                    <Skeleton tone="stellar" width="40%" height={12} />
+                    <Skeleton tone="stellar" width="60%" height={28} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <aside className="api-detail-sidebar no-print">
+              <div className="api-detail-sidebar-inner" style={{ display: "grid", gap: 20 }}>
+                <div className="stat-card-skeleton" style={{ padding: 24, display: "grid", gap: 12 }}>
+                  <Skeleton tone="stellar" width="50%" height={20} />
+                  <Skeleton tone="stellar" width="100%" height={16} />
+                  <Skeleton tone="stellar" width="100%" height={16} />
+                  <Skeleton tone="stellar" width="100%" height={16} />
+                </div>
+                <div className="preview-card-skeleton" style={{ padding: 24, display: "grid", gap: 12 }}>
+                  <Skeleton tone="stellar" width="50%" height={20} />
+                  <Skeleton tone="stellar" width="100%" height={36} />
+                  <Skeleton tone="stellar" width="100%" height={36} />
+                  <Skeleton tone="stellar" width="100%" height={36} />
+                </div>
+                <div style={{ padding: 24, borderRadius: 16, border: "1px solid var(--line)", display: "grid", gap: 12 }}>
+                  <Skeleton tone="stellar" width="50%" height={20} />
+                  <Skeleton tone="stellar" width="100%" height={14} />
+                  <Skeleton tone="stellar" width="100%" height={14} />
+                  <Skeleton tone="stellar" width="100%" height={44} borderRadius={8} />
+                </div>
+              </div>
+            </aside>
           </div>
         </div>
       </div>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -74,3 +74,138 @@ export function FiltersSidebarSkeleton() {
   );
 }
 
+export function ApiUsageSkeleton() {
+  return (
+    <div
+      className="api-usage-page"
+      aria-busy="true"
+      aria-label="API usage loading shell"
+    >
+      {/* Breadcrumb Skeleton */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 24 }} aria-hidden="true">
+        <Skeleton tone="stellar" width={80} height={16} />
+        <span style={{ color: "var(--text-secondary)" }}>/</span>
+        <Skeleton tone="stellar" width={160} height={16} />
+      </div>
+
+      {/* Header Section Skeleton */}
+      <div className="api-header" aria-hidden="true" style={{ marginBottom: 24 }}>
+        <div className="api-header-info" style={{ display: "flex", gap: 16, alignItems: "center" }}>
+          <div className="api-logo">
+            <Skeleton tone="stellar" width={56} height={56} borderRadius={12} />
+          </div>
+          <div style={{ display: "grid", gap: 8, flex: 1 }}>
+            <Skeleton tone="stellar" width="40%" height={28} />
+            <Skeleton tone="stellar" width="60%" height={16} />
+          </div>
+        </div>
+        <div className="api-header-actions" style={{ display: "flex", gap: 12 }}>
+          <Skeleton tone="stellar" width={150} height={36} borderRadius={8} />
+          <Skeleton tone="stellar" width={90} height={36} borderRadius={8} />
+          <Skeleton tone="stellar" width={110} height={36} borderRadius={8} />
+        </div>
+      </div>
+
+      {/* API Key Section Skeleton */}
+      <div className="surface api-key-section" aria-hidden="true" style={{ marginBottom: 24 }}>
+        <Skeleton tone="stellar" width={100} height={20} style={{ marginBottom: 16 }} />
+        <div className="api-key-card" style={{ padding: 20 }}>
+          <div className="api-key-display" style={{ display: "flex", gap: 12, alignItems: "center" }}>
+            <div className="key-input-group" style={{ flex: 1 }}>
+              <Skeleton tone="stellar" width="100%" height={38} borderRadius={8} />
+            </div>
+            <div className="key-actions" style={{ display: "flex", gap: 12 }}>
+              <Skeleton tone="stellar" width={80} height={38} borderRadius={8} />
+              <Skeleton tone="stellar" width={100} height={38} borderRadius={8} />
+            </div>
+          </div>
+          <Skeleton tone="stellar" width="50%" height={14} style={{ marginTop: 12 }} />
+        </div>
+      </div>
+
+      {/* Test API Call Section Skeleton */}
+      <div className="surface test-call-section" aria-hidden="true" style={{ marginBottom: 24 }}>
+        <Skeleton tone="stellar" width={140} height={20} style={{ marginBottom: 20 }} />
+        <div className="test-call-form" style={{ display: "grid", gap: 16 }}>
+          <div className="form-row" style={{ display: "grid", gap: 8 }}>
+            <Skeleton tone="stellar" width={70} height={14} />
+            <Skeleton tone="stellar" width="100%" height={38} borderRadius={8} />
+          </div>
+          <div className="form-row" style={{ display: "grid", gap: 8 }}>
+            <Skeleton tone="stellar" width={90} height={14} />
+            <Skeleton tone="stellar" width="100%" height={120} borderRadius={8} />
+          </div>
+          <div style={{ display: "flex", gap: 12 }}>
+            <Skeleton tone="stellar" width={130} height={38} borderRadius={8} />
+            <Skeleton tone="stellar" width={130} height={38} borderRadius={8} />
+          </div>
+        </div>
+      </div>
+
+      {/* Usage Statistics Section Skeleton */}
+      <div className="surface usage-stats-section" aria-hidden="true" style={{ marginBottom: 24 }}>
+        <Skeleton tone="stellar" width={150} height={20} style={{ marginBottom: 20 }} />
+        <div className="stats-grid">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="stat-card" style={{ display: "grid", gap: 8, padding: 16 }}>
+              <Skeleton tone="stellar" width="60%" height={12} />
+              <Skeleton tone="stellar" width="80%" height={24} />
+            </div>
+          ))}
+        </div>
+        <div className="mini-chart" style={{ marginTop: 24 }}>
+          <Skeleton tone="stellar" width={130} height={16} style={{ marginBottom: 16 }} />
+          <Skeleton tone="stellar" width="100%" height={160} borderRadius={8} />
+        </div>
+      </div>
+
+      {/* Call History Section Skeleton */}
+      <div className="surface call-history-section" aria-hidden="true" style={{ marginBottom: 24 }}>
+        <div className="section-header" style={{ display: "flex", justifyContent: "space-between", marginBottom: 20, flexWrap: "wrap", gap: 12 }}>
+          <Skeleton tone="stellar" width={120} height={20} />
+          <div className="history-actions" style={{ display: "flex", gap: 12, alignItems: "center" }}>
+            <Skeleton tone="stellar" width={220} height={38} borderRadius={8} />
+            <Skeleton tone="stellar" width={100} height={38} borderRadius={8} />
+            <Skeleton tone="stellar" width={100} height={38} borderRadius={8} />
+            <Skeleton tone="stellar" width={100} height={38} borderRadius={8} />
+          </div>
+        </div>
+        <div className="call-history-table">
+          <div className="table-header">
+            <span>Timestamp</span>
+            <span>Endpoint</span>
+            <span>Status</span>
+            <span>Response Time</span>
+            <span>Cost</span>
+            <span>Actions</span>
+          </div>
+          <SkeletonRow rows={5} />
+        </div>
+      </div>
+
+      {/* Integration Guide Section Skeleton */}
+      <div className="surface integration-guide-section" aria-hidden="true">
+        <Skeleton tone="stellar" width={160} height={20} style={{ marginBottom: 20 }} />
+        <div className="language-tabs" style={{ display: "flex", gap: 12, marginBottom: 16 }}>
+          <Skeleton tone="stellar" width={100} height={36} borderRadius={8} />
+          <Skeleton tone="stellar" width={80} height={36} borderRadius={8} />
+          <Skeleton tone="stellar" width={70} height={36} borderRadius={8} />
+        </div>
+        <div className="code-example">
+          <div className="code-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px" }}>
+            <Skeleton tone="stellar" width={150} height={16} />
+            <Skeleton tone="stellar" width={90} height={32} borderRadius={6} />
+          </div>
+          <div className="code-block" style={{ padding: 20, display: "grid", gap: 10 }}>
+            <Skeleton tone="stellar" width="85%" height={14} />
+            <Skeleton tone="stellar" width="60%" height={14} />
+            <Skeleton tone="stellar" width="75%" height={14} />
+            <Skeleton tone="stellar" width="40%" height={14} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/src/pages/ApiDetailPage.skeleton.test.tsx
+++ b/src/pages/ApiDetailPage.skeleton.test.tsx
@@ -16,5 +16,6 @@ describe("ApiDetailPageSkeleton", () => {
     expect(container.querySelector(".api-detail-tabs")).toBeTruthy();
     expect(container.querySelectorAll(".stat-card-skeleton").length).toBe(3);
     expect(container.querySelectorAll(".preview-card-skeleton").length).toBe(3);
+    expect(container.querySelectorAll(".skeleton--stellar").length).toBeGreaterThan(0);
   });
 });

--- a/src/pages/ApiDetailPage.skeleton.tsx
+++ b/src/pages/ApiDetailPage.skeleton.tsx
@@ -7,11 +7,11 @@ function SidebarCardSkeleton() {
       style={{ padding: 24, display: "grid", gap: 12 }}
       aria-hidden="true"
     >
-      <Skeleton width="58%" height={20} />
-      <Skeleton width="100%" height={14} />
-      <Skeleton width="100%" height={14} />
-      <Skeleton width="72%" height={14} />
-      <Skeleton width="100%" height={40} borderRadius={10} />
+      <Skeleton tone="stellar" width="58%" height={20} />
+      <Skeleton tone="stellar" width="100%" height={14} />
+      <Skeleton tone="stellar" width="100%" height={14} />
+      <Skeleton tone="stellar" width="72%" height={14} />
+      <Skeleton tone="stellar" width="100%" height={40} borderRadius={10} />
     </div>
   );
 }
@@ -25,28 +25,28 @@ export default function ApiDetailPageSkeleton() {
     >
       <div className="api-detail-container">
         <div style={{ display: "grid", gap: 16, marginBottom: 16 }}>
-          <Skeleton width="38%" height={16} />
-          <Skeleton width="26%" height={16} />
+          <Skeleton tone="stellar" width="38%" height={16} />
+          <Skeleton tone="stellar" width="26%" height={16} />
         </div>
 
         <div className="api-detail-shell">
           <div className="api-detail-hero">
             <div className="api-detail-heading">
-              <Skeleton width={72} height={36} borderRadius={10} />
+              <Skeleton tone="stellar" width={72} height={36} borderRadius={10} />
 
               <div className="api-detail-brand" style={{ display: "flex", gap: 12, alignItems: "center", flex: 1 }}>
-                <Skeleton width={56} height={56} borderRadius={12} />
+                <Skeleton tone="stellar" width={56} height={56} borderRadius={12} />
                 <div className="api-detail-title" style={{ flex: 1, display: "grid", gap: 10 }}>
-                  <Skeleton width="62%" height={32} />
-                  <Skeleton width="42%" height={16} />
+                  <Skeleton tone="stellar" width="62%" height={32} />
+                  <Skeleton tone="stellar" width="42%" height={16} />
                 </div>
               </div>
             </div>
 
             <div className="api-detail-price-panel" style={{ display: "grid", gap: 10 }}>
-              <Skeleton width="55%" height={32} />
-              <Skeleton width="70%" height={14} />
-              <Skeleton width="100%" height={44} borderRadius={8} />
+              <Skeleton tone="stellar" width="55%" height={32} />
+              <Skeleton tone="stellar" width="70%" height={14} />
+              <Skeleton tone="stellar" width="100%" height={44} borderRadius={8} />
             </div>
           </div>
 
@@ -54,15 +54,15 @@ export default function ApiDetailPageSkeleton() {
             <div className="content-left">
               <nav className="api-detail-tabs no-print" aria-hidden="true" style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
                 {Array.from({ length: 5 }).map((_, index) => (
-                  <Skeleton key={index} width={88} height={20} />
+                  <Skeleton tone="stellar" key={index} width={88} height={20} />
                 ))}
               </nav>
 
               <div className="api-detail-metrics">
                 {Array.from({ length: 3 }).map((_, index) => (
                   <div key={index} className="stat-card-skeleton" style={{ padding: 20, display: "grid", gap: 12 }}>
-                    <Skeleton width="42%" height={12} />
-                    <Skeleton width="62%" height={28} />
+                    <Skeleton tone="stellar" width="42%" height={12} />
+                    <Skeleton tone="stellar" width="62%" height={28} />
                   </div>
                 ))}
               </div>

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useRef, useCallback } from "react";
 import CodeExample from "../components/CodeExample";
 import Breadcrumb from "../components/Breadcrumb";
 import TestInBrowser from "../components/TestInBrowser";
-import Skeleton from "../components/Skeleton";
+import Skeleton, { ApiDetailPageSkeleton } from "../components/Skeleton";
 import EmbedPreview from "../components/EmbedPreview";
 import Tabs from "../components/Tabs";
 import useDocumentTitle from "../hooks/useDocumentTitle";
@@ -473,80 +473,7 @@ export default function ApiDetailPage({ onBack }: Props) {
   // ── Skeleton loading ──────────────────────────────────────────────────────
 
   if (isLoading) {
-    return (
-      <div className="api-detail-page">
-        <div className="api-detail-container">
-          <Breadcrumb
-            items={[
-              { label: "Marketplace", href: "/marketplace" },
-              { label: "Loading…", href: "", isCurrent: true },
-            ]}
-          />
-          <div className="api-detail-shell">
-            <div className="api-detail-hero">
-              <div className="api-detail-heading">
-                <button className="ghost-button no-print" onClick={onBack} type="button">
-                  Back
-                </button>
-                <div className="api-detail-brand">
-                  <Skeleton width={56} height={56} borderRadius={10} />
-                  <div className="api-detail-title" style={{ flex: 1, marginLeft: 12 }}>
-                    <Skeleton width="60%" height={32} style={{ marginBottom: 8 }} />
-                    <Skeleton width="40%" height={16} />
-                  </div>
-                </div>
-              </div>
-              <div className="api-detail-price-panel">
-                <Skeleton width={100} height={32} style={{ marginBottom: 8 }} />
-                <Skeleton width={120} height={14} style={{ marginBottom: 12 }} />
-                <Skeleton width="100%" height={44} borderRadius={8} />
-              </div>
-            </div>
-
-            <div className="api-detail-content-grid">
-              <div className="content-left">
-                <nav className="api-detail-tabs no-print">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Skeleton key={i} width={80} height={20} style={{ marginRight: 24 }} />
-                  ))}
-                </nav>
-                <div className="api-detail-metrics">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div key={i} className="stat-card-skeleton" style={{ padding: 20 }}>
-                      <Skeleton width="40%" height={12} style={{ marginBottom: 12 }} />
-                      <Skeleton width="60%" height={28} />
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <aside className="api-detail-sidebar no-print">
-                <div className="api-detail-sidebar-inner">
-                  <div className="stat-card-skeleton" style={{ padding: 24, marginBottom: 20 }}>
-                    <Skeleton width="50%" height={20} style={{ marginBottom: 16 }} />
-                    <Skeleton width="100%" height={16} style={{ marginBottom: 8 }} />
-                    <Skeleton width="100%" height={16} style={{ marginBottom: 8 }} />
-                    <Skeleton width="100%" height={16} />
-                  </div>
-                  <div className="preview-card-skeleton" style={{ padding: 24, marginBottom: 20 }}>
-                    <Skeleton width="50%" height={20} style={{ marginBottom: 16 }} />
-                    <Skeleton width="100%" height={36} style={{ marginBottom: 8 }} />
-                    <Skeleton width="100%" height={36} style={{ marginBottom: 8 }} />
-                    <Skeleton width="100%" height={36} />
-                  </div>
-                  <div style={{ padding: 24, borderRadius: 16 }}>
-                    <Skeleton width="50%" height={20} style={{ marginBottom: 12 }} />
-                    <Skeleton width="100%" height={14} style={{ marginBottom: 6 }} />
-                    <Skeleton width="100%" height={14} style={{ marginBottom: 16 }} />
-                    <Skeleton width="100%" height={44} borderRadius={8} />
-                  </div>
-                </div>
-              </aside>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+    return <ApiDetailPageSkeleton onBack={onBack} />;
   }
 
   // Safety guard — unreachable after the checks above, satisfies TS

--- a/src/pages/ApiUsage.test.tsx
+++ b/src/pages/ApiUsage.test.tsx
@@ -3,24 +3,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ApiUsage from './ApiUsage';
 
 // Mock dependencies
-vi.mock('./hooks/useFetchTracker', () => ({
+vi.mock('../hooks/useFetchTracker', () => ({
   useFetchTracker: () => ({ trackFetch: vi.fn(async (promise) => promise) })
 }));
 
-vi.mock('./hooks/useQuota', () => ({
+vi.mock('../hooks/useQuota', () => ({
   useQuota: () => ({ usagePercent: 50, isDismissed: false, dismiss: vi.fn() })
 }));
 
-vi.mock('./components/PlanNudge', () => ({
+vi.mock('../components/PlanNudge', () => ({
   default: () => <div data-testid="plan-nudge">PlanNudge</div>
 }));
 
-vi.mock('./components/CallsHeatmap', () => ({
+vi.mock('../components/CallsHeatmap', () => ({
   default: () => <div data-testid="calls-heatmap">CallsHeatmap</div>
 }));
 
 describe('ApiUsage - Filter Reset', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     Object.defineProperty(window, 'location', {
       value: {
         search: '',
@@ -44,8 +45,15 @@ describe('ApiUsage - Filter Reset', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should enable reset button when filters are active and announce reset to screen readers', async () => {
     render(<ApiUsage />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
     const resetButton = screen.getByRole('button', { name: /Reset Filters/i });
     expect(resetButton.disabled).toBe(true);
     const successTab = screen.getByRole('tab', { name: /Success/i });
@@ -59,6 +67,9 @@ describe('ApiUsage - Filter Reset', () => {
 
   it('renders an accessible breadcrumb with the current page announced', () => {
     render(<ApiUsage />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
     const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
     expect(breadcrumb).toBeTruthy();
     const marketplaceLink = screen.getByRole('link', { name: 'Marketplace' });
@@ -70,6 +81,7 @@ describe('ApiUsage - Filter Reset', () => {
 
 describe('ApiUsage - Tabular Numerals', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     Object.defineProperty(window, 'location', {
       value: { search: '', pathname: '/api-usage' },
       writable: true,
@@ -86,18 +98,25 @@ describe('ApiUsage - Tabular Numerals', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('applies tabular-nums to all stat-value elements', () => {
     render(<ApiUsage />);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
     const statValues = document.querySelectorAll('.stat-value.tabular-nums');
     expect(statValues.length).toBe(5);
     const labels = ['Calls Today', 'Calls This Week', 'Total Spent', 'Avg Response Time', 'Success Rate'];
-statValues.forEach((el, i) => {
-       expect(el.classList.contains('tabular-nums')).toBe(true);
-       const card = el.closest('.stat-card');
-       expect(card.querySelector('.stat-label').textContent).toBe(labels[i]);
-     });
-   });
- });
+    statValues.forEach((el, i) => {
+      expect(el.classList.contains('tabular-nums')).toBe(true);
+      const card = el.closest('.stat-card');
+      expect(card.querySelector('.stat-label').textContent).toBe(labels[i]);
+    });
+  });
+});
 
 describe('ApiUsage - prefers-reduced-motion', () => {
    let originalMatchMedia: typeof window.matchMedia;
@@ -159,3 +178,45 @@ describe('ApiUsage - prefers-reduced-motion', () => {
      expect(screen.getByText('Call History')).toBeTruthy();
    });
  });
+
+describe('ApiUsage - Loading Skeleton (v7)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'location', {
+      value: { search: '', pathname: '/api-usage' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the themed page skeleton on mount when prefers-reduced-motion is false', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(<ApiUsage />);
+
+    // The container should show aria-busy="true" and label
+    const shell = screen.getByLabelText('API usage loading shell');
+    expect(shell).toBeTruthy();
+    expect(shell.getAttribute('aria-busy')).toBe('true');
+
+    // There should be skeleton cells and elements present
+    const skeletonElements = document.querySelectorAll('.skeleton');
+    expect(skeletonElements.length).toBeGreaterThan(0);
+    
+    // And some should have the stellar tone/theme
+    const stellarSkeletons = document.querySelectorAll('.skeleton--stellar');
+    expect(stellarSkeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/ApiUsage.tsx
+++ b/src/pages/ApiUsage.tsx
@@ -1,26 +1,26 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import EmptyState from './components/EmptyState';
-import Skeleton, { SkeletonRow } from './components/Skeleton';
-import { formatPrice } from './utils/format';
-import type { JsonSchema } from './components/RequestBodyEditor';
-import CallHistoryRow from './components/CallHistoryRow';
-import Breadcrumb from './components/Breadcrumb';
-import RequestHistoryPanel from './components/RequestHistoryPanel';
-import ParamsBuilder from './components/ParamsBuilder';
-import { useFetchTracker } from './hooks/useFetchTracker';
-import { useQuota } from './hooks/useQuota';
-import PlanNudge from './components/PlanNudge';
-import CallsHeatmap from './components/CallsHeatmap';
-import Tabs from './components/Tabs';
-import { Icons } from './utils/icons';
-import { LinkIcon } from './components/icons';
+import EmptyState from '../components/EmptyState';
+import Skeleton, { SkeletonRow, ApiUsageSkeleton } from '../components/Skeleton';
+import { formatPrice } from '../utils/format';
+import type { JsonSchema } from '../components/RequestBodyEditor';
+import CallHistoryRow from '../components/CallHistoryRow';
+import Breadcrumb from '../components/Breadcrumb';
+import RequestHistoryPanel from '../components/RequestHistoryPanel';
+import ParamsBuilder from '../components/ParamsBuilder';
+import { useFetchTracker } from '../hooks/useFetchTracker';
+import { useQuota } from '../hooks/useQuota';
+import PlanNudge from '../components/PlanNudge';
+import CallsHeatmap from '../components/CallsHeatmap';
+import Tabs from '../components/Tabs';
+import { Icons } from '../utils/icons';
+import { LinkIcon } from '../components/icons';
 import {
   clearHistory,
   loadHistory,
   saveEntry,
   type HistoryEntry,
-} from './state/testCallHistory';
-import { copySnapshotUrl, parseSnapshotUrl } from './utils/snapshotUrl';
+} from '../state/testCallHistory';
+import { copySnapshotUrl, parseSnapshotUrl } from '../utils/snapshotUrl';
 
 const MOCK_USAGE_PERCENT = 80;
 const LOADING_DELAY_MS = 500;
@@ -226,6 +226,7 @@ export default function ApiUsage() {
   const [filterResetMessage, setFilterResetMessage] = useState('');
   const [callHistory, setCallHistory] = useState<CallRecord[]>(MOCK_CALL_HISTORY);
   const [isTableLoading, setIsTableLoading] = useState(true);
+  const [isPageLoading, setIsPageLoading] = useState(true);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const toggleHistory = useCallback(() => setIsHistoryOpen(prev => !prev), []);
   const [historyEntries, setHistoryEntries] = useState<any[]>([]);
@@ -239,6 +240,7 @@ export default function ApiUsage() {
   useEffect(() => {
     const delay = prefersReducedMotion ? 0 : LOADING_DELAY_MS;
     const timer = setTimeout(() => {
+      setIsPageLoading(false);
       setIsTableLoading(false);
     }, delay);
     return () => clearTimeout(timer);
@@ -521,6 +523,10 @@ export default function ApiUsage() {
       a.click();
     }
   };
+
+  if (isPageLoading) {
+    return <ApiUsageSkeleton />;
+  }
 
   return (
     <div className="api-usage-page">

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -4,7 +4,6 @@ export const DENSITY_STORAGE_KEY = 'callora.density';
 
 const VALID: DensityPreference[] = ['comfortable', 'compact'];
 
-export const DENSITY_STORAGE_KEY = 'callora.density';
 
 export function readDensityPreference(): DensityPreference {
   try {


### PR DESCRIPTION
Closes #462 
This PR implements the themed loading skeleton for the `ApiDetailPage` page on first paint. It is a drips wave issue on the stellar network.

### Changes Made
- **`src/components/Skeleton.tsx`**: Imported the `Breadcrumb` component and implemented the themed `ApiDetailPageSkeleton` component. All loaders use `tone="stellar"`.
- **`src/pages/ApiDetailPage.tsx`**: Replaced the inline skeleton rendering block under `if (isLoading)` with a call to `<ApiDetailPageSkeleton onBack={onBack} />`.
- **`src/pages/ApiDetailPage.skeleton.tsx`**: Updated all skeleton instances to use `tone="stellar"` themed loaders.
- **`src/pages/ApiDetailPage.skeleton.test.tsx`**: Added assertions confirming that themed skeletons (`.skeleton--stellar`) are successfully rendered.
