### PR TITLE
Add aria-live region for CallHistoryRow status updates

### DIFF
--- a/src/pages/CallHistoryRow.test.tsx
+++ b/src/pages/CallHistoryRow.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
 import CallHistoryRow from './CallHistoryRow';
 
 const baseCall = {
@@ -14,6 +14,8 @@ const baseCall = {
 };
 
 describe('CallHistoryRow', () => {
+  afterEach(cleanup);
+
   it('announces status changes through a polite live region', () => {
     const { rerender } = render(
       <CallHistoryRow call={baseCall} isExpanded={false} onToggle={() => undefined} />,
@@ -33,5 +35,47 @@ describe('CallHistoryRow', () => {
     expect(liveRegion.textContent).toContain('Call status updated to error.');
     expect(liveRegion.getAttribute('aria-live')).toBe('polite');
     expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('does not announce when status stays the same', () => {
+    const { rerender } = render(
+      <CallHistoryRow call={baseCall} isExpanded={false} onToggle={() => undefined} />,
+    );
+
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion.textContent).toBe('');
+
+    rerender(
+      <CallHistoryRow
+        call={{ ...baseCall, responseTime: 200 }}
+        isExpanded={false}
+        onToggle={() => undefined}
+      />,
+    );
+
+    expect(liveRegion.textContent).toBe('');
+  });
+
+  it('renders success status text', () => {
+    const { container } = render(
+      <CallHistoryRow call={baseCall} isExpanded={false} onToggle={() => undefined} />,
+    );
+    expect(container.querySelector('.status-cell')?.textContent).toContain('success');
+  });
+
+  it('renders error status text', () => {
+    const { container } = render(
+      <CallHistoryRow
+        call={{ ...baseCall, status: 'error' }}
+        isExpanded={false}
+        onToggle={() => undefined}
+      />,
+    );
+    expect(container.querySelector('.status-cell')?.textContent).toContain('error');
+  });
+
+  it('has a live region with role="status"', () => {
+    render(<CallHistoryRow call={baseCall} isExpanded={false} onToggle={() => undefined} />);
+    expect(screen.getByRole('status')).toBeTruthy();
   });
 });

--- a/src/pages/CallHistoryRow.tsx
+++ b/src/pages/CallHistoryRow.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { formatPrice } from '../utils/format';
 
-type CallRecord = {
+export type CallRecord = {
   id: string;
   timestamp: Date;
   endpoint: string;
   status: 'success' | 'error';
   responseTime: number;
   cost: number;
-  request?: any;
-  response?: any;
+  request?: unknown;
+  response?: unknown;
 };
 
 type CallHistoryRowProps = {
@@ -33,6 +33,7 @@ function formatTimestamp(date: Date) {
 }
 
 export default function CallHistoryRow({ call, isExpanded, onToggle }: CallHistoryRowProps) {
+  // Aria-live polite announcement for status changes (WCAG 4.1.3)
   const [announcement, setAnnouncement] = useState('');
   const previousStatusRef = useRef(call.status);
 


### PR DESCRIPTION
Closes #545

- Export `CallRecord` type for reusability
- Use `unknown` instead of `any` for `request`/`response`
- Add tests for same-status guard, status transition rendering, and live region presence

Both `src/components/CallHistoryRow.tsx` and `src/pages/CallHistoryRow.tsx` now have polite `aria-live` status announcements