### PR TITLE
fix: apply middle-ellipsis modifier classes to prevent double-truncation

### DIFF
--- a/src/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb.test.tsx
@@ -351,6 +351,103 @@ describe("Breadcrumb – middle-ellipsis (maxLabelLength)", () => {
     // No aria-label override needed
     expect(current?.getAttribute("aria-label")).toBeNull();
   });
+
+  // ── #750 — modifier class prevents double-truncation on narrow containers ──
+  //
+  // The stylesheet defines `--middle-ellipsis` modifier classes specifically
+  // to disable the CSS-level `text-overflow: ellipsis` once JS has already
+  // shortened a label — without them, a JS-truncated string that still
+  // doesn't fit its container (e.g. a very narrow viewport) gets ellipsized
+  // a second time by CSS, producing a "start…en…" artefact. These tests
+  // confirm the modifier is actually wired to the elements it was designed
+  // for, not just present as unused CSS.
+
+  it("applies the middle-ellipsis modifier class to a truncated first-crumb link", () => {
+    const items = [
+      { label: "A Very Long Root Segment Name", href: "/root" },
+      { label: "Short", href: "/root/short", isCurrent: true },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={16} />);
+
+    const link = screen.getByRole("link", {
+      name: "A Very Long Root Segment Name",
+    });
+    expect(link.classList.contains("breadcrumb-link--middle-ellipsis")).toBe(
+      true,
+    );
+  });
+
+  it("does not apply the middle-ellipsis modifier class when the link label is not truncated", () => {
+    const items = [
+      { label: "Home", href: "/" },
+      { label: "Short", href: "/short", isCurrent: true },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={28} />);
+
+    const link = screen.getByRole("link", { name: "Home" });
+    expect(link.classList.contains("breadcrumb-link--middle-ellipsis")).toBe(
+      false,
+    );
+  });
+
+  it("applies the middle-ellipsis modifier class to a truncated current-page crumb", () => {
+    const items = [
+      { label: "Marketplace", href: "/marketplace" },
+      {
+        label: "A Very Long Current Page Title Indeed",
+        href: "/current",
+        isCurrent: true,
+      },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={20} />);
+
+    const current = document.querySelector<HTMLSpanElement>(
+      '[aria-current="page"]',
+    );
+    expect(
+      current?.classList.contains("breadcrumb-current--middle-ellipsis"),
+    ).toBe(true);
+  });
+
+  it("does not apply the middle-ellipsis modifier class to a current-page crumb that fits", () => {
+    const items = [
+      { label: "Home", href: "/" },
+      { label: "Short", href: "/short", isCurrent: true },
+    ];
+    render(<Breadcrumb items={items} maxLabelLength={28} />);
+
+    const current = document.querySelector<HTMLSpanElement>(
+      '[aria-current="page"]',
+    );
+    expect(
+      current?.classList.contains("breadcrumb-current--middle-ellipsis"),
+    ).toBe(false);
+  });
+
+  it("applies the middle-ellipsis modifier class to truncated popover links", () => {
+    const { container } = render(
+      <Breadcrumb items={truncatedBreadcrumb} maxLabelLength={28} />,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>(
+      ".breadcrumb-ellipsis",
+    );
+    if (!button) throw new Error("Expected ellipsis button");
+    fireEvent.click(button);
+
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('[role="menuitem"]'),
+    );
+
+    expect(menuItems.length).toBeGreaterThan(0);
+    for (const menuItem of menuItems) {
+      expect(
+        menuItem.classList.contains(
+          "breadcrumb-popover-link--middle-ellipsis",
+        ),
+      ).toBe(true);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -63,7 +63,11 @@ function BreadcrumbLink({
   if (item.isCurrent) {
     return (
       <span
-        className="breadcrumb-current"
+        className={
+          isTruncated
+            ? "breadcrumb-current breadcrumb-current--middle-ellipsis"
+            : "breadcrumb-current"
+        }
         aria-current="page"
         // Always expose the full label to assistive technology and on hover.
         title={item.label}
@@ -78,7 +82,11 @@ function BreadcrumbLink({
 
   return (
     <a
-      className="breadcrumb-link link-nav"
+      className={
+        isTruncated
+          ? "breadcrumb-link link-nav breadcrumb-link--middle-ellipsis"
+          : "breadcrumb-link link-nav"
+      }
       href={item.href}
       title={item.label}
       {...(isTruncated ? { "aria-label": item.label } : {})}
@@ -231,7 +239,8 @@ export default function Breadcrumb({ items, maxLabelLength = 0 }: BreadcrumbProp
            * but the primary visual treatment is the JS-computed "start…end" string.
            */
           .breadcrumb-link--middle-ellipsis,
-          .breadcrumb-current--middle-ellipsis {
+          .breadcrumb-current--middle-ellipsis,
+          .breadcrumb-popover-link--middle-ellipsis {
             /* Allow the truncated text to breathe – no hard CSS cut-off needed
                because JS already shortened it. Disable the CSS ellipsis so we
                never see a double-truncation artefact ("start…en…"). */
@@ -403,7 +412,11 @@ export default function Breadcrumb({ items, maxLabelLength = 0 }: BreadcrumbProp
                           return (
                             <li key={middleItem.href} role="none">
                               <a
-                                className="breadcrumb-popover-link link-nav"
+                                className={
+                                  isTruncated
+                                    ? "breadcrumb-popover-link link-nav breadcrumb-popover-link--middle-ellipsis"
+                                    : "breadcrumb-popover-link link-nav"
+                                }
                                 href={middleItem.href}
                                 role="menuitem"
                                 title={middleItem.label}


### PR DESCRIPTION
Closes #750

## Note on scope

The issue references `src/pages/PlanSelector.tsx`, which does not exist anywhere in this repo (confirmed via full-text search and git history). The middle-ellipsis breadcrumb feature the issue describes was already fully implemented in `src/components/Breadcrumb.tsx` by a prior contribution (issue #567, demonstrated via `src/pages/RateLimitCard.tsx`) — `truncateMiddle()`, the collapsed-items popover, keyboard navigation, and full `title`/`aria-label` preservation were all already in place and already covered by 27 existing tests.

## What was actually missing

The stylesheet defines `.breadcrumb-link--middle-ellipsis` / `.breadcrumb-current--middle-ellipsis` modifier classes specifically to disable the CSS-level `text-overflow: ellipsis` once JS has already shortened a label — the comment directly above them explains this prevents a `"start…en…"` double-truncation artefact when the JS-truncated string still doesn't fit an extremely narrow container. But the JSX never actually applied either modifier class, so that protection was dead code. The same gap existed for the popover's expanded-item links, which had no modifier class defined for them at all.

## Fix

- Apply `breadcrumb-link--middle-ellipsis` / `breadcrumb-current--middle-ellipsis` to `BreadcrumbLink` when the label is actually truncated (not unconditionally).
- Add a matching `breadcrumb-popover-link--middle-ellipsis` modifier (CSS + JSX) for the popover's expanded items, which had the identical gap.

## Tests

5 new cases in `Breadcrumb.test.tsx` confirming the modifier class is present exactly when a label is truncated (first-crumb link, current-page crumb, popover links) and absent when it isn't.

```
npx vitest run src/components/Breadcrumb.test.tsx
 Test Files  1 passed (1)
      Tests  34 passed (34)
```

Repo-wide `npx vitest run` has 68 pre-existing failures across 13 files (confirmed unrelated — none touch `Breadcrumb.tsx`/`Breadcrumb.test.tsx`).