### PR TITLE
feat(fwc26): hover/focus PreviewCard on BillingHistory

### DIFF
--- a/docs/BillingHistoryPreview.md
+++ b/docs/BillingHistoryPreview.md
@@ -1,0 +1,215 @@
+# BillingHistory Preview Card
+
+**Campaign:** GrantFox FWC26
+**Issue:** UI/UX — hover-triggered preview card on BillingHistory; keyboard-accessible alternative
+**Route:** `/billing/history`
+**Files changed:**
+- `src/components/PreviewCard.tsx` — extended with billing-specific fields
+- `src/pages/BillingHistory.tsx` — new page component
+- `src/App.tsx` — route + navigation entries added
+
+---
+
+## Overview
+
+The Billing History page displays a paginated table of USDC transactions. Each row's description cell is wrapped in a **PreviewCard** trigger. Hovering or focusing the trigger opens a compact floating panel that reveals on-chain details — transaction hash, network, confirmation count, direction badge, formatted amount, and timestamp — without requiring the user to navigate to a separate page.
+
+---
+
+## User flows
+
+### Mouse user
+
+1. Visit `/billing/history`.
+2. Hover the description text of any transaction row.
+3. A tooltip-style card appears below the cell with:
+   - Transaction type + credit/debit badge
+   - Formatted USDC amount (e.g. `+100.00 USDC`)
+   - Network name (`Stellar Mainnet`)
+   - Confirmation count
+   - Truncated tx hash (full hash available in the `title` attribute)
+   - Formatted timestamp
+4. Moving the cursor off the row closes the card.
+
+### Keyboard user
+
+1. Tab to a transaction row's description trigger.
+2. The preview card opens automatically on focus.
+3. Read the on-chain details via the `aria-describedby` association or by listening to the `role="tooltip"` announcement.
+4. Press **Escape** to dismiss the card and return focus to the trigger.
+5. Tab again to move to the next row (card closes automatically on blur).
+
+---
+
+## Filtering
+
+The page exposes four filter controls above the table:
+
+| Control | Values |
+|---------|--------|
+| Search | Free text (description or tx hash prefix) |
+| Type | All / Deposit / API Call / Refund / Settlement / Fee |
+| Status | All / success / pending / error / warning |
+| Direction | All / Credit / Debit |
+
+Filters are combinable. A live region (`role="status" aria-live="polite"`) announces the active filter state to screen readers after each change.
+
+When no transactions match, a clearly labelled empty-state message replaces the table.
+
+---
+
+## API — PreviewCard
+
+`PreviewCard` is a shared component (`src/components/PreviewCard.tsx`). It accepts a `PreviewCardData` object, a trigger as `children`, an optional `position` prop, and an optional `className`.
+
+### `PreviewCardData` — complete type
+
+```ts
+export interface PreviewCardData {
+  id: string;
+  title: string;
+
+  // — Shared (dashboard overview + billing history)
+  subtitle?: string;
+  category?: string;
+  status?: StatusVariant;           // See StatusBadge
+  description?: string;
+  metrics?: PreviewMetric[];        // { label, value }[]
+  tags?: string[];
+  price?: string | number;
+  lastActive?: string;
+  details?: Record<string, string | number>;
+
+  // — Billing-specific (GrantFox FWC26)
+  txHash?: string;          // Full 64-char Stellar hash
+  network?: string;         // e.g. "Stellar Mainnet"
+  confirmations?: number;   // Ledger confirmation count
+  type?: string;            // "Deposit" | "API Call" | etc.
+  timestamp?: string;       // ISO 8601
+  amount?: number;          // USDC value (positive)
+  direction?: 'credit' | 'debit';
+}
+```
+
+**Mode detection:** if any of `txHash`, `network`, `confirmations`, `type`, or `amount` is present, the card renders the billing-specific section and suppresses the generic `metrics` grid and `price/lastActive` footer. Existing callers (DashboardOverview) are unaffected.
+
+### `PreviewCardProps`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `PreviewCardData` | required | Card content |
+| `children` | `ReactNode` | required | Hover/focus trigger element |
+| `position` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | Floating panel placement |
+| `className` | `string` | `''` | Extra class on the wrapper `div` |
+
+### Usage example — billing row
+
+```tsx
+import PreviewCard, { type PreviewCardData } from '../components/PreviewCard';
+
+const data: PreviewCardData = {
+  id: 'tx-001',
+  title: 'USDC vault deposit',
+  status: 'success',
+  type: 'Deposit',
+  direction: 'credit',
+  amount: 100.00,
+  txHash: 'A3F9B2C1D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1',
+  network: 'Stellar Mainnet',
+  confirmations: 120,
+  timestamp: '2026-07-25T14:32:00Z',
+};
+
+<PreviewCard data={data} position="bottom">
+  <span>USDC vault deposit</span>
+</PreviewCard>
+```
+
+---
+
+## API — BillingHistory page
+
+`BillingHistory` is a default-exported React component at `src/pages/BillingHistory.tsx`. It requires no props — all data comes from the internal `MOCK_TRANSACTIONS` constant.
+
+### Exports
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `BillingHistory` | named + default export | Page component |
+| `MOCK_TRANSACTIONS` | named export | Array of `BillingTransaction` for use in tests and Storybook |
+| `BillingTransaction` | type | Shape of a single transaction record |
+| `TxType` | type | `'Deposit' \| 'API Call' \| 'Refund' \| 'Settlement' \| 'Fee'` |
+| `TxDirection` | type | `'credit' \| 'debit'` |
+| `TxStatus` | type | Subset of `StatusVariant` used for transactions |
+
+---
+
+## Accessibility notes (WCAG 2.1 AA)
+
+| Criterion | Implementation |
+|-----------|----------------|
+| **1.1.1 Non-text content** | Direction arrows are `aria-hidden`; information is also in the `direction` badge text. |
+| **1.3.1 Info and Relationships** | `<table>` with `<thead>` / `<th scope="col">` / `<tbody>` exposes structure. |
+| **1.3.3 Sensory Characteristics** | Status is never conveyed by colour alone — `StatusBadge` adds a texture pattern. |
+| **1.4.1 Use of Color** | Credit/debit is labelled with text ("↑ credit" / "↓ debit") in addition to colour. |
+| **1.4.3 Contrast** | All colours reference design tokens; both dark and light themes pass 4.5:1 minimum. |
+| **2.1.1 Keyboard** | All PreviewCard triggers are `tabIndex={0}` with `role="button"`. Escape dismisses the preview. |
+| **2.4.3 Focus Order** | Escape restores focus to the trigger; `suppressNextFocus` guard prevents immediate re-open. |
+| **2.4.6 Headings and Labels** | Page heading (`<h1>`), filter group (`role="group" aria-label`), and table all have labels. |
+| **4.1.2 Name, Role, Value** | Trigger: `role="button"`, `aria-label`, `aria-describedby`. Panel: `role="tooltip"`, `aria-label`. |
+| **4.1.3 Status Messages** | Filter changes announced via `role="status" aria-live="polite" aria-atomic="true"`. |
+
+### Skip-link support
+
+The page lives under `<main id="main-content">` which the app-level skip link already targets — no additional work needed.
+
+---
+
+## Design-token usage
+
+All colours in `PreviewCard` and `BillingHistory` use CSS custom properties so both light and dark themes are covered automatically.
+
+| Token | Used for |
+|-------|----------|
+| `--surface` | Preview card background |
+| `--line` / `--border-color` | Preview card and table borders |
+| `--shadow` | Preview card drop shadow |
+| `--text-primary` / `--text` | Primary text |
+| `--text-secondary` / `--muted` | Secondary / muted text |
+| `--accent` | Tx hash, confirmation count, accent values |
+| `--success` | Credit amounts, high-confirmation count |
+| `--danger` | Debit amounts, error states |
+| `--bg-chip` | Billing details section background |
+| `--sb-success-bg/fg` | Credit direction badge |
+| `--sb-error-bg/fg` | Debit direction badge |
+
+---
+
+## Responsive behaviour
+
+- The table container uses `overflow-x: auto` so horizontal scrolling is available on small viewports.
+- The preview card has `maxWidth: 90vw` — it never overflows the viewport on narrow screens.
+- Filter controls use `flexWrap: wrap` so they stack on small screens without clipping.
+- The page heading uses `clamp(1.35rem, 3vw, 1.75rem)` for fluid sizing.
+
+---
+
+## Running the tests
+
+```bash
+# New tests only
+npm test -- --run src/components/PreviewCard.test.tsx src/pages/BillingHistory.test.tsx
+
+# Full suite
+npm test -- --run
+```
+
+Expected result: **56 new tests pass** (31 BillingHistory + 25 PreviewCard).
+
+---
+
+## Related docs
+
+- [UI Design System](./UI-Design-System.md) — design tokens and component guidelines
+- [ResponseDiff](./ResponseDiff.md) — similar hover/focus pattern on `CallHistoryRow`
+- `src/components/EndpointPreview.tsx` — the original hover preview pattern this feature follows

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import RateLimitCard from "./pages/RateLimitCard";
 import { ShortcutsModal } from "./components/ShortcutsModal";
 import { ToastProvider } from "./components/Toast";
 import { InvoiceCard } from "./pages/InvoiceCard";
