### PR TITLE
fix: ApiCard color-blind patterns

### DIFF
--- a/src/components/ApiCard.test.tsx
+++ b/src/components/ApiCard.test.tsx
@@ -5,6 +5,23 @@ import React from "react";
 import type { APIItem } from "../data/mockApis";
 import { pinnedApisStore } from "../state/pinnedApis";
 
+// Mock matchMedia globally for ApiCard tests
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    })),
+  });
+}
+
 /* ── Mocks ─────────────────────────────────────────────────────────────────
    vi.mock factories are hoisted to the top of the file by Vitest, so they
    cannot reference variables declared in module scope. All mock state must
@@ -347,6 +364,62 @@ describe("ApiCard responsiveness", () => {
     
     const card = screen.getByRole("button", { name: /View details for Responsive API/i });
     expect(card.className).not.toContain("api-card--compact");
+  });
+});
+
+describe("ApiCard status badges and color-blind patterns", () => {
+  it("renders the operational status badge with solid baseline pattern", () => {
+    const apiWithStatus: APIItem = {
+      id: "api-1",
+      name: "Stellar Metering API",
+      description: "A mock API for testing.",
+      tags: ["weather", "forecast", "geo"],
+      pricePerRequest: 0.01,
+      provider: { name: "Acme Labs" },
+      endpoints: [{ id: "meter", url: "/api/v1/meter", method: "GET", title: "Meter" }],
+      status: "operational",
+    };
+    render(<ApiCard api={apiWithStatus} />);
+    const badge = screen.getByRole("img", { name: "Operational" });
+    expect(badge).toBeTruthy();
+    expect(badge.getAttribute("data-pattern")).toBe("baseline");
+    expect(badge.className).toContain("sb-pattern-operational");
+  });
+
+  it("renders the degraded status badge with opposite-stripes pattern", () => {
+    const apiWithStatus: APIItem = {
+      id: "api-1",
+      name: "Stellar Metering API",
+      description: "A mock API for testing.",
+      tags: ["weather", "forecast", "geo"],
+      pricePerRequest: 0.01,
+      provider: { name: "Acme Labs" },
+      endpoints: [{ id: "meter", url: "/api/v1/meter", method: "GET", title: "Meter" }],
+      status: "degraded",
+    };
+    render(<ApiCard api={apiWithStatus} />);
+    const badge = screen.getByRole("img", { name: "Degraded" });
+    expect(badge).toBeTruthy();
+    expect(badge.getAttribute("data-pattern")).toBe("opposite-stripes");
+    expect(badge.className).toContain("sb-pattern-degraded");
+  });
+
+  it("renders the maintenance status badge with dots pattern", () => {
+    const apiWithStatus: APIItem = {
+      id: "api-1",
+      name: "Stellar Metering API",
+      description: "A mock API for testing.",
+      tags: ["weather", "forecast", "geo"],
+      pricePerRequest: 0.01,
+      provider: { name: "Acme Labs" },
+      endpoints: [{ id: "meter", url: "/api/v1/meter", method: "GET", title: "Meter" }],
+      status: "maintenance",
+    };
+    render(<ApiCard api={apiWithStatus} />);
+    const badge = screen.getByRole("img", { name: "Maintenance" });
+    expect(badge).toBeTruthy();
+    expect(badge.getAttribute("data-pattern")).toBe("dots");
+    expect(badge.className).toContain("sb-pattern-maintenance");
   });
 });
 

--- a/src/components/ApiCard.tsx
+++ b/src/components/ApiCard.tsx
@@ -22,6 +22,7 @@ import type { Shortcut } from "../hooks/useGlobalShortcuts";
 import KbdHint from "./KbdHint";
 import WhyApi from "./WhyApi";
 import { ClockIcon, BoltIcon } from "./icons";
+import StatusBadge from "./StatusBadge";
 
 // ─── Skeleton ────────────────────────────────────────────────────────────────
 
@@ -531,7 +532,7 @@ export default function ApiCard({
   const prefersReducedMotion = useMemo(() => {
     return typeof window !== "undefined" &&
       typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      window.matchMedia("(prefers-reduced-motion: reduce)")?.matches;
   }, []);
 
   const { isFavorite, toggleFavorite } = useFavorites();
@@ -720,9 +721,10 @@ export default function ApiCard({
         </div>
 
         <div className="api-marketplace-card-body" style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-          <div className="api-marketplace-card-title-row" style={{ display: "flex", gap: 8, alignItems: "baseline", flexWrap: "wrap" }}>
+          <div className="api-marketplace-card-title-row" style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
             <strong>{api.name}</strong>
             <div style={{ color: "var(--muted)", fontSize: 12 }}>{api.provider?.name}</div>
+            {api.status && <StatusBadge status={api.status} />}
           </div>
 
           {!isCompact && (

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -27,7 +27,8 @@ export type StatusVariant =
   | 'operational'
   | 'degraded'
   | 'down'
-  | 'pending';
+  | 'pending'
+  | 'maintenance';
 
 const DEFAULT_LABELS: Record<StatusVariant, string> = {
   success: 'Operational',
@@ -37,6 +38,7 @@ const DEFAULT_LABELS: Record<StatusVariant, string> = {
   warning: 'Degraded',
   degraded: 'Degraded',
   pending: 'Pending',
+  maintenance: 'Maintenance',
 };
 
 const PATTERN_DESCRIPTIONS: Record<StatusVariant, string> = {
@@ -47,6 +49,7 @@ const PATTERN_DESCRIPTIONS: Record<StatusVariant, string> = {
   warning: 'opposite diagonal stripes',
   degraded: 'opposite diagonal stripes',
   pending: 'dot pattern',
+  maintenance: 'dot pattern',
 };
 
 const PATTERN_KEYS: Record<StatusVariant, string> = {
@@ -57,6 +60,7 @@ const PATTERN_KEYS: Record<StatusVariant, string> = {
   warning: 'opposite-stripes',
   degraded: 'opposite-stripes',
   pending: 'dots',
+  maintenance: 'dots',
 };
 
 /** Small circle indicator rendered before the text label. */

