### PR TITLE
feat: add keyboard shortcut hint chip on PricingTable

### DIFF
--- a/docs/PricingTable-KbdHint.md
+++ b/docs/PricingTable-KbdHint.md
@@ -1,0 +1,128 @@
+# PricingTable — Keyboard Shortcut Hint Chip
+
+Implements issue **#944** (`b#090`, GrantFox FWC26 campaign): show a subtle
+keyboard shortcut hint chip on `PricingTable` for the primary action.
+
+## Summary of Changes
+
+The recommended pricing tier's primary action (its CTA button) now advertises
+the `S` shortcut with a subtle chip rendered directly beneath the button, in
+both the desktop grid and the mobile card layout.
+
+| Area | Change |
+| --- | --- |
+| `src/pages/PricingTable.tsx` | Unchanged — re-exports `PricingTierTable`, which holds the implementation. |
+| `src/components/PricingTierTable.tsx` | Hint now uses `KbdHint` with `variant="chip"`; recommended CTA gained `aria-keyshortcuts="s"`; shortcut handler ignores modifier combos. |
+| `src/components/KbdHint.tsx` | Unchanged — the existing `chip` variant is reused as-is. |
+| `src/index.css` | Added `.pricing-tier-card__kbd-hint` placement + responsive rules. |
+| `src/styles/contrast.css` | Added `prefers-contrast: more` overrides for `.kbd-hint--chip`. |
+
+### Before / after
+
+The hint previously rendered via `KbdHint`'s **default** variant, which is a
+right-aligned `<aside>` list intended for sidebars, and passed an unsupported
+`style` prop (a TypeScript error). It is now the intended compact chip:
+
+```diff
+-<KbdHint shortcuts={PRIMARY_SHORTCUT} style={{ padding: 0 }} />
++<KbdHint
++  shortcuts={PRIMARY_SHORTCUT}
++  variant="chip"
++  label="Keyboard shortcut to select the recommended plan"
++/>
+```
+
+## Visible Behaviour
+
+- A pill reading `S  Select recommended plan` appears under the recommended
+  tier's CTA button — and **only** that tier's button.
+- Pressing <kbd>S</kbd> (or <kbd>Shift</kbd>+<kbd>S</kbd>) invokes
+  `onSelectTier` with the recommended tier, matching the CTA click.
+- The shortcut is inert while focus is in an `<input>`, `<textarea>`, or any
+  `contenteditable` element.
+- Modified presses (<kbd>Ctrl</kbd>/<kbd>Cmd</kbd>/<kbd>Alt</kbd> + <kbd>S</kbd>)
+  are ignored, so browser shortcuts such as "Save page" keep working.
+- If no tier sets `isRecommended`, no chip and no shortcut are exposed.
+
+## API
+
+No breaking changes. `PricingTierTable` props are unchanged:
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `tiers` | `PricingTier[]` | — | Tiers to render. The tier with `isRecommended: true` receives the shortcut chip. |
+| `onSelectTier` | `(tier: PricingTier) => void` | `undefined` | Fired on CTA click, and on <kbd>S</kbd> for the recommended tier. |
+
+The chip is internal — it is driven by the `PRIMARY_SHORTCUT` constant in
+`PricingTierTable.tsx` and is not configurable via props.
+
+## Styling & Design Tokens
+
+Placement lives in `src/index.css`:
+
+```css
+.pricing-tier-card__kbd-hint {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--mkt-space-md);
+}
+```
+
+Colour and shape come entirely from the shared `.kbd-hint--chip` rules, so the
+chip inherits `--surface-soft`, `--surface-strong`, `--line`, `--line-strong`,
+and `--muted`. Because every value is a design token, **dark mode needs no
+extra rules** — the chip follows the active theme automatically.
+
+### Responsive
+
+| Breakpoint | Behaviour |
+| --- | --- |
+| > 768 px | Desktop grid; chip centred under the full-width CTA. |
+| ≤ 768 px | Mobile card layout (`.pricing-tiers-mobile`); chip still centred under the CTA. |
+| ≤ 480 px | Tighter `margin-top`, smaller chip padding and font size to preserve vertical rhythm. |
+
+## Accessibility (WCAG 2.1 AA)
+
+- **1.4.3 Contrast / 1.4.11 Non-text Contrast** — chip text uses `--muted` on
+  `--surface-soft` with a tokenised border. Under `prefers-contrast: more`,
+  `src/styles/contrast.css` promotes the text to `--text` and thickens both the
+  chip and key-cap borders.
+- **1.3.1 Info and Relationships** — the key is marked up as a real `<kbd>`
+  element, and the chip's text ("S Select recommended plan") is plain visible
+  text read in DOM order right after the button it describes.
+  Note: `KbdHint` also sets `aria-label` on its container, but for the `chip`
+  variant that container is a `<span>` (`role=generic`), and ARIA prohibits
+  naming on generic roles — so that label is **not** exposed to assistive tech.
+  It is harmless, and the accessible information comes from the visible text
+  plus `aria-keyshortcuts` below; do not rely on the `aria-label` alone.
+- **4.1.2 Name, Role, Value** — the recommended CTA exposes
+  `aria-keyshortcuts="s"` (lowercase, per the WAI-ARIA attribute's key-name
+  grammar), so assistive tech announces the shortcut on the control itself
+  rather than relying on adjacent text.
+- **1.4.4 Resize Text / 1.4.10 Reflow** — chip sizing uses relative `rem` font
+  sizes and wraps inside the card at 320 px.
+- **Listener hygiene** — the `keydown` listener is removed on unmount (covered
+  by a test).
+
+### Known deviation: 2.1.4 Character Key Shortcuts
+
+The <kbd>S</kbd> shortcut is a single-character shortcut bound at the `window`
+level, which SC 2.1.4 (Level A) asks to be remappable, switchable off, or
+active only on focus. Today it is only suppressed while a form field is
+focused. This matches the existing repo-wide convention for single-key
+shortcuts (`/`, `c`, `u`, `?`), so it was left consistent rather than changed
+unilaterally here — see the note in the pull request. A repo-wide fix (a
+shortcuts preference, or scoping handlers to focus) should be tracked
+separately.
+
+## Tests
+
+`src/components/PricingTierTable.test.tsx` — the `shortcut hint chip` suite
+covers: chip variant (not the `<aside>` list), accessible label, chip present
+only on the recommended tier, absence when nothing is recommended,
+`aria-keyshortcuts` placement, the mobile layout, modifier-key rejection,
+uppercase `S`, and listener cleanup on unmount.
+
+```bash
+npx vitest run src/components/PricingTierTable.test.tsx
+```

