### PR TITLE
fix(#736): add error boundary fallback for StickyToc with retry action

### DIFF
--- a/src/components/StickyTocErrorBoundary.test.tsx
+++ b/src/components/StickyTocErrorBoundary.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StickyTocErrorBoundary } from "./StickyTocErrorBoundary";
+
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("StickyToc render error");
+  }
+  return <nav aria-label="On this page">TOC content</nav>;
+}
+
+describe("StickyTocErrorBoundary", () => {
+  beforeEach(() => {
+    vi.stubGlobal("console", { error: vi.fn() });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <StickyTocErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </StickyTocErrorBoundary>,
+    );
+    expect(screen.getByText("TOC content")).toBeTruthy();
+  });
+
+  it("renders error fallback with retry button when child throws", () => {
+    render(
+      <StickyTocErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </StickyTocErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Unable to load the table of contents.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+
+  it("re-renders children after retry button is clicked when error is resolved", () => {
+    const { rerender } = render(
+      <StickyTocErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </StickyTocErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    screen.getByRole("button", { name: /retry/i }).click();
+
+    rerender(
+      <StickyTocErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </StickyTocErrorBoundary>,
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText("TOC content")).toBeTruthy();
+  });
+
+  it("has aria-live polite on the fallback container", () => {
+    render(
+      <StickyTocErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </StickyTocErrorBoundary>,
+    );
+    const fallback = screen.getByRole("alert");
+    expect(fallback.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/src/components/StickyTocErrorBoundary.tsx
+++ b/src/components/StickyTocErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { Component, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class StickyTocErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          className="api-detail-toc"
+          role="alert"
+          aria-live="polite"
+        >
+          <p className="api-detail-toc__heading">Table of Contents</p>
+          <div className="api-detail-toc__error">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--danger)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p className="api-detail-toc__error-text">
+              Unable to load the table of contents.
+            </p>
+            <button
+              className="ghost-button"
+              type="button"
+              onClick={this.handleRetry}
+              aria-label="Retry loading table of contents"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5760,6 +5760,25 @@ code,
   }
 }
 
+.api-detail-toc__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  text-align: center;
+}
+
+.api-detail-toc__error svg {
+  flex-shrink: 0;
+}
+
+.api-detail-toc__error-text {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 /* ─── Print stylesheet (ApiDetailPage docs printout) ─────────────────────
    Pure CSS. Hides chrome via .no-print, forces light theme, expands code,
    appends URLs after inline links. See src/print.test.ts for contract tests.

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -15,6 +15,7 @@ import EndpointGroupHover, { type EndpointGroupPreview } from "../components/End
 import EndpointPreview from "../components/EndpointPreview";
 import RatingHistogram from "../components/RatingHistogram";
 import { ApiDetailStickyTOC, type TocSection } from "../components/ApiDetailStickyTOC";
+import { StickyTocErrorBoundary } from "../components/StickyTocErrorBoundary";
 import { CheckIcon } from "../components/icons";
 import { copyToClipboard, getInsomniaImportUrl, getPostmanImportUrl } from "../utils/postman";
 import SubscribeButton from "../components/SubscribeButton";
@@ -796,7 +797,9 @@ print(response.json())`;
                     </div>
 
                     {/* Sticky TOC — hidden below 1100 px via CSS */}
-                    <ApiDetailStickyTOC sections={DOC_TOC_SECTIONS} />
+                    <StickyTocErrorBoundary>
+                      <ApiDetailStickyTOC sections={DOC_TOC_SECTIONS} />
+                    </StickyTocErrorBoundary>
                   </section>
                 )}
 

--- a/src/pages/StickyToc.tsx
+++ b/src/pages/StickyToc.tsx
@@ -13,3 +13,5 @@ export {
 } from "../components/ApiDetailStickyTOC";
 
 export { ApiDetailStickyTOC as default } from "../components/ApiDetailStickyTOC";
+
+export { StickyTocErrorBoundary } from "../components/StickyTocErrorBoundary";


### PR DESCRIPTION
CLOSES #736 