### PR TITLE
feat: polish Header breadcrumb overflow with middle-ellipsis (FWC26)

### DIFF
--- a/docs/Header-Breadcrumb.md
+++ b/docs/Header-Breadcrumb.md
@@ -60,6 +60,18 @@ Added a `middleEllipsis` prop to the `Breadcrumb` component and created a new `H
 | --------------- | --------- | ------- | ------------------------------------------------------------------ |
 | `middleEllipsis` | `boolean` | `false` | Collapse middle breadcrumb items behind an ellipsis popover on all viewports. |
 
+### CSS changes (overflow / flex-shrink polish)
+
+- **`.topbar-actions`** (`src/index.css`): Added `min-width: 0` so the actions container can shrink below its content size when the parent `.topbar` flex container is constrained, preventing breadcrumb overflow on narrow viewports.
+- **`.breadcrumb-nav`** (`Breadcrumb.tsx`): Added `min-width: 0` so the nav element participates in flex/grid shrink calculations within its parent container.
+
+### Overflow tests added
+
+- **`src/pages/Header.test.tsx`**: Added 3 overflow-polish tests:
+  - `"contains the breadcrumb inside .topbar-actions"` — structural containment check.
+  - `"allows the breadcrumb nav to shrink within its flex container"` — verifies `min-width: 0` and `max-width: 100%` are on the nav element.
+  - `"renders the middle-ellipsis collapsed layout with a very long path"` — validates the middle-ellipsis modifier class, first/last crumb visibility, middle items hidden, and ellipsis button rendered.
+
 ### HeaderProps (new component)
 
 | Prop               | Type                                         | Required | Description                        |

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -202,6 +202,7 @@ export default function Breadcrumb({ items, maxLabelLength = 0, middleEllipsis =
             font-size: 0.875rem;
             padding-left: 32px;
             max-width: 100%;
+            min-width: 0;
           }
 
           .breadcrumb-list,

--- a/src/index.css
+++ b/src/index.css
@@ -549,6 +549,7 @@ code,
   display: flex;
   align-items: center;
   gap: 16px;
+  min-width: 0;
 }
 
 .eyebrow {

--- a/src/pages/Header.test.tsx
+++ b/src/pages/Header.test.tsx
@@ -139,4 +139,89 @@ describe("Header – GrantFox FWC26", () => {
 
     expect(document.activeElement).toBe(button);
   });
+
+  // ── Overflow / flex-shrink polish tests ─────────────────────────────────
+  //
+  // These tests validate structural and CSS-level overflow protection in the
+  // jsdom test environment.  Because jsdom does not compute layout, we verify
+  // the presence and values of the CSS properties that control flex shrinking
+  // and content overflow, rather than measuring actual bounding boxes.
+
+  it("contains the breadcrumb inside .topbar-actions", () => {
+    const { container } = render(
+      <Header breadcrumbItems={SAMPLE_ITEMS} />,
+    );
+
+    const topbarActions = container.querySelector(".topbar-actions");
+    if (!topbarActions) throw new Error("Expected .topbar-actions");
+
+    const nav = topbarActions.querySelector('[aria-label="breadcrumb"]');
+    expect(nav).not.toBeNull();
+  });
+
+  it("allows the breadcrumb nav to shrink within its flex container", () => {
+    const { container } = render(
+      <Header breadcrumbItems={SAMPLE_ITEMS} />,
+    );
+
+    const nav = container.querySelector('[aria-label="breadcrumb"]');
+    if (!nav) throw new Error("Expected breadcrumb nav");
+
+    // jsdom returns "0" (no px suffix) for computed min-width: 0
+    const navStyle = window.getComputedStyle(nav);
+    expect(navStyle.minWidth).toBe("0");
+    expect(navStyle.maxWidth).toBe("100%");
+  });
+
+  it("renders the middle-ellipsis collapsed layout with a very long path", () => {
+    const veryLongItems: BreadcrumbItem[] = [
+      {
+        label: "A Very Long Root Segment Name That Keeps Going",
+        href: "/very-long-root-segment",
+      },
+      {
+        label: "Intermediate Level With An Extremely Long Middle Segment Path",
+        href: "/very-long-root-segment/intermediate",
+      },
+      {
+        label: "Another Middle Crumb With Even More Characters In The Label",
+        href: "/very-long-root-segment/intermediate/another",
+      },
+      {
+        label: "Final Destination Current Page Label That Is Also Quite Extended",
+        href: "/very-long-root-segment/intermediate/another/final",
+        isCurrent: true,
+      },
+    ];
+
+    const { container } = render(
+      <Header breadcrumbItems={veryLongItems} />,
+    );
+
+    // The breadcrumb nav should have the middle-ellipsis modifier class
+    const nav = container.querySelector('[aria-label="breadcrumb"]');
+    expect(nav?.className).toContain("breadcrumb-nav--middle-ellipsis");
+
+    // The first crumb link and last (current) crumb are visible
+    const firstLink = screen.getByRole("link", {
+      name: veryLongItems[0].label,
+    });
+    expect(firstLink).not.toBeNull();
+    expect(firstLink.classList.contains("link-nav")).toBe(true);
+
+    // Current page item is visible with aria-current="page"
+    const current = screen.getByText(veryLongItems[3].label);
+    expect(current.getAttribute("aria-current")).toBe("page");
+
+    // Middle items are hidden (via CSS display:none)
+    const middleItems = container.querySelectorAll(".breadcrumb-middle");
+    expect(middleItems.length).toBe(2);
+    for (const item of middleItems) {
+      expect(window.getComputedStyle(item).display).toBe("none");
+    }
+
+    // Ellipsis button is rendered for collapsed middle items
+    const ellipsis = container.querySelector(".breadcrumb-ellipsis");
+    expect(ellipsis).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds flex-shrink CSS properties and overflow-focused tests to prevent breadcrumb overflow in the Header component on narrow viewports.

## Changes

### CSS overflow / flex-shrink polish
- **`src/index.css`**: Added `min-width: 0` to `.topbar-actions` so the actions container can shrink below its content size when the parent `.topbar` flex container is constrained
- **`src/components/Breadcrumb.tsx`**: Added `min-width: 0` to `.breadcrumb-nav` so the nav element participates in flex/grid shrink calculations

### Tests
- **`src/pages/Header.test.tsx`**: Added 3 overflow-polish tests:
  - "contains the breadcrumb inside .topbar-actions" — structural containment
  - "allows the breadcrumb nav to shrink within its flex container" — CSS property validation
  - "renders the middle-ellipsis collapsed layout with a very long path" — structural overflow protection

### Documentation
- **`docs/Header-Breadcrumb.md`**: Updated with CSS overflow/flex-shrink polish section

## Testing
- ✅ All 66 tests pass (44 Breadcrumb + 12 Header + 10 Tooltip)
- ✅ Code review completed with no critical issues

Closes #582