### PR TITLE
feat: add copy-to-clipboard affordance on EmptyState

### DIFF
--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -133,6 +133,95 @@ describe("EmptyState", () => {
     });
   });
 
+  describe("copy-to-clipboard affordance (Issue #733)", () => {
+    const originalClipboard = navigator.clipboard;
+
+    beforeEach(() => {
+      Object.assign(navigator, {
+        clipboard: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+    });
+
+    afterEach(() => {
+      Object.assign(navigator, { clipboard: originalClipboard });
+    });
+
+    it("renders a copy button next to the message when clipboard is supported", () => {
+      render(<EmptyState variant="error" message="Something went wrong" />);
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      expect(copyBtn).toBeTruthy();
+      expect(copyBtn.textContent).toBe("Copy");
+    });
+
+    it("copies the message text to clipboard on button click", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<EmptyState variant="error" message="Error details to copy" />);
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      fireEvent.click(copyBtn);
+
+      // Wait for microtask
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("Error details to copy");
+      });
+    });
+
+    it("shows 'Copied!' feedback after successful copy", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<EmptyState variant="error" message="test message" />);
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      fireEvent.click(copyBtn);
+
+      await vi.waitFor(() => {
+        expect(copyBtn.textContent).toBe("Copied!");
+      });
+    });
+
+    it("has an accessible aria-label on the copy button", () => {
+      render(<EmptyState variant="filtered" message="Copy this text" />);
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      expect(copyBtn.getAttribute("aria-label")).toBe('Copy "Copy this text"');
+    });
+
+    it("does not render copy button when clipboard API is unsupported", () => {
+      Object.assign(navigator, { clipboard: undefined });
+      render(<EmptyState variant="error" message="Unsupported" />);
+      expect(screen.queryByTestId("empty-state-copy-button")).toBeNull();
+    });
+
+    it("renders copy button in compact size as well", () => {
+      render(
+        <EmptyState
+          variant="filtered"
+          size="compact"
+          message="Compact copy"
+        />,
+      );
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      expect(copyBtn).toBeTruthy();
+      expect(copyBtn.textContent).toBe("Copy");
+    });
+
+    it("announces copy status to screen readers via aria-live region", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<EmptyState variant="error" message="Announce this" />);
+      const copyBtn = screen.getByTestId("empty-state-copy-button");
+      fireEvent.click(copyBtn);
+
+      await vi.waitFor(() => {
+        const status = screen.getByRole("status");
+        expect(status.textContent).toBe("Message copied.");
+      });
+    });
+  });
+
   describe("error variant — onRetry", () => {
     it("renders retry button when onRetry is provided", () => {
       const onRetry = vi.fn();

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useCallback } from "react";
 import ExternalLink from "./ExternalLink";
+import { useCopy } from "../hooks/useCopy";
+import { EmptyStateSkeleton } from "./Skeleton";
 
 export type EmptyStateVariant =
   | "empty"
@@ -479,6 +481,107 @@ function EmptyIllustration({
 }
 
 /**
+ * Compact copy-to-clipboard line rendered alongside the EmptyState message.
+ * Provides success feedback for assistive technology via aria-live.
+ */
+function MessageWithCopy({
+  message,
+  isCompact,
+}: {
+  message: string;
+  isCompact: boolean;
+}) {
+  const { copy, copied, supported } = useCopy();
+  const [liveFeedback, setLiveFeedback] = React.useState("");
+
+  const handleCopy = useCallback(() => {
+    if (!supported) return;
+    copy(message).then((ok) => {
+      if (ok) {
+        setLiveFeedback("Message copied.");
+        setTimeout(() => setLiveFeedback(""), 2000);
+      }
+    });
+  }, [copy, message, supported]);
+
+  const containerStyle: React.CSSProperties = {
+    display: "flex",
+    gap: isCompact ? "6px" : "8px",
+    alignItems: "flex-start",
+    justifyContent: "center",
+    maxWidth: isCompact ? "240px" : "320px",
+  };
+
+  const messageStyle: React.CSSProperties = isCompact
+    ? {
+        margin: 0,
+        color: "var(--muted)",
+        fontSize: "0.8125rem",
+        lineHeight: 1.4,
+      }
+    : {
+        margin: "0 0 24px 0",
+        color: "var(--muted)",
+        fontSize: "0.9375rem",
+        lineHeight: 1.5,
+      };
+
+  const btnStyle: React.CSSProperties = {
+    flexShrink: 0,
+    background: "none",
+    border: "1px solid var(--line)",
+    borderRadius: "4px",
+    cursor: "pointer",
+    padding: "2px 6px",
+    fontSize: isCompact ? "0.7rem" : "0.75rem",
+    color: "var(--accent)",
+    lineHeight: 1.4,
+    whiteSpace: "nowrap",
+    marginTop: isCompact ? 0 : "2px",
+    transition: "color 0.15s ease, border-color 0.15s ease",
+  };
+
+  if (!supported) {
+    return (
+      <p
+        style={messageStyle}
+        data-testid="empty-state-message"
+      >
+        {message}
+      </p>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <p style={messageStyle} data-testid="empty-state-message">
+        {message}
+      </p>
+      <button
+        type="button"
+        style={btnStyle}
+        onClick={handleCopy}
+        aria-label={`Copy "${message}"`}
+        data-testid="empty-state-copy-button"
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+      {/* Screen-reader announcement for copy feedback (WCAG 4.1.3) */}
+      {liveFeedback && (
+        <span
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {liveFeedback}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
  * EmptyState component with distinct variants for different marketplace states.
  *
  * Variants:
@@ -720,7 +823,7 @@ export default function EmptyState({
 
       <HeadingTag style={headingStyle}>{finalTitle}</HeadingTag>
 
-      <p style={messageStyle}>{finalMessage}</p>
+      <MessageWithCopy message={finalMessage} isCompact={isCompact} />
 
       {resolvedAction && (
         <button

--- a/src/hooks/useCopy.ts
+++ b/src/hooks/useCopy.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const FEEDBACK_DURATION_MS = 2000;
+
+export interface UseCopyReturn {
+  /** Whether the last copy was successful and we're still showing feedback. */
+  copied: boolean;
+  /** Whether the browser's clipboard API is supported in this environment. */
+  supported: boolean;
+  /** Copy `text` to clipboard.  Returns `true` on success. */
+  copy: (text: string) => Promise<boolean>;
+}
+
+/**
+ * useCopy — a tiny copy-to-clipboard hook with success feedback.
+ *
+ * - Wraps `navigator.clipboard.writeText` with a `try/catch` so callers never
+ *   need to handle permission / HTTPS errors.
+ * - Sets `copied = true` for 2 seconds after a successful copy so the UI can
+ *   show a transient "Copied!" label, icon, or tooltip (WCAG 2.1 SC 2.2.1).
+ * - Reports `supported` so the consuming component can hide the copy button
+ *   entirely when the Clipboard API is unavailable (e.g. insecure context).
+ *
+ * @example
+ * ```tsx
+ * const { copy, copied, supported } = useCopy();
+ * if (!supported) return null;
+ * return <button onClick={() => copy("hello")}>{copied ? "Copied!" : "Copy"}</button>;
+ * ```
+ */
+export function useCopy(): UseCopyReturn {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const supported =
+    typeof navigator !== "undefined" &&
+    typeof navigator.clipboard?.writeText === "function";
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    // Cleanup timer on unmount so we never update state after dismount.
+    return () => clearTimer();
+  }, [clearTimer]);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!supported) return false;
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        clearTimer();
+        timerRef.current = setTimeout(() => setCopied(false), FEEDBACK_DURATION_MS);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [supported, clearTimer],
+  );
+
+  return { copy, copied, supported };
+}


### PR DESCRIPTION
## Overview

This PR adds a copy-to-clipboard button on EmptyState messages, allowing users to quickly copy displayed error messages, filter messages, or other text content. A reusable `useCopy` hook provides the clipboard logic with success feedback, and an aria-live region announces copy status for screen readers (WCAG 4.1.3).

## Related Issue

Closes #733

## Changes

- **`src/hooks/useCopy.ts`** — New reusable hook wrapping `navigator.clipboard.writeText` with success feedback
- **`src/components/EmptyState.tsx`** — Add `MessageWithCopy` sub-component with copy button; fixes pre-existing EmptyStateSkeleton import
- **`src/components/EmptyState.test.tsx`** — Add 7 focused tests

## Verification Results

```
npx vitest run src/components/EmptyState.test.tsx
✅ 53/53 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Copy button appears next to message text | ✅ |
| Clipboard copy works with success feedback | ✅ "Copied!" label for 2s |
| Screen reader announced on copy | ✅ aria-live="polite" role="status" |
| Graceful fallback when clipboard API unavailable | ✅ |
| Works in compact size | ✅ |
| Reusable hook | ✅ useCopy with JSDoc |
## Timeline

- garfieldxxx1 committed