### PR TITLE
feat: add color-blind safe patterns on RateLimitCard status chips

### DIFF
--- a/src/pages/RateLimitCard.test.tsx
+++ b/src/pages/RateLimitCard.test.tsx
@@ -12,7 +12,16 @@ import RateLimitCard from "./RateLimitCard";
  *  1. Page structure and accessibility
  *  2. Breadcrumb presence and middle-ellipsis truncation
  *  3. Rate-limit table content
+ *  4. Color-blind safe patterns on plan badges
  */
+
+/** Expected pattern class for each plan. */
+const PLAN_PATTERN_CLASSES: Record<string, string> = {
+  Free: "free",
+  Developer: "developer",
+  Pro: "pro",
+  Enterprise: "enterprise",
+};
 
 function renderPage() {
   return render(
@@ -138,5 +147,26 @@ describe("RateLimitCard", () => {
     expect(
       screen.getByText(/rolling 60-second window/i),
     ).toBeTruthy();
+  });
+
+  // ── Color-blind safe patterns ─────────────────────────────────────────────
+
+  it.each(["Free", "Developer", "Pro", "Enterprise"])(
+    `%s badge has a distinct pattern class for color-blind safety`,
+    (plan) => {
+      renderPage();
+      const badge = screen.getByText(plan);
+      const expectedClass = PLAN_PATTERN_CLASSES[plan];
+      expect(badge.classList.contains("rate-limit-badge")).toBe(true);
+      expect(badge.classList.contains(expectedClass)).toBe(true);
+    },
+  );
+
+  it("each plan badge carries a data-pattern attribute describing the texture", () => {
+    renderPage();
+    for (const plan of ["Free", "Developer", "Pro", "Enterprise"]) {
+      const badge = screen.getByText(plan);
+      expect(badge.getAttribute("data-pattern")).toBeTruthy();
+    }
   });
 });

--- a/src/pages/RateLimitCard.tsx
+++ b/src/pages/RateLimitCard.tsx
@@ -86,6 +86,14 @@ const BREADCRUMB_ITEMS = [
  */
 const BREADCRUMB_MAX_LABEL = 28;
 
+/** Pattern class and description for each plan tier (color-blind safe). */
+const PLAN_PATTERNS: Record<string, { class: string; description: string }> = {
+  Free: { class: "free", description: "solid baseline" },
+  Developer: { class: "developer", description: "dot pattern" },
+  Pro: { class: "pro", description: "diagonal stripes" },
+  Enterprise: { class: "enterprise", description: "crosshatch pattern" },
+};
+
 export default function RateLimitCard() {
   useDocumentTitle(
     "Rate Limit Configuration – Callora",
@@ -207,7 +215,12 @@ export default function RateLimitCard() {
             {RATE_LIMIT_TIERS.map((tier) => (
               <tr key={tier.plan}>
                 <td>
-                  <span className="rate-limit-badge">{tier.plan}</span>
+                  <span
+                    className={`rate-limit-badge ${PLAN_PATTERNS[tier.plan].class}`}
+                    data-pattern={PLAN_PATTERNS[tier.plan].description}
+                  >
+                    {tier.plan}
+                  </span>
                 </td>
                 <td>{tier.requestsPerMinute.toLocaleString()}</td>
                 <td>{tier.burstLimit.toLocaleString()}</td>

--- a/src/styles/patterns.css
+++ b/src/styles/patterns.css
@@ -101,3 +101,34 @@
   background-blend-mode: overlay;
   flex-shrink: 0;
 }
+
+/* ── Rate-limit plan badge patterns ──────────────────────────────────────────
+   Each plan tier gets a unique SVG texture so the badges are distinguishable
+   without relying on colour alone (WCAG 1.4.1 Use of Color).
+   ──────────────────────────────────────────────────────────────────────── */
+
+/* Free: no pattern — solid color baseline */
+.rate-limit-badge.free {
+  background-image: none;
+}
+
+/* Developer: small dot grid */
+.rate-limit-badge.developer {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Ccircle cx='4' cy='4' r='1' fill='currentColor' fill-opacity='0.3'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}
+
+/* Pro: diagonal stripes ╲ */
+.rate-limit-badge.pro {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='6'%3E%3Cline x1='0' y1='0' x2='6' y2='6' stroke='currentColor' stroke-width='1' stroke-opacity='0.25'/%3E%3C/svg%3E");
+  background-size: 6px 6px;
+  background-repeat: repeat;
+}
+
+/* Enterprise: crosshatch ╳ */
+.rate-limit-badge.enterprise {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 0L8 8M8 0L0 8' stroke='currentColor' stroke-width='0.75' stroke-opacity='0.25'/%3E%3C/svg%3E");
+  background-size: 8px 8px;
+  background-repeat: repeat;
+}


### PR DESCRIPTION
## Summary

Adds color-blind safe SVG texture patterns to the RateLimitCard plan badges so each tier is distinguishable by texture alone (WCAG 1.4.1 Use of Color).

## Changes

- **`src/styles/patterns.css`** — Added `.rate-limit-badge.free`, `.rate-limit-badge.developer`, `.rate-limit-badge.pro`, `.rate-limit-badge.enterprise` pattern classes with unique SVG data URI backgrounds:
  - Free: solid baseline (no pattern)
  - Developer: dot grid
  - Pro: diagonal stripes (╲)
  - Enterprise: crosshatch (╳)
- **`src/pages/RateLimitCard.tsx`** — Added `PLAN_PATTERNS` mapping; applied pattern class and `data-pattern` attribute to each badge span
- **`src/pages/RateLimitCard.test.tsx`** — Added tests verifying each plan badge has the correct pattern class and `data-pattern` attribute

## Testing

All 16 tests pass (`npm test`).

Closes #745
