### PR TITLE
feat: density toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Web app for the Callora API marketplace: developer dashboard, API management, an
 - Dashboard (usage stats, vault balance)
 - Screen-reader-friendly dashboard usage gauge with visible usage state and remaining allowance
 - Marketplace (browse and compare APIs)
+- **Marketplace density preference**: The marketplace toolbar offers Comfortable and Compact result layouts. The selected layout updates every result card, remains keyboard accessible, and is saved locally for future visits.
 - Pinned APIs on the dashboard for fast access to saved marketplace APIs
 - Billing (USDC deposit, Stellar settlement, transaction tracking)
 - API Usage analytics view

--- a/src/pages/MarketplacePage.test.tsx
+++ b/src/pages/MarketplacePage.test.tsx
@@ -8,6 +8,7 @@ import { CollectionsProvider } from "../state/collectionsStore";
 import { compareStore } from "../state/compareStore";
 import MarketplacePage from "./MarketplacePage";
 import type { APIItem } from "../data/mockApis";
+import { DENSITY_STORAGE_KEY } from "../utils/density";
 
 function renderMarketplacePage() {
   return render(
@@ -38,6 +39,7 @@ function settleMarketplaceTimers() {
 describe("MarketplacePage", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    localStorage.clear();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: (query: string) => ({
@@ -51,6 +53,20 @@ describe("MarketplacePage", () => {
         dispatchEvent: () => false,
       }),
     });
+  });
+
+  it("applies and persists the compact density selection", () => {
+    renderPage();
+    settleMarketplaceTimers();
+
+    const compactButton = screen.getByRole("button", { name: "Compact" });
+    fireEvent.click(compactButton);
+
+    expect(compactButton.getAttribute("aria-pressed")).toBe("true");
+    expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe("compact");
+    expect(
+      document.querySelectorAll(".api-marketplace-card.api-card--compact").length,
+    ).toBeGreaterThan(0);
   });
 
   afterEach(() => {

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -692,6 +692,7 @@ export default function MarketplacePage(): JSX.Element {
                 <ApiCard
                   key={a.id}
                   api={a}
+                  density={density}
                   onViewDetails={handleViewDetails}
                   onTagClick={handleTagClick}
                   activeTag={selectedTag}


### PR DESCRIPTION
Closes #373 

# Marketplace density preference

## Summary

- Apply the selected marketplace density to every API result card.
- Persist the Comfortable or Compact preference in local storage.
- Add coverage for selecting and persisting the Compact layout.
- Document the marketplace density preference in the README.

## Testing

- Added a MarketplacePage test for the Compact density selection and persistence.

## Checklist

- [x] Change is covered by automated tests.
- [x] README updated.