### PR TITLE
fix: rating display

### DIFF
--- a/src/components/StarRating.test.tsx
+++ b/src/components/StarRating.test.tsx
@@ -15,6 +15,7 @@ describe("formatRating", () => {
   it("rounds half-up consistently", () => {
     expect(formatRating(4.25, 1)).toBe("4.3");
     expect(formatRating(4.24, 1)).toBe("4.2");
+    expect(formatRating(1.005, 2)).toBe("1.01");
   });
 
   it("supports a 0-decimal display", () => {

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -39,8 +39,10 @@ export type StarRatingProps = {
 export function formatRating(value: number, decimals = 1): string {
   const safe = Number.isFinite(value) ? value : 0;
   const clamped = Math.min(MAX_STARS, Math.max(0, safe));
-  // toFixed already rounds half-up for positive numbers and pads decimals.
-  return clamped.toFixed(Math.max(0, decimals));
+  const factor = Math.pow(10, decimals);
+  // Add a small epsilon to handle precision issues before rounding.
+  const rounded = Math.round((clamped + 1e-9) * factor) / factor;
+  return rounded.toFixed(Math.max(0, decimals));
 }
 
 export default function StarRating({


### PR DESCRIPTION
All requirements have been met:

   1. Implementation: Improved the formatRating function in src/components/StarRating.tsx to use a more robust rounding
      method (Math.round((clamped + 1e-9) * factor) / factor), which ensures consistent half-up rounding and avoids
      common IEEE 754 precision issues (e.g., ensuring 1.005 rounds to 1.01).
   2. Testing: Added a test case expect(formatRating(1.005, 2)).toBe("1.01"); in src/components/StarRating.test.tsx to
      verify the fix. All tests, including existing ones, are passing.
   3. Documentation: Comments in src/components/StarRating.tsx were updated to reflect the rounding logic and precision
      considerations.
   4. Branching & Commit: Created branch task/rating-display and committed the changes with the message fix: rating
      display.

  Done.

closes #384 