### PR TITLE
Add print stylesheet section for ReviewsTab

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5872,6 +5872,32 @@ code,
     page-break-inside: avoid !important;
     break-inside: avoid !important;
   }
+
+  /* ReviewsTab — hide chrome + expand collapsibles when printing */
+  .reviews-tab__sort-row {
+    display: none !important;
+  }
+  .reviews-tab .api-detail-reviews-header {
+    display: none !important;
+  }
+  .reviews-tab::before {
+    content: "Developer Reviews";
+    display: block;
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color: #1a2332;
+  }
+  .reviews-tab__card {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
+  .reviews-tab__list {
+    display: block !important;
+  }
+  .reviews-tab {
+    max-height: none !important;
+  }
 }
 
 /* Share Snapshot Button */

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -38,4 +38,21 @@
   .endpoint-table-wrap table {
     width: 100% !important;
   }
+
+  /* ReviewsTab — hide chrome + expand collapsibles when printing */
+  .reviews-tab__sort-row {
+    display: none !important;
+  }
+  .reviews-tab::before {
+    content: "Developer Reviews";
+    display: block;
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color: #1a2332;
+  }
+  .reviews-tab__card {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
 }


### PR DESCRIPTION
## Summary

Adds `@media print` CSS rules for the ReviewsTab component to hide chrome elements and expand collapsibles when printing.

### Changes

**`src/index.css`** — Added inside the existing `@media print` block:
- `.reviews-tab__sort-row { display: none !important; }` — hides sort dropdown
- `.reviews-tab .api-detail-reviews-header { display: none !important; }` — hides heading/CTA row
- `.reviews-tab::before { content: "Developer Reviews"; ... }` — injects print-only section title
- `.reviews-tab__card { break-inside: avoid !important; }` — prevents page breaks inside cards
- `.reviews-tab__list { display: block !important; }` — collapses grid gap
- `.reviews-tab { max-height: none !important; }` — expands any collapsed content

**`src/styles/print.css`** — Mirrored the key selectors for documentation purposes.

### Testing

- All 26 ReviewsTab tests pass
- All 24 of 25 print contract tests pass (1 pre-existing failure unrelated to this change: `defines @media print near the end of index.css`)

Closes #728