### PR TITLE
feat: add aria-live region for EndpointSummary status updates [b#066]

### DIFF
--- a/src/pages/EndpointSummary.test.tsx
+++ b/src/pages/EndpointSummary.test.tsx
@@ -64,4 +64,68 @@ describe("EndpointSummary Page", () => {
     expect(printSpy).toHaveBeenCalled();
     printSpy.mockRestore();
   });
+
+  describe("aria-live announcements", () => {
+    it("renders a live region for screen-reader announcements", () => {
+      render(
+        <MemoryRouter>
+          <EndpointSummary />
+        </MemoryRouter>
+      );
+
+      const liveRegion = screen.getByTestId("live-region-endpoint-summary");
+      expect(liveRegion).toBeTruthy();
+      expect(liveRegion.getAttribute("aria-live")).toBe("polite");
+      expect(liveRegion.getAttribute("aria-atomic")).toBe("true");
+    });
+
+    it("announces when an endpoint card is expanded", () => {
+      render(
+        <MemoryRouter>
+          <EndpointSummary />
+        </MemoryRouter>
+      );
+
+      const triggers = screen.getAllByRole("button");
+      const endpointTrigger = triggers.find((btn) =>
+        btn.classList.contains("endpoint-summary-trigger") && btn.getAttribute("aria-expanded") === "false"
+      );
+      expect(endpointTrigger).toBeTruthy();
+      if (!endpointTrigger) return;
+
+      const liveRegion = screen.getByTestId("live-region-endpoint-summary");
+
+      fireEvent.click(endpointTrigger);
+
+      expect(liveRegion.textContent).toMatch(/Expanded/);
+    });
+
+    it("announces when an endpoint card is collapsed", () => {
+      render(
+        <MemoryRouter>
+          <EndpointSummary />
+        </MemoryRouter>
+      );
+
+      const triggers = screen.getAllByRole("button");
+      const endpointTrigger = triggers.find((btn) =>
+        btn.classList.contains("endpoint-summary-trigger")
+      );
+      expect(endpointTrigger).toBeTruthy();
+      if (!endpointTrigger) return;
+
+      const liveRegion = screen.getByTestId("live-region-endpoint-summary");
+
+      // First expand
+      const initialExpanded = endpointTrigger.getAttribute("aria-expanded") === "true";
+      if (!initialExpanded) {
+        fireEvent.click(endpointTrigger);
+      }
+
+      // Now collapse
+      fireEvent.click(endpointTrigger);
+
+      expect(liveRegion.textContent).toMatch(/Collapsed/);
+    });
+  });
 });

--- a/src/pages/EndpointSummary.tsx
+++ b/src/pages/EndpointSummary.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { MOCK_APIS } from "../data/mockApis";
 import { API_BASE_URL } from "../config/constants";
+import LiveRegion from "../components/LiveRegion";
 
 export default function EndpointSummary(): JSX.Element {
   useDocumentTitle(
@@ -21,6 +22,33 @@ export default function EndpointSummary(): JSX.Element {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(
     new Set(allEndpoints.slice(0, 3).map((ep) => ep.id)) // Expand first 3 by default
   );
+
+  // Screen-reader announcement state
+  const [announcement, setAnnouncement] = useState("");
+  const prevExpandedIdsRef = useRef(expandedIds);
+
+  useEffect(() => {
+    const prev = prevExpandedIdsRef.current;
+    const endpointMap = new Map(allEndpoints.map((ep) => [ep.id, ep]));
+
+    for (const id of expandedIds) {
+      if (!prev.has(id)) {
+        const ep = endpointMap.get(id);
+        setAnnouncement(`Expanded ${ep?.title ?? id} details`);
+        prevExpandedIdsRef.current = expandedIds;
+        return;
+      }
+    }
+    for (const id of prev) {
+      if (!expandedIds.has(id)) {
+        const ep = endpointMap.get(id);
+        setAnnouncement(`Collapsed ${ep?.title ?? id} details`);
+        prevExpandedIdsRef.current = expandedIds;
+        return;
+      }
+    }
+    prevExpandedIdsRef.current = expandedIds;
+  }, [expandedIds, allEndpoints]);
 
   const toggleExpand = (id: string) => {
     setExpandedIds((prev) => {
@@ -67,6 +95,10 @@ export default function EndpointSummary(): JSX.Element {
         >
           Print Summary
         </button>
+        <LiveRegion
+          message={announcement}
+          regionId="endpoint-summary"
+        />
       </header>
 
       <section style={{ display: "grid", gap: "16px" }}>


### PR DESCRIPTION
## Description

Add a polite `aria-live` region to `EndpointSummary` that announces expand/collapse actions to screen readers, improving accessibility for users relying on assistive technology.

## Requirements and Context

- Implements per the description above
- Adheres to repo's lint and code style
- WCAG 2.1 AA accessibility

## Changes

- `src/pages/EndpointSummary.tsx` — Added `LiveRegion` component with `useEffect` tracking `expandedIds` changes; announces card title on expand/collapse
- `src/pages/EndpointSummary.test.tsx` — Added tests for aria-live announcements (expand, collapse, and region presence)

## Suggested Execution

1. Fork the repo and create a branch
2. Implement changes touching:
   - `src/pages/EndpointSummary.tsx`
3. Test and commit; open a PR with `Closes #<issue-number>` in the body

## Guidelines

- Responsive across all breakpoints
- WCAG 2.1 AA accessibility
- Design-token + dark-mode consistency

Closes #743