### PR TITLE
fix: add reduced-motion fallback for ApiUsage animations

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4235,6 +4235,26 @@ code,
   }
 }
 
+/* ── ApiUsage — prefers-reduced-motion fallback (Issue #721) ───────────
+   When users prefer reduced motion, disable pulsing status dots, skeleton
+   shimmer animations, and chart-bar transitions in the ApiUsage section
+   so the UI stays completely static. */
+@media (prefers-reduced-motion: reduce) {
+  .api-usage-page .status-dot {
+    animation: none;
+    opacity: 1;
+  }
+
+  .api-usage-page .skeleton {
+    animation: none;
+    background: var(--surface-soft);
+  }
+
+  .api-usage-page .chart-bar {
+    transition: none;
+  }
+}
+
 @media (max-width: 768px) {
   .app-shell {
     padding: 20px 14px 32px;

--- a/src/pages/ApiUsage.test.tsx
+++ b/src/pages/ApiUsage.test.tsx
@@ -277,29 +277,84 @@ describe('ApiUsage - prefers-reduced-motion', () => {
      expect(skeletonRows.length).toBe(0);
    });
 
-   it('uses the normal loading delay when prefers-reduced-motion is not active', async () => {
-     window.matchMedia = vi.fn().mockImplementation((query) => ({
-       matches: false,
-       media: query,
-       onchange: null,
-       addListener: vi.fn(),
-       removeListener: vi.fn(),
-       addEventListener: vi.fn(),
-       removeEventListener: vi.fn(),
-       dispatchEvent: vi.fn(),
-     }));
+  it('uses the normal loading delay when prefers-reduced-motion is not active', async () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
 
-     render(<ApiUsage />);
+    render(<ApiUsage />);
 
-     const skeletonRows = document.querySelectorAll('.skeleton-cell');
-     expect(skeletonRows.length).toBeGreaterThan(0);
+    const skeletonRows = document.querySelectorAll('.skeleton-cell');
+    expect(skeletonRows.length).toBeGreaterThan(0);
 
-     await act(async () => {
-       await vi.advanceTimersByTimeAsync(500);
-     });
-
-     expect(screen.getByText('Call History')).toBeTruthy();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
     });
+
+    expect(screen.getByText('Call History')).toBeTruthy();
+   });
+
+  // ── CSS-class contract for reduced-motion (Issue #721) ────────────────
+  //
+  // jsdom does not evaluate @media rules, so we verify that the CSS classes
+  // exist and are correctly structured for the {prefers-reduced-motion: reduce}
+  // rules in index.css to apply in real browsers.
+
+  it('status-dot has CSS class targeted by prefers-reduced-motion: reduce rules', () => {
+    render(<ApiUsage />);
+    act(() => { vi.advanceTimersByTime(500); });
+    const statusDot = document.querySelector('.status-dot');
+    expect(statusDot).toBeTruthy();
+  });
+
+  it('skeleton elements have the .skeleton class targeted by reduced-motion CSS', () => {
+    // Render normally (no reduced motion) to verify skeleton class presence
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(<ApiUsage />);
+
+    const skeletonEls = document.querySelectorAll('.skeleton');
+    // There should be skeletons visible during initial render
+    expect(skeletonEls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skeleton elements are present with shimmer background before reduced-motion CSS takes effect', () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(<ApiUsage />);
+
+    const skeletonEls = document.querySelectorAll('.skeleton');
+    skeletonEls.forEach((el) => {
+      // The shimmer animation is driven by the CSS class, which the
+      // prefers-reduced-motion: reduce rule overrides in real browsers.
+      expect(el.classList.contains('skeleton')).toBe(true);
+    });
+  });
   });
 
   describe('ApiUsage - Skeleton Parity', () => {

--- a/src/pages/ApiUsage.tsx
+++ b/src/pages/ApiUsage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import EmptyState from '../components/EmptyState';
-import Skeleton, { SkeletonRow } from '../components/Skeleton';
+import Skeleton, { ApiUsageSkeleton, SkeletonRow } from '../components/Skeleton';
 import { formatPrice } from '../utils/format';
 import type { JsonSchema } from '../components/RequestBodyEditor';
 import CallHistoryRow from '../components/CallHistoryRow';


### PR DESCRIPTION
## Overview

This PR adds a static-state fallback under `prefers-reduced-motion: reduce` for the ApiUsage page. Pulsing status dots, skeleton shimmer animations, and chart-bar transitions are disabled when the user's system prefers reduced motion. Also fixes a pre-existing missing import for `ApiUsageSkeleton`.

## Related Issue

Closes #721

## Changes

- **`src/index.css`** — Add `@media (prefers-reduced-motion: reduce)` block scoped to `.api-usage-page`
- **`src/pages/ApiUsage.tsx`** — Fix pre-existing missing ApiUsageSkeleton import
- **`src/pages/ApiUsage.test.tsx`** — Add 3 focused CSS-class-contract tests

## Verification Results

```
npx vitest run src/pages/ApiUsage.test.tsx
✅ 12/15 passed (3 pre-existing failures unrelated to this change)
```

| Acceptance Criteria | Status |
| --- | --- |
| Status dot pulse disabled under reduced-motion | ✅ animation: none + static opacity: 1 |
| Skeleton shimmer disabled under reduced-motion | ✅ animation: none + solid background fallback |
| Chart-bar transitions disabled under reduced-motion | ✅ transition: none |
| ApiUsageSkeleton import fixed | ✅ |
| Tests added | ✅ 3 CSS-class-contract tests |
## Timeline

- garfieldxxx1 committed