+import BillingHistory from "./pages/BillingHistory";
 
 type DepositStage = "input" | "approving" | "pending" | "confirmed" | "failed";
 type DemoOutcome = "confirmed" | "failed";
@@ -117,6 +118,7 @@ const APP_ROUTES = {
   planBadge: "/apis/plan-badge",
   apiUsage: "/api-usage",
   billing: "/billing",
+  billingHistory: "/billing/history",
   documentation: "/documentation",
   status: "/status",
   themePlayground: "/theme-playground",
@@ -277,6 +279,7 @@ function App() {
     [APP_ROUTES.dashboard]: "Dashboard – Callora",
     [APP_ROUTES.myApis]: "My APIs – Callora",
     [APP_ROUTES.billing]: "Billing – Callora",
+    [APP_ROUTES.billingHistory]: "Billing History – Callora",
     "/api-usage": "API Usage – Callora",
     [APP_ROUTES.landing]: "Callora",
     [APP_ROUTES.endpointSummary]: "Endpoint Summary – Callora",
@@ -285,6 +288,7 @@ function App() {
     [APP_ROUTES.marketplace]: "Explore APIs on the Callora marketplace, discover and integrate APIs for your applications.",
     [APP_ROUTES.dashboard]: "Your Callora dashboard showing balances, recent activity and quick actions.",
     [APP_ROUTES.billing]: "Manage your USDC vault, deposit funds, and view transaction status.",
+    [APP_ROUTES.billingHistory]: "View your full USDC transaction history with on-chain details, filters, and hover previews.",
     "/api-usage": "Monitor API usage, request stats, and view call history.",
     [APP_ROUTES.landing]: "Callora - Programmable API Access, pay-per-call billing, and on-chain settlement.",
     [APP_ROUTES.endpointSummary]: "Quick reference list of all API endpoints on Callora.",
@@ -554,6 +558,9 @@ function App() {
               <NavLink to={APP_ROUTES.billing} className={({ isActive }) => (isActive ? "link-nav active" : "link-nav")}>
                 Billing
               </NavLink>
+              <NavLink to={APP_ROUTES.billingHistory} className={({ isActive }) => (isActive ? "link-nav active" : "link-nav")}>
+                Billing History
+              </NavLink>
               <NavLink to={APP_ROUTES.themePlayground} className={({ isActive }) => (isActive ? "link-nav active" : "link-nav")}>
                 Theme Playground
               </NavLink>
@@ -684,6 +691,9 @@ function App() {
             <Route path="/a11y-audit" element={<A11yAudit />} />
 
             <Route path={APP_ROUTES.rateLimitCard} element={<RateLimitCard />} />
+
+            {/* ── Billing History (FWC26) ──────────────────────────────── */}
+            <Route path={APP_ROUTES.billingHistory} element={<BillingHistory />} />
 
             <Route path="*" element={<NotFound onGoHome={() => navigate(APP_ROUTES.dashboard)} />} />
           </Routes>

--- a/src/components/PreviewCard.test.tsx
+++ b/src/components/PreviewCard.test.tsx
@@ -1,10 +1,22 @@
 // @vitest-environment jsdom
+/**
+ * PreviewCard.test.tsx
+ *
+ * Tests for the PreviewCard component covering:
+ *   - Dashboard/generic usage (original issue #689 surface)
+ *   - Billing-specific mode (GrantFox FWC26 — txHash, network,
+ *     confirmations, type, amount, direction, timestamp fields)
+ *   - Keyboard accessibility (focus open, Escape close, aria-describedby)
+ *   - ARIA semantics (role="tooltip", aria-label)
+ */
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import PreviewCard, { type PreviewCardData } from './PreviewCard';
 
-const MOCK_PREVIEW_DATA: PreviewCardData = {
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const DASHBOARD_DATA: PreviewCardData = {
   id: 'test-api-preview',
   title: 'WeatherSim API',
   subtitle: 'Callora Verified',
@@ -20,44 +32,65 @@ const MOCK_PREVIEW_DATA: PreviewCardData = {
   lastActive: '10 mins ago',
 };
 
-describe('PreviewCard Component', () => {
+/** Billing-mode data: includes at least one FWC26-specific field. */
+const BILLING_DATA: PreviewCardData = {
+  id: 'tx-001',
+  title: 'USDC vault deposit',
+  status: 'success',
+  type: 'Deposit',
+  direction: 'credit',
+  amount: 100.0,
+  txHash: 'A3F9B2C1D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1',
+  network: 'Stellar Mainnet',
+  confirmations: 120,
+  timestamp: '2026-07-25T14:32:00Z',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getWrapper(container: HTMLElement) {
+  return container.querySelector('.preview-card__wrapper') as HTMLElement;
+}
+
+function getTrigger() {
+  return screen.getByRole('button', { name: /preview details for/i });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PreviewCard — shared behaviour', () => {
   afterEach(cleanup);
 
   it('does not render the preview panel initially', () => {
     render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
     expect(screen.queryByRole('tooltip')).toBeNull();
   });
 
-  it('renders trigger element with an accessible aria-label', () => {
+  it('renders a trigger with an accessible aria-label', () => {
     render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
-
-    const trigger = screen.getByRole('button', {
-      name: /preview details for weathersim api/i,
-    });
-    expect(trigger).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /preview details for weathersim api/i }),
+    ).toBeTruthy();
   });
 
-  it('opens panel on mouseEnter and hides on mouseLeave', () => {
+  it('opens panel on mouseEnter and closes on mouseLeave', () => {
     const { container } = render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
-
-    const wrapper = container.querySelector('.preview-card__wrapper') as HTMLElement;
-    expect(wrapper).toBeTruthy();
+    const wrapper = getWrapper(container);
 
     fireEvent.mouseEnter(wrapper);
     expect(screen.getByRole('tooltip')).toBeTruthy();
-    expect(screen.getByRole('tooltip')).toHaveTextContent('WeatherSim API');
 
     fireEvent.mouseLeave(wrapper);
     expect(screen.queryByRole('tooltip')).toBeNull();
@@ -65,47 +98,50 @@ describe('PreviewCard Component', () => {
 
   it('opens panel when trigger receives keyboard focus', () => {
     render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
-
-    const trigger = screen.getByRole('button', {
-      name: /preview details for weathersim api/i,
-    });
-
-    fireEvent.focus(trigger);
+    fireEvent.focus(getTrigger());
     expect(screen.getByRole('tooltip')).toBeTruthy();
   });
 
-  it('links trigger to preview panel via aria-describedby while open', () => {
+  it('sets aria-describedby on trigger while panel is open', () => {
     render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
-
-    const trigger = screen.getByRole('button', {
-      name: /preview details for weathersim api/i,
-    });
-
+    const trigger = getTrigger();
     fireEvent.focus(trigger);
 
     const panel = screen.getByRole('tooltip');
     expect(trigger.getAttribute('aria-describedby')).toBe(panel.id);
   });
 
-  it('closes preview panel and clears aria-describedby on Escape key', () => {
-    render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+  it('clears aria-describedby when panel is closed', () => {
+    const { container } = render(
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
+    const wrapper = getWrapper(container);
+    const trigger = getTrigger();
 
-    const trigger = screen.getByRole('button', {
-      name: /preview details for weathersim api/i,
-    });
+    fireEvent.mouseEnter(wrapper);
+    expect(trigger.getAttribute('aria-describedby')).toBeTruthy();
 
+    fireEvent.mouseLeave(wrapper);
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('closes panel on Escape and removes aria-describedby', () => {
+    render(
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    const trigger = getTrigger();
     fireEvent.focus(trigger);
     expect(screen.getByRole('tooltip')).toBeTruthy();
 
@@ -114,17 +150,64 @@ describe('PreviewCard Component', () => {
     expect(trigger.getAttribute('aria-describedby')).toBeNull();
   });
 
-  it('renders title, status, description, metrics, and tags inside panel', () => {
+  it('panel has role="tooltip" and an aria-label', () => {
     render(
-      <PreviewCard data={MOCK_PREVIEW_DATA}>
-        <div>Card trigger</div>
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
       </PreviewCard>,
     );
+    fireEvent.focus(getTrigger());
 
-    const trigger = screen.getByRole('button', {
-      name: /preview details for weathersim api/i,
-    });
-    fireEvent.focus(trigger);
+    const panel = screen.getByRole('tooltip');
+    expect(panel.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  it('panel has pointer-events: none to avoid mouse trapping', () => {
+    render(
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel.style.pointerEvents).toBe('none');
+  });
+
+  it('passes custom position prop without crashing', () => {
+    const { container } = render(
+      <PreviewCard data={DASHBOARD_DATA} position="top">
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    const wrapper = getWrapper(container);
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+  });
+
+  it('passes className to wrapper', () => {
+    const { container } = render(
+      <PreviewCard data={DASHBOARD_DATA} className="custom-class">
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    const wrapper = getWrapper(container);
+    expect(wrapper.classList.contains('custom-class')).toBe(true);
+  });
+});
+
+// ── Dashboard-mode tests ──────────────────────────────────────────────────────
+
+describe('PreviewCard — dashboard mode (no billing fields)', () => {
+  afterEach(cleanup);
+
+  it('renders title, status badge, description, metrics, and tags', () => {
+    render(
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
 
     const panel = screen.getByRole('tooltip');
     expect(panel).toHaveTextContent('WeatherSim API');
@@ -133,5 +216,201 @@ describe('PreviewCard Component', () => {
     expect(panel).toHaveTextContent('35ms');
     expect(panel).toHaveTextContent('#weather');
     expect(panel).toHaveTextContent('$0.005 / call');
+    expect(panel).toHaveTextContent('Last active: 10 mins ago');
+  });
+
+  it('does not render the billing section when no billing fields are provided', () => {
+    render(
+      <PreviewCard data={DASHBOARD_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    // The billing section shows "Network", "Confirmations", "Tx hash"
+    const panel = screen.getByRole('tooltip');
+    expect(panel).not.toHaveTextContent('Network');
+    expect(panel).not.toHaveTextContent('Confirmations');
+    expect(panel).not.toHaveTextContent('Tx hash');
+  });
+});
+
+// ── Billing-mode tests (FWC26) ────────────────────────────────────────────────
+
+describe('PreviewCard — billing mode (FWC26)', () => {
+  afterEach(cleanup);
+
+  it('renders billing section when txHash is provided', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveTextContent('Tx hash');
+    // truncated hash: first 8 chars
+    expect(panel).toHaveTextContent('A3F9B2C1');
+  });
+
+  it('renders transaction type and credit direction badge', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveTextContent('Type');
+    expect(panel).toHaveTextContent('Deposit');
+    expect(panel).toHaveTextContent('credit');
+  });
+
+  it('renders debit direction badge when direction is debit', () => {
+    const debitData: PreviewCardData = {
+      ...BILLING_DATA,
+      direction: 'debit',
+      title: 'API Call',
+    };
+    render(
+      <PreviewCard data={debitData}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('debit');
+  });
+
+  it('renders formatted amount with USDC label', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveTextContent('Amount');
+    expect(panel).toHaveTextContent('100.00 USDC');
+  });
+
+  it('renders network name', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Stellar Mainnet');
+  });
+
+  it('renders confirmation count', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveTextContent('Confirmations');
+    expect(panel).toHaveTextContent('120');
+  });
+
+  it('renders timestamp as a <time> element with dateTime attribute', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    const timeEl = panel.querySelector('time');
+    expect(timeEl).toBeTruthy();
+    expect(timeEl!.getAttribute('dateTime')).toBe('2026-07-25T14:32:00Z');
+  });
+
+  it('does not render generic metrics grid in billing mode', () => {
+    const billingWithMetrics: PreviewCardData = {
+      ...BILLING_DATA,
+      metrics: [{ label: 'ShouldNotAppear', value: 'X' }],
+    };
+    render(
+      <PreviewCard data={billingWithMetrics}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    // Metrics grid is suppressed in billing mode
+    expect(screen.getByRole('tooltip')).not.toHaveTextContent('ShouldNotAppear');
+  });
+
+  it('does not render generic price/lastActive footer in billing mode', () => {
+    const billingWithPrice: PreviewCardData = {
+      ...BILLING_DATA,
+      price: 999,
+      lastActive: 'yesterday',
+    };
+    render(
+      <PreviewCard data={billingWithPrice}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).not.toHaveTextContent('$999 / call');
+    expect(panel).not.toHaveTextContent('Last active: yesterday');
+  });
+
+  it('renders escape-key hint inside the panel', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Esc');
+  });
+
+  it('keyboard: Escape closes billing preview and clears aria-describedby', () => {
+    render(
+      <PreviewCard data={BILLING_DATA}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    const trigger = getTrigger();
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('detects billing mode from amount alone (no txHash)', () => {
+    const amountOnly: PreviewCardData = {
+      id: 'tx-x',
+      title: 'Partial billing data',
+      amount: 25.5,
+      direction: 'credit',
+    };
+    render(
+      <PreviewCard data={amountOnly}>
+        <div>trigger</div>
+      </PreviewCard>,
+    );
+    fireEvent.focus(getTrigger());
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveTextContent('Amount');
+    expect(panel).toHaveTextContent('25.50 USDC');
   });
 });

--- a/src/components/PreviewCard.tsx
+++ b/src/components/PreviewCard.tsx
@@ -1,28 +1,51 @@
 /**
- * PreviewCard.tsx — Hover and focus preview card component for dashboard overview elements.
+ * PreviewCard.tsx — Hover and focus preview card component.
  *
- * GrantFox FWC26 campaign (Issue #689 / b#012) requirement:
- * Provide hover-triggered and keyboard-accessible preview card on DashboardOverview
- * rows/cards so users can preview details (status, metrics, tags, pricing, description)
- * without navigating away.
+ * GrantFox FWC26 campaign requirement:
+ * - Issue #689: Hover-triggered preview on DashboardOverview rows/cards.
+ * - Issue #FWC26: Hover-triggered preview on BillingHistory transaction rows,
+ *   surfacing on-chain details (tx hash, network, confirmations, tx type)
+ *   without navigating away.
  *
  * Accessibility (WCAG 2.1 AA):
- * - The trigger receives `aria-describedby` pointing at the preview panel while open.
- * - The preview card has `role="tooltip"` for supplementary info announcement.
- * - Pressing `Escape` closes the preview card cleanly and restores focus position.
- * - Color and styling rely on CSS custom properties (design tokens) for light/dark theme parity.
+ * - The trigger receives `aria-describedby` pointing at the preview panel
+ *   while open, satisfying WCAG 1.3.1 (Info and Relationships).
+ * - The preview card has `role="tooltip"` so assistive technology announces
+ *   it as supplementary information rather than as a live region.
+ * - Pressing `Escape` closes the preview card cleanly and returns focus to
+ *   the trigger (WCAG 2.1.1 Keyboard, 2.4.3 Focus Order).
+ * - `pointer-events: none` on the panel prevents mouse trapping.
+ * - All colours reference CSS custom properties (design tokens) so both
+ *   light and dark themes are covered automatically (WCAG 1.4.3 Contrast).
  */
 
-import { useId, useRef, useState, type ReactNode, type KeyboardEvent, type FocusEvent } from 'react';
+import {
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type KeyboardEvent,
+  type FocusEvent,
+} from 'react';
 import StatusBadge, { type StatusVariant } from './StatusBadge';
+
+// ── Shared metric type ────────────────────────────────────────────────────────
 
 export interface PreviewMetric {
   label: string;
   value: string | number;
 }
 
+// ── PreviewCardData ───────────────────────────────────────────────────────────
+// The data shape used by PreviewCard.  All billing-specific fields are optional
+// so existing dashboard callers are not affected.
+
 export interface PreviewCardData {
+  /** Unique row/item ID used as a React key. */
   id: string;
+
+  // ── Common fields (Dashboard overview & Billing history) ──────────────────
+
   title: string;
   subtitle?: string;
   category?: string;
@@ -32,19 +55,108 @@ export interface PreviewCardData {
   tags?: string[];
   price?: string | number;
   lastActive?: string;
+  /** Arbitrary key/value pairs rendered as a compact detail list. */
   details?: Record<string, string | number>;
+
+  // ── Billing-specific fields (Issue FWC26) ─────────────────────────────────
+
+  /**
+   * Full 64-character Stellar transaction hash.
+   * Displayed truncated (first 8 … last 6 chars) with a copy hint.
+   */
+  txHash?: string;
+
+  /**
+   * Blockchain / ledger network name, e.g. "Stellar Mainnet", "Stellar Testnet".
+   */
+  network?: string;
+
+  /**
+   * Number of ledger confirmations at the time the data was fetched.
+   * Shown as a numeric badge.
+   */
+  confirmations?: number;
+
+  /**
+   * High-level billing transaction type.
+   * Examples: "Deposit", "API Call", "Refund", "Settlement", "Fee"
+   */
+  type?: string;
+
+  /**
+   * ISO 8601 timestamp string for when the transaction was recorded.
+   * Displayed in a human-readable locale format.
+   */
+  timestamp?: string;
+
+  /**
+   * Amount of USDC involved in the transaction.
+   * Pass as a numeric value; the card formats it with 2 decimal places.
+   */
+  amount?: number;
+
+  /**
+   * Direction of the transaction from the user's perspective.
+   * Controls colour: credit (positive) = success green; debit = danger red.
+   */
+  direction?: 'credit' | 'debit';
 }
 
+// ── PreviewCardProps ──────────────────────────────────────────────────────────
+
 export interface PreviewCardProps {
-  /** The item details to present in the preview card overlay */
+  /** The item details to present in the preview card overlay. */
   data: PreviewCardData;
-  /** Content acting as trigger for hover/focus */
+  /** Content acting as the hover/focus trigger. */
   children: ReactNode;
-  /** Floating overlay placement relative to trigger */
+  /** Floating overlay placement relative to the trigger element. */
   position?: 'top' | 'bottom' | 'left' | 'right';
-  /** Optional custom class name */
+  /** Optional additional class name for the wrapper element. */
   className?: string;
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Truncate a transaction hash for compact display.
+ * "abcdefgh...xyz" where the prefix is 8 chars and suffix is 6.
+ */
+function truncateTxHash(hash: string): string {
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}…${hash.slice(-6)}`;
+}
+
+/**
+ * Format a numeric USDC amount with exactly 2 decimal places.
+ * Uses Intl.NumberFormat for locale-aware thousands separators.
+ */
+function formatUsdcAmount(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+/**
+ * Format an ISO 8601 timestamp into a human-readable string.
+ * Falls back to the raw string if parsing fails.
+ */
+function formatTimestamp(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 export function PreviewCard({
   data,
@@ -55,6 +167,12 @@ export function PreviewCard({
   const [open, setOpen] = useState(false);
   const panelId = useId();
   const triggerRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * When the user presses Escape we programmatically re-focus the trigger.
+   * This flag prevents the subsequent focus event from immediately re-opening
+   * the panel.
+   */
   const suppressNextFocus = useRef(false);
 
   const show = () => setOpen(true);
@@ -71,16 +189,45 @@ export function PreviewCard({
   const getPositionStyles = (): React.CSSProperties => {
     switch (position) {
       case 'top':
-        return { bottom: '100%', left: '50%', transform: 'translateX(-50%)', marginBottom: '8px' };
+        return {
+          bottom: '100%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          marginBottom: '8px',
+        };
       case 'left':
-        return { right: '100%', top: '50%', transform: 'translateY(-50%)', marginRight: '8px' };
+        return {
+          right: '100%',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          marginRight: '8px',
+        };
       case 'right':
-        return { left: '100%', top: '50%', transform: 'translateY(-50%)', marginLeft: '8px' };
+        return {
+          left: '100%',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          marginLeft: '8px',
+        };
       case 'bottom':
       default:
-        return { top: '100%', left: '50%', transform: 'translateX(-50%)', marginTop: '8px' };
+        return {
+          top: '100%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          marginTop: '8px',
+        };
     }
   };
+
+  // Detect billing mode: if any billing-specific field is present we render
+  // the billing-oriented section instead of the generic footer.
+  const isBillingCard =
+    data.txHash !== undefined ||
+    data.network !== undefined ||
+    data.confirmations !== undefined ||
+    data.type !== undefined ||
+    data.amount !== undefined;
 
   return (
     <div
@@ -89,6 +236,7 @@ export function PreviewCard({
       onMouseEnter={show}
       onMouseLeave={hide}
     >
+      {/* ── Trigger ─────────────────────────────────────────────────────── */}
       <div
         ref={triggerRef}
         className="preview-card__trigger"
@@ -101,6 +249,7 @@ export function PreviewCard({
           show();
         }}
         onBlur={(e: FocusEvent<HTMLDivElement>) => {
+          // Only close when focus has left the entire wrapper subtree.
           if (!e.currentTarget.parentElement?.contains(e.relatedTarget as Node)) {
             hide();
           }
@@ -114,6 +263,7 @@ export function PreviewCard({
         {children}
       </div>
 
+      {/* ── Preview panel ───────────────────────────────────────────────── */}
       {open && (
         <div
           id={panelId}
@@ -123,12 +273,13 @@ export function PreviewCard({
           style={{
             position: 'absolute',
             zIndex: 1000,
-            width: '280px',
+            width: '300px',
             maxWidth: '90vw',
             padding: '12px 16px',
             borderRadius: '10px',
             background: 'var(--surface, #1e1e2e)',
-            border: '1px solid var(--border-color, var(--line, rgba(255, 255, 255, 0.15)))',
+            border:
+              '1px solid var(--border-color, var(--line, rgba(255, 255, 255, 0.15)))',
             boxShadow: 'var(--shadow, 0 10px 30px rgba(0, 0, 0, 0.3))',
             color: 'var(--text-primary, var(--text, #f9fafb))',
             pointerEvents: 'none',
@@ -137,7 +288,7 @@ export function PreviewCard({
             ...getPositionStyles(),
           }}
         >
-          {/* Header row: title and status badge */}
+          {/* Header: title + status badge */}
           <div
             style={{
               display: 'flex',
@@ -152,6 +303,9 @@ export function PreviewCard({
                 fontSize: '0.875rem',
                 color: 'var(--text-primary, var(--text, #ffffff))',
                 fontWeight: 600,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               }}
             >
               {data.title}
@@ -168,7 +322,7 @@ export function PreviewCard({
                 color: 'var(--text-secondary, var(--muted, #9ca3af))',
               }}
             >
-              {data.subtitle || data.category}
+              {data.subtitle ?? data.category}
             </p>
           )}
 
@@ -185,8 +339,142 @@ export function PreviewCard({
             </p>
           )}
 
-          {/* Metrics summary */}
-          {data.metrics && data.metrics.length > 0 && (
+          {/* ── Billing-specific section (FWC26) ───────────────────────── */}
+          {isBillingCard && (
+            <div
+              style={{
+                margin: '8px 0',
+                padding: '8px',
+                borderRadius: '6px',
+                backgroundColor: 'var(--bg-chip, rgba(255, 255, 255, 0.04))',
+                fontSize: '0.75rem',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '5px',
+              }}
+            >
+              {/* Transaction type + direction badge */}
+              {data.type && (
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Type</span>
+                  <span
+                    style={{
+                      fontWeight: 600,
+                      color: 'var(--text-primary, #f9fafb)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                  >
+                    {data.type}
+                    {data.direction && (
+                      <span
+                        aria-label={data.direction === 'credit' ? 'incoming' : 'outgoing'}
+                        style={{
+                          fontSize: '0.65rem',
+                          padding: '1px 5px',
+                          borderRadius: '4px',
+                          fontWeight: 700,
+                          backgroundColor:
+                            data.direction === 'credit'
+                              ? 'var(--sb-success-bg, rgba(115, 242, 187, 0.14))'
+                              : 'var(--sb-error-bg, rgba(255, 125, 141, 0.14))',
+                          color:
+                            data.direction === 'credit'
+                              ? 'var(--sb-success-fg, #73f2bb)'
+                              : 'var(--sb-error-fg, #ff7d8d)',
+                        }}
+                      >
+                        {data.direction === 'credit' ? '↑ credit' : '↓ debit'}
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {/* Amount */}
+              {data.amount !== undefined && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Amount</span>
+                  <strong
+                    className="tabular-nums numeric-tabular"
+                    style={{
+                      color:
+                        data.direction === 'credit'
+                          ? 'var(--success, #10b981)'
+                          : data.direction === 'debit'
+                            ? 'var(--danger, #ef4444)'
+                            : 'var(--accent, #6366f1)',
+                    }}
+                  >
+                    {data.direction === 'credit' ? '+' : data.direction === 'debit' ? '−' : ''}
+                    {formatUsdcAmount(data.amount)} USDC
+                  </strong>
+                </div>
+              )}
+
+              {/* Network */}
+              {data.network && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Network</span>
+                  <span style={{ color: 'var(--text-primary, #f9fafb)' }}>{data.network}</span>
+                </div>
+              )}
+
+              {/* Confirmations */}
+              {data.confirmations !== undefined && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Confirmations</span>
+                  <span
+                    className="tabular-nums"
+                    style={{
+                      color:
+                        data.confirmations >= 10
+                          ? 'var(--success, #10b981)'
+                          : 'var(--accent, #6366f1)',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {data.confirmations}
+                  </span>
+                </div>
+              )}
+
+              {/* Transaction hash */}
+              {data.txHash && (
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Tx hash</span>
+                  <code
+                    className="tabular-nums"
+                    title={data.txHash}
+                    style={{
+                      fontSize: '0.7rem',
+                      color: 'var(--accent, #6366f1)',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {truncateTxHash(data.txHash)}
+                  </code>
+                </div>
+              )}
+
+              {/* Timestamp */}
+              {data.timestamp && (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: 'var(--text-secondary, #9ca3af)' }}>Time</span>
+                  <time
+                    dateTime={data.timestamp}
+                    style={{ color: 'var(--text-secondary, #9ca3af)', fontSize: '0.7rem' }}
+                  >
+                    {formatTimestamp(data.timestamp)}
+                  </time>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── Generic metrics grid (non-billing, Dashboard overview) ─── */}
+          {!isBillingCard && data.metrics && data.metrics.length > 0 && (
             <div
               style={{
                 display: 'grid',
@@ -203,7 +491,10 @@ export function PreviewCard({
                   <span style={{ color: 'var(--text-secondary, #9ca3af)', display: 'block' }}>
                     {m.label}
                   </span>
-                  <strong className="tabular-nums numeric-tabular" style={{ color: 'var(--accent, #6366f1)' }}>
+                  <strong
+                    className="tabular-nums numeric-tabular"
+                    style={{ color: 'var(--accent, #6366f1)' }}
+                  >
                     {m.value}
                   </strong>
                 </div>
@@ -211,7 +502,7 @@ export function PreviewCard({
             </div>
           )}
 
-          {/* Tags */}
+          {/* Tags (common to both modes) */}
           {data.tags && data.tags.length > 0 && (
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '6px' }}>
               {data.tags.map((tag) => (
@@ -231,8 +522,8 @@ export function PreviewCard({
             </div>
           )}
 
-          {/* Footer: Price or Last Active */}
-          {(data.price !== undefined || data.lastActive) && (
+          {/* Footer: price / last-active (non-billing only) */}
+          {!isBillingCard && (data.price !== undefined || data.lastActive) && (
             <div
               style={{
                 display: 'flex',
@@ -246,15 +537,30 @@ export function PreviewCard({
               }}
             >
               {data.price !== undefined && (
-                <span className="tabular-nums numeric-tabular" style={{ color: 'var(--success, #10b981)', fontWeight: 600 }}>
+                <span
+                  className="tabular-nums numeric-tabular"
+                  style={{ color: 'var(--success, #10b981)', fontWeight: 600 }}
+                >
                   {typeof data.price === 'number' ? `$${data.price} / call` : data.price}
                 </span>
               )}
-              {data.lastActive && (
-                <span>Last active: {data.lastActive}</span>
-              )}
+              {data.lastActive && <span>Last active: {data.lastActive}</span>}
             </div>
           )}
+
+          {/* Escape-key hint */}
+          <p
+            style={{
+              margin: '8px 0 0',
+              paddingTop: '6px',
+              borderTop: '1px solid var(--line, rgba(255, 255, 255, 0.08))',
+              fontSize: '0.65rem',
+              color: 'var(--text-secondary, #6b7280)',
+              textAlign: 'right',
+            }}
+          >
+            Press <kbd style={{ fontFamily: 'monospace' }}>Esc</kbd> to close
+          </p>
         </div>
       )}
     </div>

--- a/src/pages/BillingHistory.test.tsx
+++ b/src/pages/BillingHistory.test.tsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+/**
+ * BillingHistory.test.tsx
+ *
+ * Tests for the BillingHistory page (GrantFox FWC26).
+ *
+ * Coverage areas:
+ *   - Page renders with correct heading and all transactions
+ *   - Each row has a PreviewCard trigger (hover / focus open)
+ *   - Filter controls work: type, status, direction, search
+ *   - Empty-state message when no rows match filters
+ *   - Net-balance summary updates with filters
+ *   - ARIA: table has accessible label, status live region present,
+ *     keyboard tip present, status badges present
+ *   - Tx hash truncation in the table
+ */
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BillingHistory, MOCK_TRANSACTIONS } from './BillingHistory';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Get the row element for a given transaction id. */
+function getRow(txId: string) {
+  return screen.getByTestId(`bh-row-${txId}`) as HTMLElement;
+}
+
+/** Get the PreviewCard trigger inside a given row. */
+function getTriggerInRow(row: HTMLElement) {
+  return within(row).getByRole('button', { name: /preview details for/i });
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('BillingHistory — page structure', () => {
+  afterEach(cleanup);
+
+  it('renders the page heading', () => {
+    render(<BillingHistory />);
+    expect(
+      screen.getByRole('heading', { name: /billing history/i, level: 1 }),
+    ).toBeTruthy();
+  });
+
+  it('renders all mock transactions by default', () => {
+    render(<BillingHistory />);
+    expect(screen.getByText(`${MOCK_TRANSACTIONS.length} transactions`)).toBeTruthy();
+  });
+
+  it('renders a table with an accessible aria-label', () => {
+    render(<BillingHistory />);
+    expect(
+      screen.getByRole('table', { name: /billing transaction history/i }),
+    ).toBeTruthy();
+  });
+
+  it('renders column headers with scope="col"', () => {
+    render(<BillingHistory />);
+    const headerCells = screen
+      .getAllByRole('columnheader')
+      .filter((th) => th.getAttribute('scope') === 'col');
+    // Expect Date, Description, Type, Status, Amount, Tx Hash
+    expect(headerCells.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('renders a status live region for filter announcements', () => {
+    render(<BillingHistory />);
+    const liveRegion = document.querySelector('[role="status"][aria-live="polite"]');
+    expect(liveRegion).toBeTruthy();
+  });
+
+  it('renders a keyboard tip containing "Esc"', () => {
+    render(<BillingHistory />);
+    // The bottom keyboard tip paragraph
+    expect(screen.getAllByText(/Esc/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders StatusBadge for each transaction', () => {
+    render(<BillingHistory />);
+    // StatusBadge uses role="img"; there should be at least one per row.
+    const badges = screen.getAllByRole('img');
+    expect(badges.length).toBeGreaterThanOrEqual(MOCK_TRANSACTIONS.length);
+  });
+
+  it('shows the net balance summary line', () => {
+    render(<BillingHistory />);
+    // Net: label should be visible
+    expect(screen.getByText('Net:')).toBeTruthy();
+  });
+});
+
+// ── PreviewCard integration ───────────────────────────────────────────────────
+
+describe('BillingHistory — PreviewCard hover/focus integration', () => {
+  afterEach(cleanup);
+
+  it('each transaction row has a PreviewCard trigger button', () => {
+    render(<BillingHistory />);
+    // Each row must have exactly one trigger per PreviewCard
+    MOCK_TRANSACTIONS.forEach((tx) => {
+      const row = getRow(tx.id);
+      expect(getTriggerInRow(row)).toBeTruthy();
+    });
+  });
+
+  it('hovering a row description opens the preview tooltip', () => {
+    render(<BillingHistory />);
+    const row = getRow(MOCK_TRANSACTIONS[0].id);
+    const wrapper = row.querySelector('.preview-card__wrapper') as HTMLElement;
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('focusing a row trigger opens the preview tooltip', () => {
+    render(<BillingHistory />);
+    const row = getRow(MOCK_TRANSACTIONS[0].id);
+    const trigger = getTriggerInRow(row);
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+  });
+
+  it('preview panel shows the transaction description', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0]; // "USDC vault deposit"
+    const row = getRow(tx.id);
+    const trigger = getTriggerInRow(row);
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toHaveTextContent(tx.description);
+  });
+
+  it('preview panel shows the tx hash (truncated)', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0];
+    const row = getRow(tx.id);
+    const trigger = getTriggerInRow(row);
+
+    fireEvent.focus(trigger);
+    const panel = screen.getByRole('tooltip');
+    // Should show at least the first 8 chars of the hash
+    expect(panel).toHaveTextContent(tx.txHash.slice(0, 8));
+  });
+
+  it('preview panel shows network name', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0];
+    const row = getRow(tx.id);
+    fireEvent.focus(getTriggerInRow(row));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Stellar Mainnet');
+  });
+
+  it('preview panel shows confirmation count', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0]; // 120 confirmations
+    const row = getRow(tx.id);
+    fireEvent.focus(getTriggerInRow(row));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('120');
+  });
+
+  it('preview panel shows formatted USDC amount', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0]; // 100.00 USDC
+    const row = getRow(tx.id);
+    fireEvent.focus(getTriggerInRow(row));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('100.00 USDC');
+  });
+
+  it('Escape closes the preview and removes aria-describedby', () => {
+    render(<BillingHistory />);
+    const row = getRow(MOCK_TRANSACTIONS[0].id);
+    const trigger = getTriggerInRow(row);
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('trigger aria-label includes the transaction description', () => {
+    render(<BillingHistory />);
+    const tx = MOCK_TRANSACTIONS[0];
+    const row = getRow(tx.id);
+    const trigger = getTriggerInRow(row);
+    // aria-label is "Preview details for <title>"
+    expect(trigger.getAttribute('aria-label')).toMatch(
+      new RegExp(tx.description, 'i'),
+    );
+  });
+
+  it('panel has pointer-events: none to avoid mouse trapping', () => {
+    render(<BillingHistory />);
+    const row = getRow(MOCK_TRANSACTIONS[0].id);
+    fireEvent.focus(getTriggerInRow(row));
+    expect(screen.getByRole('tooltip').style.pointerEvents).toBe('none');
+  });
+});
+
+// ── Filtering ─────────────────────────────────────────────────────────────────
+
+describe('BillingHistory — filters', () => {
+  afterEach(cleanup);
+
+  it('filter by type "Deposit" shows only deposit rows', () => {
+    render(<BillingHistory />);
+    const typeSelect = screen.getByRole('combobox', { name: /filter by transaction type/i });
+
+    fireEvent.change(typeSelect, { target: { value: 'Deposit' } });
+
+    const depositCount = MOCK_TRANSACTIONS.filter((tx) => tx.type === 'Deposit').length;
+    expect(screen.getByText(`${depositCount} transaction${depositCount !== 1 ? 's' : ''}`)).toBeTruthy();
+
+    // Non-deposit transactions should not be visible
+    const apiCallTxs = MOCK_TRANSACTIONS.filter((tx) => tx.type === 'API Call');
+    apiCallTxs.forEach((tx) => {
+      expect(screen.queryByTestId(`bh-row-${tx.id}`)).toBeNull();
+    });
+  });
+
+  it('filter by status "pending" shows only pending rows', () => {
+    render(<BillingHistory />);
+    const statusSelect = screen.getByRole('combobox', { name: /filter by transaction status/i });
+
+    fireEvent.change(statusSelect, { target: { value: 'pending' } });
+
+    const pendingCount = MOCK_TRANSACTIONS.filter((tx) => tx.status === 'pending').length;
+    expect(screen.getByText(`${pendingCount} transaction${pendingCount !== 1 ? 's' : ''}`)).toBeTruthy();
+  });
+
+  it('filter by direction "credit" shows only credit rows', () => {
+    render(<BillingHistory />);
+    const dirSelect = screen.getByRole('combobox', { name: /filter by transaction direction/i });
+
+    fireEvent.change(dirSelect, { target: { value: 'credit' } });
+
+    const creditCount = MOCK_TRANSACTIONS.filter((tx) => tx.direction === 'credit').length;
+    expect(screen.getByText(`${creditCount} transaction${creditCount !== 1 ? 's' : ''}`)).toBeTruthy();
+
+    // Debit rows must be hidden
+    MOCK_TRANSACTIONS.filter((tx) => tx.direction === 'debit').forEach((tx) => {
+      expect(screen.queryByTestId(`bh-row-${tx.id}`)).toBeNull();
+    });
+  });
+
+  it('search by description filters rows', () => {
+    render(<BillingHistory />);
+    const searchInput = screen.getByRole('searchbox', { name: /search transactions/i });
+
+    fireEvent.change(searchInput, { target: { value: 'WeatherSim' } });
+
+    const matchCount = MOCK_TRANSACTIONS.filter((tx) =>
+      tx.description.toLowerCase().includes('weathersim'),
+    ).length;
+    expect(screen.getByText(`${matchCount} transaction${matchCount !== 1 ? 's' : ''}`)).toBeTruthy();
+  });
+
+  it('search by tx hash filters rows', () => {
+    render(<BillingHistory />);
+    const searchInput = screen.getByRole('searchbox', { name: /search transactions/i });
+    // Use the first 8 chars of the first tx hash
+    const hashPrefix = MOCK_TRANSACTIONS[0].txHash.slice(0, 8).toLowerCase();
+    fireEvent.change(searchInput, { target: { value: hashPrefix } });
+
+    // At least one row should remain
+    expect(screen.queryByRole('table')).toBeTruthy();
+  });
+
+  it('shows empty state when no transactions match', () => {
+    render(<BillingHistory />);
+    const searchInput = screen.getByRole('searchbox', { name: /search transactions/i });
+
+    fireEvent.change(searchInput, { target: { value: 'ZZZNOMATCH999' } });
+
+    expect(
+      screen.getByText(/no transactions match the current filters/i),
+    ).toBeTruthy();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('net balance is positive when only credits are shown', () => {
+    render(<BillingHistory />);
+    const dirSelect = screen.getByRole('combobox', { name: /filter by transaction direction/i });
+    fireEvent.change(dirSelect, { target: { value: 'credit' } });
+
+    // Net label visible and "+" prefix present
+    const netStrong = document.querySelector('[class*="tabular-nums"]');
+    // We just check the page still renders with a "+" somewhere in the net line
+    const pageText = document.body.textContent ?? '';
+    expect(pageText).toContain('+');
+  });
+
+  it('live region contains filter summary after type filter change', () => {
+    render(<BillingHistory />);
+    const typeSelect = screen.getByRole('combobox', { name: /filter by transaction type/i });
+    fireEvent.change(typeSelect, { target: { value: 'Fee' } });
+
+    const liveRegion = document.querySelector('[role="status"][aria-live="polite"]') as HTMLElement;
+    expect(liveRegion.textContent).toContain('Fee');
+  });
+
+  it('live region reads "Showing all transactions" when no filters active', () => {
+    render(<BillingHistory />);
+    const liveRegion = document.querySelector('[role="status"][aria-live="polite"]') as HTMLElement;
+    expect(liveRegion.textContent).toMatch(/showing all transactions/i);
+  });
+});
+
+// ── Table content ─────────────────────────────────────────────────────────────
+
+describe('BillingHistory — table row content', () => {
+  afterEach(cleanup);
+
+  it('shows truncated tx hash in the Tx Hash column', () => {
+    render(<BillingHistory />);
+    // First transaction: A3F9B2C1... → "A3F9B2…F0A1" (6+…+4)
+    const hashCode = screen.getAllByTitle(MOCK_TRANSACTIONS[0].txHash)[0];
+    expect(hashCode).toBeTruthy();
+    // Truncated form must be shorter than the full hash
+    expect((hashCode.textContent ?? '').length).toBeLessThan(
+      MOCK_TRANSACTIONS[0].txHash.length,
+    );
+  });
+
+  it('amount cell has tabular-nums class for alignment', () => {
+    render(<BillingHistory />);
+    const cells = document.querySelectorAll('td.tabular-nums');
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it('date cells render <time> elements with dateTime attributes', () => {
+    render(<BillingHistory />);
+    const timeTags = document.querySelectorAll('td time');
+    // At least one per row
+    expect(timeTags.length).toBeGreaterThanOrEqual(MOCK_TRANSACTIONS.length);
+    timeTags.forEach((t) => {
+      expect(t.getAttribute('dateTime')).toBeTruthy();
+    });
+  });
+});

--- a/src/pages/BillingHistory.tsx
+++ b/src/pages/BillingHistory.tsx
@@ -1,0 +1,669 @@
+/**
+ * BillingHistory.tsx — Billing transaction history page (GrantFox FWC26).
+ *
+ * Displays a paginated table of past USDC transactions. Each row carries a
+ * hover-triggered (and keyboard-accessible) PreviewCard that reveals on-chain
+ * details — transaction hash, network, confirmation count, direction, and
+ * precise timestamp — without navigating away from the page.
+ *
+ * Accessibility (WCAG 2.1 AA):
+ * - Table uses <thead> / <tbody> with <th scope="col"> for screen readers.
+ * - Each row's PreviewCard trigger has an explicit aria-label and responds to
+ *   Escape (dismiss), Tab (move focus), and Enter/Space (open on keyboard-only).
+ * - Status badges use the project's pattern-based StatusBadge component so
+ *   information is never conveyed by colour alone (WCAG 1.4.1).
+ * - A live-region announces when the active filter changes (WCAG 4.1.3).
+ * - All colours reference design tokens so both light and dark themes work.
+ *
+ * Keyboard navigation:
+ *   Tab               Move focus between row triggers.
+ *   Focus on trigger  Opens the preview card automatically.
+ *   Escape            Closes the preview and returns focus to the trigger.
+ *   Blur / Tab away   Closes the preview when focus leaves the row.
+ */
+
+import { useId, useMemo, useState } from 'react';
+import PreviewCard, { type PreviewCardData } from '../components/PreviewCard';
+import StatusBadge, { type StatusVariant } from '../components/StatusBadge';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type TxType = 'Deposit' | 'API Call' | 'Refund' | 'Settlement' | 'Fee';
+export type TxDirection = 'credit' | 'debit';
+export type TxStatus = Extract<StatusVariant, 'success' | 'pending' | 'error' | 'warning'>;
+
+export interface BillingTransaction {
+  id: string;
+  /** Human-readable description of the transaction. */
+  description: string;
+  type: TxType;
+  direction: TxDirection;
+  /** Amount in USDC (positive number). */
+  amount: number;
+  status: TxStatus;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+  /** Full 64-character Stellar transaction hash. */
+  txHash: string;
+  /** Ledger / network name. */
+  network: string;
+  /** Number of block/ledger confirmations. */
+  confirmations: number;
+}
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+// Realistic-looking mock transactions for the GrantFox FWC26 prototype.
+
+export const MOCK_TRANSACTIONS: BillingTransaction[] = [
+  {
+    id: 'tx-001',
+    description: 'USDC vault deposit',
+    type: 'Deposit',
+    direction: 'credit',
+    amount: 100.00,
+    status: 'success',
+    timestamp: '2026-07-25T14:32:00Z',
+    txHash: 'A3F9B2C1D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1',
+    network: 'Stellar Mainnet',
+    confirmations: 120,
+  },
+  {
+    id: 'tx-002',
+    description: 'WeatherSim API · 3 calls',
+    type: 'API Call',
+    direction: 'debit',
+    amount: 0.24,
+    status: 'success',
+    timestamp: '2026-07-25T15:10:22Z',
+    txHash: 'B4G0C3D2E5F6A8B9C0D1E2F3A4B5C6D7E8F9A0B1C2D3E4F5A6B7C8D9E0F1A2B3',
+    network: 'Stellar Mainnet',
+    confirmations: 98,
+  },
+  {
+    id: 'tx-003',
+    description: 'Stellar settlement · Epoch 1047',
+    type: 'Settlement',
+    direction: 'credit',
+    amount: 12.80,
+    status: 'success',
+    timestamp: '2026-07-26T00:00:00Z',
+    txHash: 'C5H1D4E3F6A9B0C1D2E3F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5',
+    network: 'Stellar Mainnet',
+    confirmations: 60,
+  },
+  {
+    id: 'tx-004',
+    description: 'Refund · CreditScore API',
+    type: 'Refund',
+    direction: 'credit',
+    amount: 0.05,
+    status: 'success',
+    timestamp: '2026-07-26T09:17:44Z',
+    txHash: 'D6I2E5F4A7B0C1D2E3F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6',
+    network: 'Stellar Mainnet',
+    confirmations: 45,
+  },
+  {
+    id: 'tx-005',
+    description: 'Network fee · tx D6I2…',
+    type: 'Fee',
+    direction: 'debit',
+    amount: 0.001,
+    status: 'success',
+    timestamp: '2026-07-26T09:17:44Z',
+    txHash: 'E7J3F6A5B8C1D2E3F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7',
+    network: 'Stellar Mainnet',
+    confirmations: 45,
+  },
+  {
+    id: 'tx-006',
+    description: 'USDC vault deposit',
+    type: 'Deposit',
+    direction: 'credit',
+    amount: 50.00,
+    status: 'pending',
+    timestamp: '2026-07-27T11:04:00Z',
+    txHash: 'F8K4A7B6C9D2E3F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8',
+    network: 'Stellar Mainnet',
+    confirmations: 2,
+  },
+  {
+    id: 'tx-007',
+    description: 'ChainRisk API · 1 call',
+    type: 'API Call',
+    direction: 'debit',
+    amount: 0.08,
+    status: 'error',
+    timestamp: '2026-07-27T13:22:10Z',
+    txHash: 'G9L5B8C7D0E3F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9',
+    network: 'Stellar Mainnet',
+    confirmations: 0,
+  },
+  {
+    id: 'tx-008',
+    description: 'MarketFeed API · 10 calls',
+    type: 'API Call',
+    direction: 'debit',
+    amount: 0.80,
+    status: 'success',
+    timestamp: '2026-07-28T08:55:33Z',
+    txHash: 'H0M6C9D8E1F4A5B6C7D8E9F0A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0',
+    network: 'Stellar Mainnet',
+    confirmations: 88,
+  },
+];
+
+// ── Filter & sort helpers ─────────────────────────────────────────────────────
+
+const ALL_TYPES: TxType[] = ['Deposit', 'API Call', 'Refund', 'Settlement', 'Fee'];
+const ALL_STATUSES: TxStatus[] = ['success', 'pending', 'error', 'warning'];
+
+function formatUsdcAmount(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: value < 0.01 ? 3 : 2,
+    maximumFractionDigits: value < 0.01 ? 3 : 2,
+  }).format(value);
+}
+
+function formatDateShort(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function truncateTxHash(hash: string): string {
+  if (hash.length <= 14) return hash;
+  return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+}
+
+/** Build a PreviewCardData object from a BillingTransaction. */
+function txToPreviewData(tx: BillingTransaction): PreviewCardData {
+  return {
+    id: tx.id,
+    title: tx.description,
+    status: tx.status,
+    type: tx.type,
+    direction: tx.direction,
+    amount: tx.amount,
+    txHash: tx.txHash,
+    network: tx.network,
+    confirmations: tx.confirmations,
+    timestamp: tx.timestamp,
+  };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function BillingHistory() {
+  // ── Filter state ──────────────────────────────────────────────────────────
+  const [typeFilter, setTypeFilter] = useState<TxType | 'All'>('All');
+  const [statusFilter, setStatusFilter] = useState<TxStatus | 'All'>('All');
+  const [directionFilter, setDirectionFilter] = useState<TxDirection | 'All'>('All');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Live-region ID for filter-change announcements.
+  const liveRegionId = useId();
+
+  // Build a human-readable description of the active filters for the live region.
+  const filterSummary = useMemo(() => {
+    const parts: string[] = [];
+    if (typeFilter !== 'All') parts.push(`type: ${typeFilter}`);
+    if (statusFilter !== 'All') parts.push(`status: ${statusFilter}`);
+    if (directionFilter !== 'All') parts.push(`direction: ${directionFilter}`);
+    if (searchQuery.trim()) parts.push(`search: "${searchQuery}"`);
+    return parts.length === 0 ? 'Showing all transactions' : `Filtered by ${parts.join(', ')}`;
+  }, [typeFilter, statusFilter, directionFilter, searchQuery]);
+
+  // ── Derived filtered/sorted list ──────────────────────────────────────────
+  const filteredTxs = useMemo(() => {
+    return MOCK_TRANSACTIONS.filter((tx) => {
+      if (typeFilter !== 'All' && tx.type !== typeFilter) return false;
+      if (statusFilter !== 'All' && tx.status !== statusFilter) return false;
+      if (directionFilter !== 'All' && tx.direction !== directionFilter) return false;
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        return (
+          tx.description.toLowerCase().includes(q) ||
+          tx.txHash.toLowerCase().includes(q) ||
+          tx.type.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [typeFilter, statusFilter, directionFilter, searchQuery]);
+
+  // ── Totals ─────────────────────────────────────────────────────────────────
+  const netBalance = useMemo(() => {
+    return filteredTxs.reduce(
+      (sum, tx) => sum + (tx.direction === 'credit' ? tx.amount : -tx.amount),
+      0,
+    );
+  }, [filteredTxs]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <section
+      className="billing-history"
+      aria-labelledby="bh-page-title"
+      style={{
+        padding: '24px',
+        maxWidth: '1000px',
+        margin: '0 auto',
+      }}
+    >
+      {/* Page heading */}
+      <header style={{ marginBottom: '20px' }}>
+        <p className="eyebrow" style={{ marginBottom: '4px' }}>
+          GrantFox FWC26
+        </p>
+        <h1
+          id="bh-page-title"
+          style={{
+            fontSize: 'clamp(1.35rem, 3vw, 1.75rem)',
+            fontWeight: 700,
+            margin: '0 0 6px',
+            color: 'var(--text-primary, var(--text, #f9fafb))',
+          }}
+        >
+          Billing History
+        </h1>
+        <p style={{ color: 'var(--text-secondary, #9ca3af)', fontSize: '0.875rem', margin: 0 }}>
+          Hover or focus any transaction row to preview on-chain details. Press{' '}
+          <kbd
+            style={{
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              padding: '1px 4px',
+              borderRadius: '3px',
+              border: '1px solid var(--line, rgba(255,255,255,0.15))',
+            }}
+          >
+            Esc
+          </kbd>{' '}
+          to dismiss the preview.
+        </p>
+      </header>
+
+      {/* Live region for filter changes (WCAG 4.1.3) */}
+      <div
+        id={liveRegionId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {filterSummary}
+      </div>
+
+      {/* ── Filters bar ─────────────────────────────────────────────────── */}
+      <div
+        className="bh-filters"
+        role="group"
+        aria-label="Transaction filters"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '10px',
+          marginBottom: '16px',
+          alignItems: 'center',
+        }}
+      >
+        {/* Search */}
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '2px', flex: '1 1 180px' }}>
+          <span
+            style={{ fontSize: '0.7rem', color: 'var(--text-secondary, #9ca3af)', fontWeight: 600 }}
+          >
+            Search
+          </span>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Description or hash…"
+            aria-label="Search transactions by description or hash"
+            style={{
+              padding: '5px 8px',
+              borderRadius: '6px',
+              border: '1px solid var(--line, rgba(255,255,255,0.15))',
+              background: 'var(--bg-chip, rgba(255,255,255,0.04))',
+              color: 'var(--text-primary, #f9fafb)',
+              fontSize: '0.8125rem',
+            }}
+          />
+        </label>
+
+        {/* Type filter */}
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          <span
+            style={{ fontSize: '0.7rem', color: 'var(--text-secondary, #9ca3af)', fontWeight: 600 }}
+          >
+            Type
+          </span>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as TxType | 'All')}
+            aria-label="Filter by transaction type"
+            style={{
+              padding: '5px 8px',
+              borderRadius: '6px',
+              border: '1px solid var(--line, rgba(255,255,255,0.15))',
+              background: 'var(--bg-chip, rgba(255,255,255,0.04))',
+              color: 'var(--text-primary, #f9fafb)',
+              fontSize: '0.8125rem',
+            }}
+          >
+            <option value="All">All types</option>
+            {ALL_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </label>
+
+        {/* Status filter */}
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          <span
+            style={{ fontSize: '0.7rem', color: 'var(--text-secondary, #9ca3af)', fontWeight: 600 }}
+          >
+            Status
+          </span>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as TxStatus | 'All')}
+            aria-label="Filter by transaction status"
+            style={{
+              padding: '5px 8px',
+              borderRadius: '6px',
+              border: '1px solid var(--line, rgba(255,255,255,0.15))',
+              background: 'var(--bg-chip, rgba(255,255,255,0.04))',
+              color: 'var(--text-primary, #f9fafb)',
+              fontSize: '0.8125rem',
+            }}
+          >
+            <option value="All">All statuses</option>
+            {ALL_STATUSES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </label>
+
+        {/* Direction filter */}
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          <span
+            style={{ fontSize: '0.7rem', color: 'var(--text-secondary, #9ca3af)', fontWeight: 600 }}
+          >
+            Direction
+          </span>
+          <select
+            value={directionFilter}
+            onChange={(e) => setDirectionFilter(e.target.value as TxDirection | 'All')}
+            aria-label="Filter by transaction direction"
+            style={{
+              padding: '5px 8px',
+              borderRadius: '6px',
+              border: '1px solid var(--line, rgba(255,255,255,0.15))',
+              background: 'var(--bg-chip, rgba(255,255,255,0.04))',
+              color: 'var(--text-primary, #f9fafb)',
+              fontSize: '0.8125rem',
+            }}
+          >
+            <option value="All">All directions</option>
+            <option value="credit">Credit</option>
+            <option value="debit">Debit</option>
+          </select>
+        </label>
+      </div>
+
+      {/* ── Summary strip ────────────────────────────────────────────────── */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '12px',
+          fontSize: '0.8125rem',
+          color: 'var(--text-secondary, #9ca3af)',
+        }}
+      >
+        <span>
+          {filteredTxs.length} transaction{filteredTxs.length !== 1 ? 's' : ''}
+        </span>
+        <span>
+          Net:{' '}
+          <strong
+            className="tabular-nums"
+            style={{
+              color:
+                netBalance > 0
+                  ? 'var(--success, #10b981)'
+                  : netBalance < 0
+                    ? 'var(--danger, #ef4444)'
+                    : 'var(--text-primary, #f9fafb)',
+            }}
+          >
+            {netBalance >= 0 ? '+' : '−'}
+            {formatUsdcAmount(Math.abs(netBalance))} USDC
+          </strong>
+        </span>
+      </div>
+
+      {/* ── Transaction table ─────────────────────────────────────────────── */}
+      {filteredTxs.length === 0 ? (
+        <div
+          role="status"
+          style={{
+            padding: '40px 24px',
+            textAlign: 'center',
+            color: 'var(--text-secondary, #9ca3af)',
+            borderRadius: '10px',
+            border: '1px dashed var(--line, rgba(255,255,255,0.1))',
+          }}
+        >
+          No transactions match the current filters.
+        </div>
+      ) : (
+        <div
+          style={{
+            overflowX: 'auto',
+            borderRadius: '10px',
+            border: '1px solid var(--line, rgba(255,255,255,0.08))',
+          }}
+        >
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: '0.8125rem',
+            }}
+            aria-label="Billing transaction history"
+          >
+            <thead>
+              <tr
+                style={{
+                  background: 'var(--bg-chip, rgba(255,255,255,0.03))',
+                  borderBottom: '1px solid var(--line, rgba(255,255,255,0.08))',
+                }}
+              >
+                {(
+                  [
+                    { label: 'Date', width: '160px' },
+                    { label: 'Description', width: 'auto' },
+                    { label: 'Type', width: '110px' },
+                    { label: 'Status', width: '110px' },
+                    { label: 'Amount (USDC)', width: '130px' },
+                    { label: 'Tx Hash', width: '110px' },
+                  ] as const
+                ).map(({ label, width }) => (
+                  <th
+                    key={label}
+                    scope="col"
+                    style={{
+                      padding: '10px 12px',
+                      textAlign: label === 'Amount (USDC)' ? 'right' : 'left',
+                      fontWeight: 600,
+                      color: 'var(--text-secondary, #9ca3af)',
+                      whiteSpace: 'nowrap',
+                      width,
+                    }}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+
+            <tbody>
+              {filteredTxs.map((tx, idx) => (
+                <tr
+                  key={tx.id}
+                  data-testid={`bh-row-${tx.id}`}
+                  style={{
+                    borderBottom:
+                      idx < filteredTxs.length - 1
+                        ? '1px solid var(--line, rgba(255,255,255,0.05))'
+                        : 'none',
+                  }}
+                >
+                  {/* Date cell */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      whiteSpace: 'nowrap',
+                      color: 'var(--text-secondary, #9ca3af)',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    <time dateTime={tx.timestamp}>{formatDateShort(tx.timestamp)}</time>
+                  </td>
+
+                  {/* Description cell — wraps the PreviewCard trigger */}
+                  <td style={{ padding: '10px 12px' }}>
+                    <PreviewCard
+                      data={txToPreviewData(tx)}
+                      position="bottom"
+                    >
+                      <span
+                        style={{
+                          color: 'var(--text-primary, #f9fafb)',
+                          fontWeight: 500,
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '6px',
+                        }}
+                      >
+                        {/* Direction indicator */}
+                        <span
+                          aria-hidden="true"
+                          style={{
+                            fontSize: '0.75rem',
+                            color:
+                              tx.direction === 'credit'
+                                ? 'var(--success, #10b981)'
+                                : 'var(--danger, #ef4444)',
+                          }}
+                        >
+                          {tx.direction === 'credit' ? '↑' : '↓'}
+                        </span>
+                        {tx.description}
+                      </span>
+                    </PreviewCard>
+                  </td>
+
+                  {/* Type cell */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      color: 'var(--text-secondary, #9ca3af)',
+                    }}
+                  >
+                    {tx.type}
+                  </td>
+
+                  {/* Status cell */}
+                  <td style={{ padding: '10px 12px' }}>
+                    <StatusBadge status={tx.status} />
+                  </td>
+
+                  {/* Amount cell */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      textAlign: 'right',
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                    }}
+                    className="tabular-nums"
+                  >
+                    <span
+                      style={{
+                        color:
+                          tx.direction === 'credit'
+                            ? 'var(--success, #10b981)'
+                            : 'var(--danger, #ef4444)',
+                      }}
+                    >
+                      {tx.direction === 'credit' ? '+' : '−'}
+                      {formatUsdcAmount(tx.amount)}
+                    </span>
+                  </td>
+
+                  {/* Tx hash cell */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      fontFamily: 'monospace',
+                      fontSize: '0.7rem',
+                      color: 'var(--accent, #6366f1)',
+                    }}
+                  >
+                    <code title={tx.txHash}>{truncateTxHash(tx.txHash)}</code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ── Accessible keyboard tip ──────────────────────────────────────── */}
+      <p
+        style={{
+          marginTop: '14px',
+          fontSize: '0.75rem',
+          color: 'var(--text-secondary, #6b7280)',
+        }}
+      >
+        <strong>Keyboard tip:</strong> Tab to a transaction description to open its preview.
+        Press{' '}
+        <kbd
+          style={{
+            fontFamily: 'monospace',
+            fontSize: '0.75rem',
+            padding: '1px 4px',
+            borderRadius: '3px',
+            border: '1px solid var(--line, rgba(255,255,255,0.15))',
+          }}
+        >
+          Esc
+        </kbd>{' '}
+        to close it and return focus to that row.
+      </p>
+    </section>
+  );
+}
+
+export default BillingHistory;


### PR DESCRIPTION
 feat(fwc26): Hover-triggered PreviewCard on BillingHistory with keyboard-accessible alternative
  
  Summary
  
  Implements the GrantFox FWC26 UI/UX requirement: each transaction row on the new Billing
  History page reveals a compact floating preview card on hover or keyboard focus, surfacing
  on-chain details without navigating away.
  
  Changes
  
  src/components/PreviewCard.tsx
  
  Extended PreviewCardData with 7 billing-specific fields: txHash, network, confirmations, type,
  amount, direction, and timestamp. A isBillingCard flag auto-selects the billing layout when any
  of those fields are present — existing dashboard callers are unaffected.
  
  src/pages/BillingHistory.tsx (new)
  Billing history page at /billing/history. Renders a responsive, filterable transaction table
  (filter by type, status, direction, and free-text search). Each row's description cell is
  wrapped in a PreviewCard trigger that opens on hover or focus and shows the tx hash, network,
  confirmation count, direction badge, USDC amount, and timestamp.
  
  src/App.tsx
  
  Registered the /billing/history route, added a NavLink in the primary nav, and added page
  title/description map entries.
  
  docs/BillingHistoryPreview.md (new)
  Full API reference for the new PreviewCardData billing fields, BillingHistory exports, WCAG
  compliance table, design-token usage, and responsive notes.
  
  Accessibility (WCAG 2.1 AA)
  
  ┌────────────────────┬──────────────────────────────────────────────────────────────────────┐
  │ Criterion          │ How it's met                                                         │
  ├────────────────────┼──────────────────────────────────────────────────────────────────────┤
  │ 1.4.1 Use of Color │ Direction shown as text badge ("↑ credit" / "↓ debit"), not colour   │
  │                    │ alone; StatusBadge adds texture pattern                              │
  ├────────────────────┼──────────────────────────────────────────────────────────────────────┤
  │ 2.1.1 Keyboard     │ All triggers are tabIndex={0} role="button"; Tab opens preview,      │
  │                    │ Escape closes and restores focus                                     │
  ├─────────────────────────┼─────────────────────────────────────────────────────────────────┤
  │ 2.4.3 Focus Order       │ suppressNextFocus guard prevents Escape → focus from            │
  │                         │ immediately re-opening the panel                                │
  ├─────────────────────────┼─────────────────────────────────────────────────────────────────┤
  │ 4.1.2 Name, Role, Value │ Trigger: aria-label, aria-describedby. Panel: role="tooltip",   │
  │                         │ aria-label                                                      │
  ├─────────────────────────┼─────────────────────────────────────────────────────────────────┤
  │ 4.1.3 Status Messages   │ Filter changes announced via role="status" aria-live="polite"   │
  └─────────────────────────┴─────────────────────────────────────────────────────────────────┘
  
  Tests
  
  56 new focused tests, all passing:
  
  - src/components/PreviewCard.test.tsx — 25 tests covering shared behaviour, dashboard mode, and
  billing mode (FWC26)
  - src/pages/BillingHistory.test.tsx — 31 tests covering page structure, hover/focus
  integration, all filter variants, empty state, ARIA semantics, and table content
  
  Test Files  2 passed (2)
       Tests  56 passed (56)
  
  What was not changed
  
  No existing tests were broken. Pre-existing failures in ApiCard, EmptyState, and FiltersSidebar
   are unrelated to this PR.
closes #709