--- a/src/styles/patterns.css
+++ b/src/styles/patterns.css
@@ -40,7 +40,8 @@
 }
 
 /* Pending: small dot grid — feels "in progress" without directional bias */
-.sb-pattern-pending {
+.sb-pattern-pending,
+.sb-pattern-maintenance {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Ccircle cx='4' cy='4' r='1' fill='currentColor' fill-opacity='0.3'/%3E%3C/svg%3E");
   background-size: 8px 8px;
   background-repeat: repeat;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -104,6 +104,11 @@
   --sb-pending-bg: rgba(78, 133, 255, 0.14);
   --sb-pending-fg: #4e85ff;
   --sb-pending-border: rgba(78, 133, 255, 0.35);
+
+  /* maintenance (alias of pending) */
+  --sb-maintenance-bg: var(--sb-pending-bg);
+  --sb-maintenance-fg: var(--sb-pending-fg);
+  --sb-maintenance-border: var(--sb-pending-border);
 }
 
 [data-theme="light"] {
@@ -134,4 +139,9 @@
   --sb-pending-bg: rgba(37, 99, 235, 0.1);
   --sb-pending-fg: #1e40af;
   --sb-pending-border: rgba(37, 99, 235, 0.25);
+
+  /* maintenance (alias of pending) */
+  --sb-maintenance-bg: var(--sb-pending-bg);
+  --sb-maintenance-fg: var(--sb-pending-fg);
+  --sb-maintenance-border: var(--sb-pending-border);
 }

--- a/src/utils/density.ts
+++ b/src/utils/density.ts
@@ -4,7 +4,6 @@ export const DENSITY_STORAGE_KEY = 'callora.density';
 
 const VALID: DensityPreference[] = ['comfortable', 'compact'];
 
-export const DENSITY_STORAGE_KEY = 'callora.density';
 
 export function readDensityPreference(): DensityPreference {
   try {


### PR DESCRIPTION
Closes #458 
## Description
This PR resolves the Drips Wave accessibility issue by adding color-blind safe status badges (with distinct background patterns) to the `ApiCard` component.

## Key Changes
- **Status Badge Integration:** Imported and rendered the `StatusBadge` component inside the header of `ApiCard` to display the API's current health status (`operational`, `degraded`, or `maintenance`).
- **Added Maintenance Status:** Extended `StatusBadge.tsx` and design tokens to fully support the `maintenance` variant, mapping it to a color-blind friendly dot pattern in both light and dark themes.
- **Testing:** Added focused unit tests in `ApiCard.test.tsx` to verify the rendering and pattern values of operational, degraded, and maintenance status badges.
- **Robust Mocking:** Adjusted the global `matchMedia` mock in `ApiCard.test.tsx` to prevent it from being cleared by Vitest's `vi.restoreAllMocks()` helper.
- **Duplicate Declaration Fix:** Resolved a duplicate export of `DENSITY_STORAGE_KEY` in `src/utils/density.ts`.
