### PR TITLE
feat: add sticky invoice card action bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import A11yAudit from "./pages/A11yAudit";
 import RateLimitCard from "./pages/RateLimitCard";
 import { ShortcutsModal } from "./components/ShortcutsModal";
 import { ToastProvider } from "./components/Toast";
+import { InvoiceCard } from "./pages/InvoiceCard";
 
 type DepositStage = "input" | "approving" | "pending" | "confirmed" | "failed";
 type DemoOutcome = "confirmed" | "failed";
@@ -612,6 +613,8 @@ function App() {
                         <p>Deposits settle on Stellar. Network fee is shown before wallet approval.</p>
                       </article>
                     </div>
+
+                    <InvoiceCard invoiceNumber="INV-1001" amountDue="$4,200" dueDate="Due in 7 days" />
 
                     <div className="info-row">
                       <div className="info-card">

--- a/src/index.css
+++ b/src/index.css
@@ -5554,6 +5554,145 @@ code,
   opacity: 1 !important;
 }
 
+/* ─── Invoice card sticky action bar ───────────────────────────────────── */
+.invoice-card {
+  position: relative;
+  display: grid;
+  gap: 16px;
+  max-width: 760px;
+  margin: 24px 0;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl, 24px);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.invoice-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.invoice-card__eyebrow {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.invoice-card__title {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.4rem;
+}
+
+.invoice-card__amount {
+  display: grid;
+  gap: 4px;
+  text-align: right;
+}
+
+.invoice-card__amount-label {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.invoice-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.invoice-card__body {
+  padding: 16px;
+  border-radius: 16px;
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.invoice-card-action-bar {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 180;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px)) 16px;
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform var(--transition-speed, 240ms) ease, opacity var(--transition-speed, 240ms) ease;
+}
+
+.invoice-card-action-bar--visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.invoice-card-action-bar__inner {
+  display: flex;
+  gap: 8px;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow);
+}
+
+.invoice-card-action-bar__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  flex: 1;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.invoice-card-action-bar__button--primary {
+  background: linear-gradient(135deg, var(--accent, #4e85ff), color-mix(in srgb, var(--accent, #4e85ff) 70%, #fff));
+  color: #fff;
+}
+
+.invoice-card-action-bar__button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .invoice-card {
+    margin: 16px 0 80px;
+    padding: 20px 16px 24px;
+  }
+
+  .invoice-card__header {
+    flex-direction: column;
+  }
+
+  .invoice-card__amount {
+    text-align: left;
+  }
+
+  .invoice-card-action-bar__inner {
+    max-width: 100%;
+  }
+}
+
 /* ─── ApiDetailStickyTOC ────────────────────────────────────────────────────
    Sticky right-rail TOC inside the documentation tab. Tokens only — no
    hardcoded hex values. Transition respects prefers-reduced-motion.

--- a/src/pages/InvoiceCard.test.tsx
+++ b/src/pages/InvoiceCard.test.tsx
@@ -1,0 +1,46 @@
+import { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InvoiceCard } from './InvoiceCard';
+
+function simulateScroll(y: number) {
+  Object.defineProperty(window, 'scrollY', {
+    writable: true,
+    configurable: true,
+    value: y,
+  });
+  window.dispatchEvent(new Event('scroll'));
+}
+
+describe('InvoiceCard sticky action bar', () => {
+  it('keeps the action bar hidden until the card is scrolled', () => {
+    render(<InvoiceCard invoiceNumber="INV-1001" amountDue="$4,200" />);
+
+    const bar = screen.getByTestId('invoice-card-action-bar');
+    expect(bar).toBeInTheDocument();
+    expect(bar.classList.contains('invoice-card-action-bar--visible')).toBe(false);
+    expect(bar).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('reveals the sticky action bar after scrolling and exposes the primary action', () => {
+    const onPay = vi.fn();
+    render(
+      <InvoiceCard
+        invoiceNumber="INV-1001"
+        amountDue="$4,200"
+        onPay={onPay}
+      />,
+    );
+
+    act(() => {
+      simulateScroll(220);
+    });
+
+    const bar = screen.getByTestId('invoice-card-action-bar');
+    expect(bar.classList.contains('invoice-card-action-bar--visible')).toBe(true);
+    expect(bar).toHaveAttribute('aria-hidden', 'false');
+
+    const payButton = screen.getByRole('button', { name: /pay now/i });
+    fireEvent.click(payButton);
+    expect(onPay).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/InvoiceCard.tsx
+++ b/src/pages/InvoiceCard.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+
+export type InvoiceCardProps = {
+  invoiceNumber: string;
+  amountDue: string;
+  dueDate?: string;
+  onPay?: () => void;
+  onDownload?: () => void;
+};
+
+const SCROLL_THRESHOLD = 140;
+
+export function InvoiceCard({
+  invoiceNumber,
+  amountDue,
+  dueDate = 'Due in 7 days',
+  onPay,
+  onDownload,
+}: InvoiceCardProps) {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setIsScrolled(window.scrollY > SCROLL_THRESHOLD);
+    };
+
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <section className="invoice-card" aria-labelledby="invoice-card-title">
+      <header className="invoice-card__header">
+        <div>
+          <p className="invoice-card__eyebrow">Invoice</p>
+          <h2 id="invoice-card-title" className="invoice-card__title">
+            {invoiceNumber}
+          </h2>
+        </div>
+        <div className="invoice-card__amount">
+          <span className="invoice-card__amount-label">Amount due</span>
+          <strong>{amountDue}</strong>
+        </div>
+      </header>
+
+      <div className="invoice-card__meta">
+        <span>{dueDate}</span>
+        <span>GrantFox FWC26</span>
+      </div>
+
+      <div className="invoice-card__body">
+        <p>
+          Review the invoice details, then continue to payment or download a copy
+          for your records.
+        </p>
+      </div>
+
+      <div
+        className={`invoice-card-action-bar${isScrolled ? ' invoice-card-action-bar--visible' : ''}`}
+        role="toolbar"
+        aria-label="Invoice actions"
+        aria-hidden={!isScrolled}
+        {...(!isScrolled ? { inert: '' } : {})}
+        data-testid="invoice-card-action-bar"
+      >
+        <div className="invoice-card-action-bar__inner">
+          <button
+            type="button"
+            className="invoice-card-action-bar__button invoice-card-action-bar__button--primary"
+            onClick={onPay}
+            aria-label="Pay now"
+          >
+            Pay now
+          </button>
+          <button
+            type="button"
+            className="invoice-card-action-bar__button"
+            onClick={onDownload}
+            aria-label="Download invoice"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #751

Summary
Adds a sticky bottom action bar to the invoice card that appears while the user scrolls, keeping the primary actions visible and accessible without forcing them to scroll back up.

Changes
Added a new invoice card component with a sticky bottom action bar
Implemented scroll-based visibility for the action bar
Added primary and secondary actions with accessible button semantics
Added focused tests covering hidden/visible behavior and primary action interaction
Kept the UI responsive and aligned with the existing design-token-based styling
Testing
Verified the new invoice card behavior with targeted Vitest coverage
Confirmed the feature branch is pushed and ready for your PR