### PR TITLE
fix: ApiUsage skeleton parity

### DIFF
--- a/src/ApiUsage.test.tsx
+++ b/src/ApiUsage.test.tsx
@@ -282,5 +282,49 @@ describe('ApiUsage - prefers-reduced-motion', () => {
      });
 
      expect(screen.getByText('Call History')).toBeTruthy();
-   });
- });
+    });
+  });
+
+  describe('ApiUsage - Skeleton Parity', () => {
+    let originalMatchMedia: typeof window.matchMedia;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      originalMatchMedia = window.matchMedia;
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it('renders skeleton rows with shape and height parity matching the final component', () => {
+      render(<ApiUsage />);
+      
+      const skeletonRows = document.querySelectorAll('.table-row');
+      expect(skeletonRows.length).toBeGreaterThan(0);
+      
+      const firstSkeletonRow = skeletonRows[1];
+      const skeletonCells = firstSkeletonRow.querySelectorAll('.skeleton-cell');
+      
+      expect(skeletonCells.length).toBe(7);
+      
+      const statusIconSkeleton = skeletonCells[2];
+      expect(statusIconSkeleton.getAttribute('style')).toContain('width: 16px');
+      expect(statusIconSkeleton.getAttribute('style')).toContain('border-radius: 50%');
+      
+      const actionButtonSkeleton = skeletonCells[6];
+      expect(actionButtonSkeleton.getAttribute('style')).toContain('width: 64px');
+      expect(actionButtonSkeleton.getAttribute('style')).toContain('height: 32px');
+    });
+  });

--- a/src/ApiUsage.tsx
+++ b/src/ApiUsage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import EmptyState from './components/EmptyState';
-import Skeleton from './components/Skeleton';
-import CallHistoryRow from './pages/CallHistoryRow';
+import Skeleton, { SkeletonRow } from './components/Skeleton';
 import { formatPrice } from './utils/format';
 import type { JsonSchema } from './components/RequestBodyEditor';
 import CallHistoryRow from './components/CallHistoryRow';

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -38,10 +38,13 @@ export function SkeletonRow({ rows = 5 }: { rows?: number }) {
     <div className="table-row">
       <Skeleton width="60%" height="16px" className="skeleton-cell" />
       <Skeleton width="85%" height="16px" className="skeleton-cell" />
-      <Skeleton width="50%" height="16px" className="skeleton-cell" />
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <Skeleton width="16px" height="16px" borderRadius="50%" className="skeleton-cell" />
+        <Skeleton width="50px" height="16px" className="skeleton-cell" />
+      </div>
       <Skeleton width="45%" height="16px" className="skeleton-cell" />
-      <Skeleton width="35%" height="16px" className="skeleton-cell" />
-      <Skeleton width="50%" height="16px" className="skeleton-cell" />
+      <Skeleton width="40%" height="16px" className="skeleton-cell" />
+      <Skeleton width="64px" height="32px" borderRadius="6px" className="skeleton-cell" />
     </div>
   );
   return (


### PR DESCRIPTION
Resolves #424 This PR addresses UI/UX requirements for the GrantFox FWC26 campaign. It audits and updates the ApiUsage skeleton table so that its layout and dimensions perfectly match the final loaded CallHistoryRow component, drastically reducing layout shift (CLS) and improving the perceived loading experience.

What was changed:
Skeleton Parity:
Updated SkeletonRow within src/components/Skeleton.tsx to strictly mimic the 6-column layout of the actual CallHistoryRow.
Status Column: Added a flex container with a 16x16px circular skeleton to represent the status icon, followed by a 50px width skeleton for the text label.
Action Column: Replaced the generic text skeleton with a 64x32px bounding box with a 6px border-radius to closely represent the "View" ghost button.
Component Bug Fixes:
Fixed a ReferenceError caused by an unimported SkeletonRow reference in ApiUsage.tsx.
Removed a duplicate/invalid import of CallHistoryRow in ApiUsage.tsx that was pointing to an incorrect directory.
Focused Tests Added:
Added a dedicated ApiUsage - Skeleton Parity test suite to ApiUsage.test.tsx.
The tests strictly verify that the skeleton row outputs the correct number of node pieces and validates the shape/height assertions on the status icon and button placeholders, preventing future regressions.
Testing Instructions
Run npm test locally to verify that the 12 tests for ApiUsage.test.tsx pass.
Spin up the application locally and navigate to /api-usage.
Refresh the page to trigger the skeleton loading state in the Call History section.
Verify that the loading skeleton lines up smoothly with the fully rendered call history table (especially the Status icon and Action button).
Checklist
 Implementation matches the visual parity description
 Responsive layout respected
 Missing imports fixed and duplicate logic cleaned up
 Focused parity tests added and passing successfully
 Adheres to repository lint and code styling standards