### PR TITLE
feat: add copy-to-clipboard affordance on EmptyState

### DIFF
--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import EmptyState from "./EmptyState";
 import type { EmptyStateSize, EmptyStateVariant } from "./EmptyState";
@@ -361,6 +361,107 @@ describe("EmptyState", () => {
       );
       const withActionSkeletonsCount = withAction.querySelectorAll(".skeleton").length;
       expect(withActionSkeletonsCount).toBe(initialSkeletonsCount + 1);
+    });
+  });
+
+  describe("copy-to-clipboard", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      Object.defineProperty(navigator, "clipboard", {
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("renders copy button when copyable is true and message is present", () => {
+      render(<EmptyState copyable message="Copy this text" />);
+      expect(screen.getByLabelText("Copy message to clipboard")).toBeTruthy();
+    });
+
+    it("does not render copy button when copyable is false (default)", () => {
+      render(<EmptyState message="No copy here" />);
+      expect(screen.queryByLabelText("Copy message to clipboard")).toBeNull();
+    });
+
+    it("copies the message text to clipboard on click", async () => {
+      render(<EmptyState copyable message="Test message" />);
+      const btn = screen.getByLabelText("Copy message to clipboard");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Test message");
+    });
+
+    it("shows 'Copied' feedback after clicking", async () => {
+      render(<EmptyState copyable message="Some text" />);
+      const btn = screen.getByLabelText("Copy message to clipboard");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      expect(btn.textContent).toMatch(/Copied/);
+    });
+
+    it("announces copy success via aria-live region", async () => {
+      render(<EmptyState copyable message="Announce this" />);
+      const btn = screen.getByLabelText("Copy message to clipboard");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      const liveRegion = screen.getByText("Message copied to clipboard");
+      expect(liveRegion).toBeTruthy();
+      expect(liveRegion.getAttribute("aria-live")).toBe("polite");
+    });
+
+    it("reverts 'Copied' feedback after 2 seconds", async () => {
+      render(<EmptyState copyable message="Revert test" />);
+      const btn = screen.getByLabelText("Copy message to clipboard");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      expect(btn.textContent).toMatch(/Copied/);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(btn.textContent).toMatch(/Copy/);
+    });
+
+    it("copies the resolved message (message prop takes precedence over description)", async () => {
+      render(
+        <EmptyState
+          copyable
+          message="Primary message"
+          description="Deprecated description"
+        />,
+      );
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Copy message to clipboard"));
+      });
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Primary message");
+    });
+
+    it("copies the default message when no custom message is provided", async () => {
+      render(<EmptyState variant="empty" copyable />);
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Copy message to clipboard"));
+      });
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "Check back soon for new integrations.",
+      );
+    });
+
+    it("renders copy button with compact size styling", () => {
+      render(<EmptyState copyable size="compact" message="Compact copy" />);
+      const btn = screen.getByLabelText("Copy message to clipboard");
+      expect(btn).toBeTruthy();
+      expect(btn.style.fontSize).toBe("0.75rem");
     });
   });
 });

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ExternalLink from "./ExternalLink";
+import useCopy from "../hooks/useCopy";
 
 export type EmptyStateVariant =
   | "empty"
@@ -29,6 +30,8 @@ export interface EmptyStateProps {
     onClick: () => void;
   };
   loading?: boolean;
+  /** When true, renders a copy-to-clipboard button for the message text. */
+  copyable?: boolean;
 }
 
 /**
@@ -532,9 +535,11 @@ export default function EmptyState({
   action,
   secondaryAction,
   loading = false,
+  copyable = false,
 }: EmptyStateProps) {
   const resolvedMessage = message ?? description;
   const resolvedAction = action;
+  const { copied, handleCopy } = useCopy();
 
   if (loading) {
     return (
@@ -721,6 +726,48 @@ export default function EmptyState({
       <HeadingTag style={headingStyle}>{finalTitle}</HeadingTag>
 
       <p style={messageStyle}>{finalMessage}</p>
+
+      {copyable && finalMessage && (
+        <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={() => handleCopy(finalMessage)}
+            aria-label="Copy message to clipboard"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
+              fontSize: isCompact ? "0.75rem" : "0.8125rem",
+              padding: isCompact ? "0.25rem 0.5rem" : "0.3125rem 0.75rem",
+              color: copied ? "var(--success, #10b981)" : "var(--muted)",
+              minHeight: "36px",
+            }}
+          >
+            <span aria-hidden="true">
+              {copied ? "✓" : "⧉"}
+            </span>
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <span
+            aria-live="polite"
+            aria-atomic="true"
+            style={{
+              position: "absolute",
+              width: "1px",
+              height: "1px",
+              margin: "-1px",
+              padding: 0,
+              overflow: "hidden",
+              clip: "rect(0 0 0 0)",
+              whiteSpace: "nowrap",
+              border: 0,
+            }}
+          >
+            {copied ? "Message copied to clipboard" : ""}
+          </span>
+        </div>
+      )}
 
       {resolvedAction && (
         <button

--- a/src/hooks/__tests__/useCopy.test.ts
+++ b/src/hooks/__tests__/useCopy.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import useCopy from "../useCopy";
+
+describe("useCopy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns copied false initially", () => {
+    const { result } = renderHook(() => useCopy());
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("calls navigator.clipboard.writeText on handleCopy", async () => {
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("hello world");
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello world");
+  });
+
+  it("sets copied to true after successful copy", async () => {
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("text");
+    });
+    expect(result.current.copied).toBe(true);
+  });
+
+  it("resets copied to false after 2 seconds", async () => {
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("text");
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("falls back to textarea/execCommand when clipboard API is unavailable", async () => {
+    // @ts-expect-error — testing fallback path
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    // jsdom does not implement execCommand; define it for the fallback path
+    const execCommandSpy = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommandSpy,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("fallback text");
+    });
+
+    expect(execCommandSpy).toHaveBeenCalledWith("copy");
+    expect(result.current.copied).toBe(true);
+  });
+
+  it("clears timer on unmount", async () => {
+    const { result, unmount } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("text");
+    });
+    unmount();
+    // Should not throw after unmount
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+  });
+
+  it("resets previous timer on rapid consecutive copies", async () => {
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      await result.current.handleCopy("first");
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      await result.current.handleCopy("second");
+    });
+    expect(result.current.copied).toBe(true);
+
+    // Still true at the 1s mark from the second copy
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copied).toBe(true);
+
+    // Now the 2s from second copy elapses
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/src/hooks/useCopy.ts
+++ b/src/hooks/useCopy.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const RESET_MS = 2000;
+
+/**
+ * Reusable copy-to-clipboard hook.
+ *
+ * Uses the async Clipboard API with a textarea/execCommand fallback
+ * for older browsers. Exposes a `copied` flag that auto-resets after
+ * 2 seconds, matching the feedback pattern used by CodeExample and
+ * CopyCurlButton.
+ *
+ * @example
+ * const { copied, handleCopy } = useCopy();
+ * <button onClick={() => handleCopy("text")}>Copy</button>
+ */
+export default function useCopy() {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async (text: string) => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      setCopied(true);
+    } catch (err) {
+      console.error("Failed to copy to clipboard:", err);
+    }
+
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setCopied(false), RESET_MS);
+  }, []);
+
+  return { copied, handleCopy } as const;
+}


### PR DESCRIPTION
- Add useCopy hook with clipboard API + textarea/execCommand fallback
- Add copyable prop to EmptyState with inline copy button
- Ghost-button style with clipboard icon, 'Copied' feedback, aria-live region
- 16 new tests covering hook and component copy behavior

Closes #693