--- a/src/components/PricingTierTable.test.tsx
+++ b/src/components/PricingTierTable.test.tsx
@@ -6,6 +6,27 @@ import PricingTierTable, { type PricingTier } from "./PricingTierTable";
 
 afterEach(cleanup);
 
+/**
+ * Forces `window.matchMedia("(max-width: 768px)")` to report a match so the
+ * component renders its mobile card layout.
+ */
+function mockViewport(isMobile: boolean) {
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 const mockTiers: PricingTier[] = [
   {
     name: "Free",
@@ -75,5 +96,135 @@ describe("PricingTierTable", () => {
     fireEvent.keyDown(input, { key: "s" });
 
     expect(onSelectTier).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Shortcut hint chip (issue #944) ─────────────────────────────────────────
+
+describe("PricingTierTable — shortcut hint chip", () => {
+  /** Returns the KbdHint chip element, or null when it is not rendered. */
+  const getChip = (container: HTMLElement) =>
+    container.querySelector(".kbd-hint--chip");
+
+  it("renders the hint as the compact chip variant, not the default list", () => {
+    const { container } = render(<PricingTierTable tiers={mockTiers} />);
+
+    const chip = getChip(container);
+    expect(chip).toBeTruthy();
+    // The chip variant must not fall back to the right-aligned <aside> list.
+    expect(chip?.tagName.toLowerCase()).toBe("span");
+    expect(container.querySelector("aside.kbd-hint")).toBeNull();
+  });
+
+  it("wires the descriptive label through to KbdHint", () => {
+    const { container } = render(<PricingTierTable tiers={mockTiers} />);
+
+    // NOTE: this asserts the prop is wired, not that it is announced — the
+    // chip container is a <span> (role=generic), where ARIA prohibits naming.
+    // The information a screen reader actually receives is the visible text
+    // below plus aria-keyshortcuts on the button.
+    expect(getChip(container)?.getAttribute("aria-label")).toBe(
+      "Keyboard shortcut to select the recommended plan"
+    );
+  });
+
+  it("keeps the shortcut description as real visible text", () => {
+    render(<PricingTierTable tiers={mockTiers} />);
+
+    expect(screen.getByText("Select recommended plan")).toBeTruthy();
+    // A real <kbd> element, not a styled span.
+    expect(screen.getByText("S").tagName.toLowerCase()).toBe("kbd");
+  });
+
+  it("renders the chip only for the recommended tier", () => {
+    const { container } = render(<PricingTierTable tiers={mockTiers} />);
+
+    // Two tiers are rendered but only "Pro" is recommended.
+    expect(container.querySelectorAll(".kbd-hint--chip")).toHaveLength(1);
+
+    const recommendedCard = screen
+      .getByText("Upgrade Now")
+      .closest(".pricing-tier-card");
+    expect(recommendedCard?.querySelector(".kbd-hint--chip")).toBeTruthy();
+  });
+
+  it("renders no chip when no tier is marked as recommended", () => {
+    const tiersWithoutRecommendation = mockTiers.map((tier) => ({
+      ...tier,
+      isRecommended: false,
+    }));
+    const { container } = render(
+      <PricingTierTable tiers={tiersWithoutRecommendation} />
+    );
+
+    expect(getChip(container)).toBeNull();
+  });
+
+  it("sets aria-keyshortcuts on the recommended tier's primary action only", () => {
+    render(<PricingTierTable tiers={mockTiers} />);
+
+    expect(screen.getByText("Upgrade Now").getAttribute("aria-keyshortcuts")).toBe("s");
+    expect(screen.getByText("Get Started").getAttribute("aria-keyshortcuts")).toBeNull();
+  });
+
+  it("renders the chip in the mobile card layout as well", () => {
+    const restore = mockViewport(true);
+    try {
+      const { container } = render(<PricingTierTable tiers={mockTiers} />);
+
+      expect(container.querySelector(".pricing-tiers-mobile")).toBeTruthy();
+      expect(getChip(container)).toBeTruthy();
+      expect(screen.getByText("Select recommended plan")).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignores modified 's' presses so browser combos like Ctrl+S still work", () => {
+    const onSelectTier = vi.fn();
+    render(<PricingTierTable tiers={mockTiers} onSelectTier={onSelectTier} />);
+
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "s", metaKey: true });
+    fireEvent.keyDown(window, { key: "s", altKey: true });
+
+    expect(onSelectTier).not.toHaveBeenCalled();
+
+    // Sanity check: the unmodified key still activates the shortcut.
+    fireEvent.keyDown(window, { key: "s" });
+    expect(onSelectTier).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts uppercase 'S' matching the key cap shown in the chip", () => {
+    const onSelectTier = vi.fn();
+    render(<PricingTierTable tiers={mockTiers} onSelectTier={onSelectTier} />);
+
+    fireEvent.keyDown(window, { key: "S" });
+
+    expect(onSelectTier).toHaveBeenCalledWith(mockTiers[1]);
+  });
+
+  it("removes its keydown listener on unmount", () => {
+    const onSelectTier = vi.fn();
+    const { unmount } = render(
+      <PricingTierTable tiers={mockTiers} onSelectTier={onSelectTier} />
+    );
+
+    unmount();
+    fireEvent.keyDown(window, { key: "s" });
+
+    expect(onSelectTier).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the tier name when the tier has no PlanBadge metadata", () => {
+    // "developer" is not one of PlanBadge's supported tiers; the card must
+    // still label itself rather than rendering a badge with no metadata.
+    render(
+      <PricingTierTable
+        tiers={[{ ...mockTiers[1], tier: "developer" }]}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Pro" })).toBeTruthy();
   });
 });

--- a/src/components/PricingTierTable.tsx
+++ b/src/components/PricingTierTable.tsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from "react";
 import { CheckIcon } from "./icons";
 import type { Shortcut } from "../hooks/useGlobalShortcuts";
 import KbdHint from "./KbdHint";
-import PlanBadge from "./PlanBadge";
+import PlanBadge, { type PlanTier } from "./PlanBadge";
+// High-contrast (`prefers-contrast: more`) overrides for the shortcut hint chip.
+import "../styles/contrast.css";
 
 export interface PricingFeature {
   label: string;
@@ -24,7 +26,7 @@ interface PricingTierTableProps {
   onSelectTier?: (tier: PricingTier) => void;
 }
 
-const XIcon = () => (
+const XIcon = ({ style }: { style?: React.CSSProperties }) => (
   <svg
     width="20"
     height="20"
@@ -35,15 +37,54 @@ const XIcon = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden="true"
+    style={style}
   >
     <line x1="18" y1="6" x2="6" y2="18"></line>
     <line x1="6" y1="6" x2="18" y2="18"></line>
   </svg>
 );
 
+/**
+ * Tiers that `PlanBadge` knows how to render. `PricingTier.tier` accepts a
+ * wider set of marketing names, so anything outside this list falls back to the
+ * plain `<h3>` tier name instead of rendering a badge with undefined metadata.
+ */
+const PLAN_BADGE_TIERS: readonly string[] = ["free", "pro", "enterprise"];
+
+const toPlanBadgeTier = (tier: PricingTier["tier"]): PlanTier | null =>
+  tier && PLAN_BADGE_TIERS.includes(tier) ? (tier as PlanTier) : null;
+
+/**
+ * The single shortcut advertised by the hint chip on the recommended tier's
+ * primary action. Displayed as an uppercase key cap for legibility while the
+ * handler and `aria-keyshortcuts` both use the case-insensitive "s".
+ */
 const PRIMARY_SHORTCUT: readonly Shortcut[] = [
   { key: "S", description: "Select recommended plan", category: "Pricing" },
 ];
+
+/** Lowercase key name required by the `aria-keyshortcuts` attribute. */
+const PRIMARY_SHORTCUT_KEY = "s";
+
+/**
+ * Subtle keyboard shortcut hint chip shown directly beneath the recommended
+ * tier's primary action (issue #944).
+ *
+ * Renders `KbdHint`'s `chip` variant so the pill inherits the shared
+ * `.kbd-hint--chip` design tokens — border, radius, and muted foreground —
+ * which keeps it consistent in both light and dark themes.
+ */
+function PrimaryActionHint() {
+  return (
+    <div className="pricing-tier-card__kbd-hint">
+      <KbdHint
+        shortcuts={PRIMARY_SHORTCUT}
+        variant="chip"
+        label="Keyboard shortcut to select the recommended plan"
+      />
+    </div>
+  );
+}
 
 export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTableProps) {
   const [isMobile, setIsMobile] = useState(false);
@@ -67,6 +108,10 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
       );
       if (isEditable) return;
 
+      // Ignore modified presses so we don't hijack browser/OS combos such as
+      // Ctrl+S / Cmd+S (save page) or Alt+S.
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
       if (e.key.toLowerCase() === "s") {
         const recommended = tiers.find((t) => t.isRecommended);
         if (recommended) {
@@ -82,7 +127,9 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
   if (isMobile) {
     return (
       <div className="pricing-tiers-mobile" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-        {tiers.map((tier) => (
+        {tiers.map((tier) => {
+          const badgeTier = toPlanBadgeTier(tier.tier);
+          return (
           <div
             key={tier.name}
             className="pricing-tier-card"
@@ -117,14 +164,14 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
               </div>
             )}
 
-            {tier.tier && (
+            {badgeTier && (
               <div style={{ display: "flex", justifyContent: "center", marginBottom: 8 }}>
-                <PlanBadge tier={tier.tier} />
+                <PlanBadge tier={badgeTier} />
               </div>
             )}
 
             <div style={{ textAlign: "center" }}>
-              {!tier.tier && <h3 style={{ margin: 0, fontSize: 20 }}>{tier.name}</h3>}
+              {!badgeTier && <h3 style={{ margin: 0, fontSize: 20 }}>{tier.name}</h3>}
               <div style={{ fontSize: 28, fontWeight: 800, marginTop: 8 }}>{tier.price}</div>
               <p style={{ fontSize: 14, color: "var(--muted)", marginTop: 4 }}>{tier.description}</p>
             </div>
@@ -146,23 +193,25 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
               className="primary-button"
               style={{ width: "100%", marginTop: 8 }}
               onClick={() => onSelectTier?.(tier)}
+              // Exposes the shortcut programmatically; only the recommended
+              // tier's action is reachable via the "s" key.
+              aria-keyshortcuts={tier.isRecommended ? PRIMARY_SHORTCUT_KEY : undefined}
             >
               {tier.ctaLabel}
             </button>
-            {tier.isRecommended && (
-              <div style={{ display: "flex", justifyContent: "center", marginTop: 4 }}>
-                <KbdHint shortcuts={PRIMARY_SHORTCUT} style={{ padding: 0 }} />
-              </div>
-            )}
+            {tier.isRecommended && <PrimaryActionHint />}
           </div>
-        ))}
+          );
+        })}
       </div>
     );
   }
 
   return (
     <div className="api-detail-pricing-grid pricing-tiers-desktop" style={{ display: "grid", gridTemplateColumns: `repeat(${tiers.length}, 1fr)`, gap: 24 }}>
-      {tiers.map((tier) => (
+      {tiers.map((tier) => {
+        const badgeTier = toPlanBadgeTier(tier.tier);
+        return (
         <div
           key={tier.name}
           className="pricing-tier-card"
@@ -196,14 +245,14 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
             </div>
           )}
 
-          {tier.tier && (
+          {badgeTier && (
             <div style={{ marginBottom: 12 }}>
-              <PlanBadge tier={tier.tier} />
+              <PlanBadge tier={badgeTier} />
             </div>
           )}
 
           <div style={{ textAlign: "center", marginBottom: 24 }}>
-            {!tier.tier && <h3 style={{ margin: 0, fontSize: 20 }}>{tier.name}</h3>}
+            {!badgeTier && <h3 style={{ margin: 0, fontSize: 20 }}>{tier.name}</h3>}
             <div style={{ fontSize: 28, fontWeight: 800, marginTop: 8 }}>{tier.price}</div>
             <p style={{ fontSize: 14, color: "var(--muted)", marginTop: 4 }}>{tier.description}</p>
           </div>
@@ -235,17 +284,17 @@ export default function PricingTierTable({ tiers, onSelectTier }: PricingTierTab
             className="primary-button"
             style={{ width: "100%" }}
             onClick={() => onSelectTier?.(tier)}
+            // Exposes the shortcut programmatically; only the recommended
+            // tier's action is reachable via the "s" key.
+            aria-keyshortcuts={tier.isRecommended ? PRIMARY_SHORTCUT_KEY : undefined}
           >
             {tier.ctaLabel}
           </button>
 
-          {tier.isRecommended && (
-            <div style={{ display: "flex", justifyContent: "center", marginTop: 8 }}>
-              <KbdHint shortcuts={PRIMARY_SHORTCUT} style={{ padding: 0 }} />
-            </div>
-          )}
+          {tier.isRecommended && <PrimaryActionHint />}
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2665,6 +2665,35 @@ code,
   }
 }
 
+/* ── PricingTable primary-action shortcut hint (issue #944) ───────────────
+   Centres the `KbdHint` chip under the recommended tier's CTA button. The
+   chip itself is styled by `.kbd-hint--chip` above, so this only handles
+   placement — colours and radii stay token-driven for dark-mode parity. */
+.pricing-tier-card__kbd-hint {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--mkt-space-md);
+}
+
+/* On narrow viewports the CTA is full-width and vertical space is scarce,
+   so tighten the gap and shrink the chip slightly. */
+@media (max-width: 480px) {
+  .pricing-tier-card__kbd-hint {
+    margin-top: var(--mkt-space-sm);
+  }
+
+  .pricing-tier-card__kbd-hint .kbd-hint--chip {
+    gap: var(--mkt-space-sm);
+    padding: 2px var(--mkt-space-md);
+    font-size: 0.7rem;
+  }
+
+  .pricing-tier-card__kbd-hint .kbd-hint--chip .kbd-hint__key {
+    min-width: 16px;
+    font-size: 0.65rem;
+  }
+}
+
 /* QuotaBanner layout and styles */
 .quota-banner {
   display: flex;
@@ -7279,7 +7308,6 @@ code,
   .sort-menu {
     max-height: none !important;
   }
-}
 
 /* ── LatencyChart page (GrantFox FWC26) ───────────────────────────────────────
    Responsive latency dashboard with bar chart and HelpPopover. Uses design

--- a/src/styles/contrast.css
+++ b/src/styles/contrast.css
@@ -50,4 +50,24 @@
     color: #ffffff;
     transform: none;
   }
+
+  /* ── KbdHint chip high-contrast overrides (issue #944) ─────────────────
+     The chip variant uses var(--muted) text on var(--surface-soft) with a
+     1px var(--line) border.  Under `prefers-contrast: more` we promote the
+     text to full-strength and thicken the borders so both the chip and the
+     inner <kbd> key cap meet 1.4.11 non-text contrast.
+
+     Selectors are doubled up (`.kbd-hint.kbd-hint--chip`) so they outrank the
+     single-class base rules in index.css regardless of bundle order. */
+  .kbd-hint.kbd-hint--chip {
+    color: var(--text);
+    border-width: 2px;
+    background: var(--surface);
+  }
+
+  .kbd-hint.kbd-hint--chip .kbd-hint__key {
+    color: var(--text);
+    border-width: 2px;
+    border-color: var(--line-strong, var(--line));
+  }
 }


### PR DESCRIPTION
Closes #944

### What this does

Shows a subtle keyboard shortcut hint chip — **`S` · Select recommended plan** —
directly beneath the recommended tier's primary action in `PricingTable`, in both
the desktop grid and the mobile card layout. Only the recommended tier gets it,
since it is the only tier whose action responds to the shortcut.

### Starting point

A quick note on where the code stood, since it explains why this PR **does not touch
the two files the issue suggested**.

A hint was already wired into `PricingTierTable` on `main`, but not yet as a chip:

- It rendered with `KbdHint`'s **`default`** variant — a right-aligned `<aside>` list
  intended for sidebars — rather than the compact chip the issue describes.
- It passed `style={{ padding: 0 }}` to `KbdHint`, which is not part of that
  component's props, so the file did not typecheck.

This PR moves it to the intended chip presentation and resolves the type error.

On the files the issue suggested touching:

- `src/pages/PricingTable.tsx` — three lines re-exporting `PricingTierTable`. The
  real logic lives there, so that is where I worked. Unchanged.
- `src/components/KbdHint.tsx` — **already had** the `variant="chip"` implementation.
  Reused as-is. Unchanged.

### Changes

| File | Change |
|---|---|
| `src/components/PricingTierTable.tsx` | Chip via `variant="chip"`; `aria-keyshortcuts="s"` on the recommended CTA; handler now ignores modifier combos |
| `src/components/PricingTierTable.test.tsx` | +11 focused tests |
| `src/index.css` | `.pricing-tier-card__kbd-hint` placement + ≤480px tuning |
| `src/styles/contrast.css` | `prefers-contrast: more` overrides for the chip |
| `docs/PricingTable-KbdHint.md` | New documentation |

The core change:

```diff
-<KbdHint shortcuts={PRIMARY_SHORTCUT} style={{ padding: 0 }} />
+<KbdHint
+  shortcuts={PRIMARY_SHORTCUT}
+  variant="chip"
+  label="Keyboard shortcut to select the recommended plan"
+/>
```

### Fixes included

Three fixes the issue did not ask for but that were in the way. Each is independent
and can be pulled out of this PR on request:

1. **`KbdHint` received a `style` prop it does not accept** — a TypeScript error.
   This is the feature code itself, so fixing it is part of the work: with
   `variant="chip"` the padding override is no longer needed.

2. **`PlanBadge` could receive tiers it does not support** — `PricingTier.tier`
   accepts `"developer"` and `"standard"`, which are not in `PlanTier`. In that case
   `PLAN_META[tier]` is `undefined` and the component **crashes** on `meta.label`. A
   guard (`toPlanBadgeTier`) now falls back to the `<h3>` tier name. Covered by a
   test.

3. **`XIcon` received a `style` prop it does not accept** — TypeScript error, 2 call
   sites.

Plus two improvements to the shortcut handler, justified because the chip now
*advertises* that key: if the chip promises `S`, that key must work, and it must not
hijack browser combos.

- Ignores `Ctrl`/`Cmd`/`Alt` + `S`, so "save page" keeps working.
- Accepts uppercase `S`, matching the key cap the chip displays.

### Accessibility (WCAG 2.1 AA)

- **4.1.2 Name, Role, Value** — the recommended CTA exposes `aria-keyshortcuts="s"`.
- **1.4.11 Non-text Contrast** — under `prefers-contrast: more` the chip promotes
  text to `--text` and thickens borders to 2px. Selectors are doubled up
  (`.kbd-hint.kbd-hint--chip`) so they outrank the base rules regardless of bundle
  order.
- **1.3.1 Info and Relationships** — the key is a real `<kbd>` element and the
  description is visible text read in DOM order right after the button.

Two limitations, documented in `docs/PricingTable-KbdHint.md`:

- **`aria-label` is not exposed.** The chip variant's container is a `<span>`
  (`role=generic`), and ARIA prohibits naming generic roles, so that `aria-label`
  is **not announced by screen readers**. It is harmless; the accessible
  information comes from the visible text plus `aria-keyshortcuts`. Worth knowing so
  nobody relies on the `aria-label` alone.
- **SC 2.1.4 (Character Key Shortcuts) — known deviation.** `S` is a
  single-character shortcut bound at the `window` level. The criterion asks for it
  to be remappable, switchable off, or active only on focus; today it is only
  suppressed while a form field is focused. Left **consistent with the existing
  repo-wide convention** (`/`, `c`, `u`, `?` all behave this way) rather than
  changed unilaterally here. Deserves its own issue and a repo-wide fix.

### Responsive

| Breakpoint | Behaviour |
|---|---|
| > 768px | Desktop grid, chip centred under the CTA |
| ≤ 768px | Mobile card layout, chip centred under the CTA |
| ≤ 480px | Reduced `margin-top`, padding and font size |

Colours and radii come entirely from design tokens (`--surface-soft`,
`--surface-strong`, `--line`, `--line-strong`, `--muted`), so **dark mode needs no
extra rules**.

### Verification

- **16/16** tests in `PricingTierTable.test.tsx` (was 5). I reverted the component
  to its `main` version and ran the new tests: **7 failed**, confirming they
  actually detect the regression.
- `TagChip.test.tsx` 9/9 — run because `contrast.css` is shared.
- `tsc` clean on both the component and the test file.
- **Full suite, no regressions:**

| | `main` | This PR |
|---|---|---|
| Tests passing | 1754 | **1765** |
| Tests failing | 60 | **60** |
| Failing files | 13 | **13** (identical list) |

The 60 failures and 13 files are **pre-existing** on `main` and unrelated to this
PR. I verified the list of failing files is exactly the same before and after.

### Side note: `src/index.css` does not compile on `main`

While setting up visual verification I found that **`npm run dev` is currently broken
on `main`**: `src/index.css` has an orphan `}` that makes **PostCSS throw**, so
`index.css` never compiles and the app is served unstyled (a browser would discard
the brace; PostCSS does not).

This PR deletes **that single brace** to unblock the dev server. I deliberately chose
the option that **does not change rendering**: the browser was already ignoring it,
so the visual result is identical.

I did **not** address the underlying problem, which is larger and deserves its own
PR: the `@media print` block closes early, leaving ~60 lines of print-only rules at
global scope where they apply **on screen** (`EndpointSummary` collapsibles always
expanded, sort rows permanently hidden, phantom "Developer Reviews" / "Sort Options"
text, hardcoded colours hostile to dark mode). Fixing that changes the appearance of
ReviewsTab, SortMenu and EndpointSummary, so it needs its own visual review.

Happy to pull that one-line change out of this PR if you would rather it landed
separately.

