### PR TITLE
feat: downsample latency chart data without changing percentile meani…

### DIFF
--- a/src/pages/LatencyChart.test.tsx
+++ b/src/pages/LatencyChart.test.tsx
@@ -1,32 +1,47 @@
 // @vitest-environment jsdom
+import { vi } from "vitest";
+vi.mock("../config/constants", () => ({ LOADING_DELAY_MS: 100 }));
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import LatencyChart from "./LatencyChart";
+import LatencyChart, { useLatencyData } from "./LatencyChart";
+import { FetchTrackerProvider } from "../hooks/useFetchTracker";
+import { renderHook } from "@testing-library/react";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
-function renderChart() {
-  return render(
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <FetchTrackerProvider>
     <MemoryRouter>
-      <LatencyChart />
+      {children}
     </MemoryRouter>
-  );
+  </FetchTrackerProvider>
+);
+
+async function renderChartAndWait() {
+  const rendered = render(<LatencyChart />, { wrapper: Wrapper });
+  await waitFor(() => {
+    expect(screen.queryByText(/Loading latency data/)).toBeNull();
+  });
+  return rendered;
 }
 
-describe("LatencyChart Page (#714)", () => {
-  it("renders the page title and breadcrumb", () => {
-    renderChart();
+describe("LatencyChart Component UI (#997)", () => {
+  // --- Original tests restored and adapted for async data load ---
 
+  it("renders the page title and breadcrumb", async () => {
+    await renderChartAndWait();
     expect(screen.getByRole("heading", { name: "Latency" })).toBeTruthy();
     expect(screen.getByText("Dashboard")).toBeTruthy();
     expect(screen.getByText("Last 24 hours")).toBeTruthy();
   });
 
   it("renders the HelpPopover with an accessible label explaining P95 latency", async () => {
-    renderChart();
-
+    await renderChartAndWait();
     const helpBtn = screen.getByRole("button", { name: "Help: What is P95 latency?" });
     expect(helpBtn).toBeTruthy();
 
@@ -40,18 +55,16 @@ describe("LatencyChart Page (#714)", () => {
     });
   });
 
-  it("renders stat cards for min, avg, P95, and max", () => {
-    renderChart();
-
+  it("renders stat cards for min, avg, P95, and max", async () => {
+    await renderChartAndWait();
     expect(screen.getByText("Min")).toBeTruthy();
     expect(screen.getByText("Avg")).toBeTruthy();
     expect(screen.getByText("P95")).toBeTruthy();
     expect(screen.getByText("Max")).toBeTruthy();
   });
 
-  it("renders the correct latency values in stat cards", () => {
-    renderChart();
-
+  it("renders the correct latency values in stat cards", async () => {
+    await renderChartAndWait();
     const minValue = screen.getByText("88 ms");
     const maxValue = screen.getByText("210 ms");
     const avgValue = screen.getByText("152 ms");
@@ -62,21 +75,19 @@ describe("LatencyChart Page (#714)", () => {
     expect(p95Value).toBeTruthy();
   });
 
-  it("renders the latency chart bars with accessible labels", () => {
-    renderChart();
-
+  it("renders the latency chart bars with accessible labels", async () => {
+    await renderChartAndWait();
     const bars = screen.getAllByRole("img", { name: /ms/ });
     expect(bars.length).toBeGreaterThan(0);
   });
 
-  it("renders the chart caption for screen reader context", () => {
-    renderChart();
-
+  it("renders the chart caption for screen reader context", async () => {
+    await renderChartAndWait();
     expect(screen.getByText(/Bars represent sampled response times/)).toBeTruthy();
   });
 
   it("dismisses the HelpPopover tooltip on Escape", async () => {
-    renderChart();
+    await renderChartAndWait();
 
     const helpBtn = screen.getByRole("button", { name: "Help: What is P95 latency?" });
     fireEvent.focus(helpBtn);
@@ -90,5 +101,79 @@ describe("LatencyChart Page (#714)", () => {
     await waitFor(() => {
       expect(screen.queryByRole("tooltip")).toBeNull();
     });
+  });
+
+  // --- New state tests added for #997 ---
+
+  it("renders the loading state initially", () => {
+    render(<LatencyChart />, { wrapper: Wrapper });
+    expect(screen.getByText(/Loading latency data/)).toBeTruthy();
+  });
+
+  it("renders the stale state visually when account changes", async () => {
+    const { rerender } = await renderChartAndWait();
+    rerender(
+      
+        <LatencyChart accountId="acc-2" />
+      
+    );
+    expect(screen.getByText(/Updating chart data/)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText(/Updating chart data/)).toBeNull();
+    });
+  });
+});
+
+describe("useLatencyData hook state transitions (#997)", () => {
+  it("handles empty state", async () => {
+    const { result } = renderHook(() => useLatencyData("empty"), { wrapper: Wrapper });
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.data.length).toBe(0);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("handles error state and retry", async () => {
+    const { result } = renderHook(() => useLatencyData("error"), { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isError).toBe(true);
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});
+
+describe("useLatencyData race condition guard (#997)", () => {
+  it("ignores older requests that resolve after newer ones due to generation counter", async () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ accountId }) => useLatencyData(accountId), {
+      initialProps: { accountId: "acc-1" },
+      wrapper: Wrapper,
+    });
+
+    act(() => vi.advanceTimersByTime(10));
+    rerender({ accountId: "error" });
+    
+    act(() => vi.advanceTimersByTime(10));
+    rerender({ accountId: "acc-2" });
+    
+    act(() => vi.runAllTimers());
+    
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data.length).toBeGreaterThan(0);
+    expect(result.current.isError).toBe(false);
   });
 });

--- a/src/pages/LatencyChart.tsx
+++ b/src/pages/LatencyChart.tsx
@@ -1,12 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect, useRef, useCallback } from "react";
 import Breadcrumb from "../components/Breadcrumb";
 import HelpPopover from "../components/HelpPopover";
-
-type LatencyPoint = {
-  label: string;
-  value: number;
-  timestamp: Date;
-};
+import { downsampleLatencyData, type LatencyPoint } from "../utils/downsample";
+import { useFetchTracker } from "../hooks/useFetchTracker";
+import { LOADING_DELAY_MS } from "../config/constants";
+import EmptyState from "../components/EmptyState";
 
 const MOCK_DATA: LatencyPoint[] = [
   { label: "00:00", value: 120, timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000) },
@@ -36,7 +34,16 @@ const MOCK_DATA: LatencyPoint[] = [
   { label: "Now", value: 120, timestamp: new Date() },
 ];
 
+function getMockDataForAccount(accountId: string): LatencyPoint[] {
+  if (accountId === "empty") return [];
+  if (accountId === "error") throw new Error("Simulated backend error");
+  
+  const multiplier = accountId === "acc-2" ? 1.5 : 1;
+  return MOCK_DATA.map(d => ({ ...d, value: Math.round(d.value * multiplier) }));
+}
+
 function computeStats(data: LatencyPoint[]) {
+  if (data.length === 0) return { min: 0, max: 0, avg: 0, p95: 0 };
   const values = data.map((d) => d.value);
   const min = Math.min(...values);
   const max = Math.max(...values);
@@ -47,20 +54,89 @@ function computeStats(data: LatencyPoint[]) {
   return { min, max, avg, p95 };
 }
 
-export default function LatencyChart() {
-  const stats = useMemo(() => computeStats(MOCK_DATA), []);
-  const maxValue = useMemo(() => Math.max(...MOCK_DATA.map((d) => d.value)), []);
+export function useLatencyData(accountId: string) {
+  const [state, setState] = useState({
+    data: [] as LatencyPoint[],
+    isLoading: true,
+    isError: false,
+    isStale: false,
+  });
+  
+  const { trackFetch } = useFetchTracker();
+  const generationRef = useRef(0);
+  const [retryCounter, setRetryCounter] = useState(0);
+
+  const retry = useCallback(() => setRetryCounter(c => c + 1), []);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    const currentGen = generationRef.current;
+    const abortController = new AbortController();
+
+    setState(prev => ({
+      ...prev,
+      isLoading: prev.data.length === 0,
+      isStale: prev.data.length > 0,
+      isError: false,
+    }));
+
+    trackFetch(
+      new Promise<LatencyPoint[]>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          if (!abortController.signal.aborted) {
+            try {
+              resolve(getMockDataForAccount(accountId));
+            } catch (err) {
+              reject(err);
+            }
+          } else {
+            resolve([]);
+          }
+        }, LOADING_DELAY_MS);
+
+        abortController.signal.addEventListener("abort", () => {
+          clearTimeout(timer);
+          resolve([]);
+        });
+      })
+    ).then((data) => {
+      // The GUARANTEED generation check
+      if (currentGen === generationRef.current) {
+        setState({
+          data, // Keep the raw data for stats calculations
+          isLoading: false,
+          isStale: false,
+          isError: false,
+        });
+      }
+    }).catch((err) => {
+      if (currentGen === generationRef.current) {
+        setState(prev => ({ ...prev, isLoading: false, isError: true, isStale: false }));
+      }
+    });
+
+    return () => abortController.abort();
+  }, [accountId, trackFetch, retryCounter]);
+
+  return { ...state, retry };
+}
+
+export default function LatencyChart({ accountId = "default" }: { accountId?: string }) {
+  const { data, isLoading, isError, isStale, retry } = useLatencyData(accountId);
+
+  // Compute stats on the RAW data, not the downsampled peaks, so Min/Avg remain accurate.
+  const stats = useMemo(() => computeStats(data), [data]);
+  
+  // Downsample visually for the bars chart
+  const visualData = useMemo(() => downsampleLatencyData(data, 12), [data]);
+  const maxValue = useMemo(() => visualData.length > 0 ? Math.max(...visualData.map((d) => d.value)) : 100, [visualData]);
 
   return (
     <div className="latency-chart-page">
       <Breadcrumb
         items={[
           { label: "Dashboard", href: "/dashboard" },
-          {
-            label: "Latency",
-            href: "/latency-chart",
-            isCurrent: true,
-          },
+          { label: "Latency", href: "/latency-chart", isCurrent: true },
         ]}
       />
 
@@ -71,22 +147,12 @@ export default function LatencyChart() {
             <HelpPopover
               content={
                 <span>
-                  <strong style={{ display: "block", marginBottom: "0.25rem" }}>
-                    P95 Latency
-                  </strong>
+                  <strong style={{ display: "block", marginBottom: "0.25rem" }}>P95 Latency</strong>
                   <span style={{ display: "block" }}>
-                    The 95th percentile response time. 95% of requests complete
-                    faster than this value; the remaining 5% are slower.
+                    The 95th percentile response time. 95% of requests complete faster than this value; the remaining 5% are slower.
                   </span>
-                  <span
-                    style={{
-                      display: "block",
-                      marginTop: "0.25rem",
-                      opacity: 0.85,
-                    }}
-                  >
-                    Lower is better — aim for under 200 ms for a smooth
-                    experience.
+                  <span style={{ display: "block", marginTop: "0.25rem", opacity: 0.85 }}>
+                    Lower is better — aim for under 200 ms for a smooth experience.
                   </span>
                 </span>
               }
@@ -96,61 +162,68 @@ export default function LatencyChart() {
           <span className="latency-chart-subtitle">Last 24 hours</span>
         </div>
 
-        <div className="latency-stats-grid">
-          <div className="latency-stat-card">
-            <span className="latency-stat-label">Min</span>
-            <strong className="latency-stat-value tabular-nums">
-              {stats.min} ms
-            </strong>
-          </div>
-          <div className="latency-stat-card">
-            <span className="latency-stat-label">Avg</span>
-            <strong className="latency-stat-value tabular-nums">
-              {stats.avg} ms
-            </strong>
-          </div>
-          <div className="latency-stat-card">
-            <span className="latency-stat-label">P95</span>
-            <strong className="latency-stat-value tabular-nums">
-              {stats.p95} ms
-            </strong>
-          </div>
-          <div className="latency-stat-card">
-            <span className="latency-stat-label">Max</span>
-            <strong className="latency-stat-value tabular-nums">
-              {stats.max} ms
-            </strong>
-          </div>
-        </div>
+        {isError ? (
+          <EmptyState
+            variant="error"
+            title="Failed to load latency data"
+            message="There was an error loading the latency chart. Please try again."
+            onRetry={retry}
+          />
+        ) : isLoading ? (
+          <div className="latency-chart-skeleton" aria-live="polite" aria-busy="true">Loading latency data...</div>
+        ) : data.length === 0 ? (
+          <EmptyState
+            variant="empty"
+            title="No Data"
+            message="There is no latency data available for this account."
+          />
+        ) : (
+          <>
+            <div className={`latency-stats-grid ${isStale ? "latency-chart-stale" : ""}`} style={{ opacity: isStale ? 0.6 : 1 }}>
+              <div className="latency-stat-card">
+                <span className="latency-stat-label">Min</span>
+                <strong className="latency-stat-value tabular-nums">{stats.min} ms</strong>
+              </div>
+              <div className="latency-stat-card">
+                <span className="latency-stat-label">Avg</span>
+                <strong className="latency-stat-value tabular-nums">{stats.avg} ms</strong>
+              </div>
+              <div className="latency-stat-card">
+                <span className="latency-stat-label">P95</span>
+                <strong className="latency-stat-value tabular-nums">{stats.p95} ms</strong>
+              </div>
+              <div className="latency-stat-card">
+                <span className="latency-stat-label">Max</span>
+                <strong className="latency-stat-value tabular-nums">{stats.max} ms</strong>
+              </div>
+            </div>
 
-        <div className="latency-chart-container" role="img" aria-label="Latency bar chart showing response times over the last 24 hours">
-          <div className="latency-chart-bars">
-            {MOCK_DATA.map((point, idx) => {
-              const heightPct = (point.value / maxValue) * 100;
-              const isHighest = point.value === maxValue;
-              return (
-                <div
-                  key={idx}
-                  className={`latency-chart-bar-wrapper`}
-                  style={{ flex: 1 }}
-                >
-                  <div
-                    className={`latency-chart-bar${isHighest ? " latency-chart-bar--peak" : ""}`}
-                    style={{ height: `${heightPct}%` }}
-                    title={`${point.label}: ${point.value} ms`}
-                    role="img"
-                    aria-label={`${point.label}: ${point.value} ms`}
-                  />
-                  <span className="latency-chart-bar-label">{point.label}</span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+            <div className={`latency-chart-container ${isStale ? "latency-chart-stale" : ""}`} style={{ opacity: isStale ? 0.6 : 1 }} role="img" aria-label="Latency bar chart showing response times over the last 24 hours">
+              {isStale && <div className="sr-only" aria-live="polite">Updating chart data...</div>}
+              <div className="latency-chart-bars">
+                {visualData.map((point, idx) => {
+                  const heightPct = (point.value / maxValue) * 100;
+                  const isHighest = point.value === maxValue;
+                  return (
+                    <div key={idx} className={`latency-chart-bar-wrapper`} style={{ flex: 1 }}>
+                      <div
+                        className={`latency-chart-bar${isHighest ? " latency-chart-bar--peak" : ""}`}
+                        style={{ height: `${heightPct}%` }}
+                        title={`${point.label}: ${point.value} ms`}
+                        role="img"
+                        aria-label={`${point.label}: ${point.value} ms`}
+                      />
+                      <span className="latency-chart-bar-label">{point.label}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        )}
 
         <p className="latency-chart-caption">
-          Bars represent sampled response times. The tallest bar marks the
-          highest observed latency in the window.
+          Bars represent sampled response times. The tallest bar marks the highest observed latency in the window.
         </p>
       </div>
     </div>

--- a/src/utils/downsample.test.ts
+++ b/src/utils/downsample.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { downsampleLatencyData, type LatencyPoint } from "./downsample";
+
+describe("downsampleLatencyData", () => {
+  it("does not downsample if data length is less than or equal to maxPoints", () => {
+    const data: LatencyPoint[] = [
+      { label: "1", value: 10, timestamp: new Date() },
+      { label: "2", value: 20, timestamp: new Date() },
+    ];
+    expect(downsampleLatencyData(data, 2)).toEqual(data);
+    expect(downsampleLatencyData(data, 5)).toEqual(data);
+  });
+
+  it("downsamples by taking the max() of the values in each bucket (preserves spikes)", () => {
+    const data: LatencyPoint[] = [
+      { label: "00:00", value: 100, timestamp: new Date(1000) },
+      { label: "01:00", value: 150, timestamp: new Date(2000) },
+      { label: "02:00", value: 500, timestamp: new Date(3000) }, // Spike
+      { label: "03:00", value: 120, timestamp: new Date(4000) },
+      { label: "04:00", value: 130, timestamp: new Date(5000) },
+      { label: "05:00", value: 140, timestamp: new Date(6000) },
+    ];
+
+    // Downsample to 2 points -> bucket size = 6/2 = 3
+    const result = downsampleLatencyData(data, 2);
+
+    expect(result).toHaveLength(2);
+
+    // Bucket 1: 100, 150, 500 -> max is 500
+    expect(result[0].value).toBe(500);
+    expect(result[0].label).toBe("00:00");
+
+    // Bucket 2: 120, 130, 140 -> max is 140
+    expect(result[1].value).toBe(140);
+    expect(result[1].label).toBe("03:00");
+  });
+});

--- a/src/utils/downsample.ts
+++ b/src/utils/downsample.ts
@@ -1,0 +1,35 @@
+export type LatencyPoint = {
+  label: string;
+  value: number;
+  timestamp: Date;
+};
+
+/**
+ * Downsamples latency data by grouping into buckets and returning the maximum
+ * value (P95) from each bucket. We do not average percentiles because they are
+ * non-additive and averaging smooths away latency spikes.
+ */
+export function downsampleLatencyData(data: LatencyPoint[], maxPoints: number): LatencyPoint[] {
+  if (data.length <= maxPoints || maxPoints <= 0) {
+    return data;
+  }
+
+  const bucketSize = Math.ceil(data.length / maxPoints);
+  const downsampled: LatencyPoint[] = [];
+
+  for (let i = 0; i < data.length; i += bucketSize) {
+    const chunk = data.slice(i, i + bucketSize);
+    
+    // Compute max value in the chunk
+    const maxValue = Math.max(...chunk.map((p) => p.value));
+    
+    // We use the timestamp and label of the first element in the bucket
+    downsampled.push({
+      label: chunk[0].label,
+      timestamp: chunk[0].timestamp,
+      value: maxValue,
+    });
+  }
+
+  return downsampled;
+}


### PR DESCRIPTION
## Downsample latency charts without changing percentile meaning

Closes #997

### Summary
`LatencyChart.tsx` previously rendered a static `MOCK_DATA` array synchronously with
no loading/error/empty/stale handling. This PR introduces the repo's existing
`useFetchTracker`/`AbortController` async pattern (matching `MarketplacePage.tsx`'s
conventions) to the chart, adds correct downsampling for the rendered bar chart, and
makes all required UI states explicit.

### Downsampling approach
`LatencyPoint.value` represents a pre-aggregated P95 latency value (confirmed — no
raw samples or other percentiles exist in this component's data). Averaging
percentile values across time buckets is mathematically invalid and would smooth
away real latency spikes. `downsampleLatencyData` (new file: `src/utils/downsample.ts`)
buckets points and takes `Math.max()` per bucket, preserving spikes rather than
flattening them, and is only applied above a point-count threshold.

Summary statistics (Min/Avg/P95/Max stat cards) are computed from the raw,
un-downsampled data via `computeStats`; only the rendered bar chart itself uses the
downsampled `visualData`, so downsampling never affects the reported numbers — only
what's visually plotted.

### State handling
- Loading: explicit skeleton state (`aria-live="polite" aria-busy="true"`).
- Empty: distinct `EmptyState` (variant="empty"), separate from error.
- Error: distinct `EmptyState` (variant="error") with a retry callback.
- Stale: while a background refetch is in flight and prior data exists, the stats
  grid and chart get a `.latency-chart-stale` visual treatment plus an
  `aria-live` announcement, rather than silently presenting old data as current.
- Cancellation / race safety: a `generationRef` counter guards every state update.
  This repo's `AbortController` convention *resolves* the promise on abort rather
  than rejecting it (see `MarketplacePage.tsx`), so cancellation cannot be detected
  via try/catch — the generation check is the actual source of truth for whether a
  resolved response is still the latest one.
- Account-switch: `LatencyChart` now takes an optional `accountId` prop
  (`{ accountId = "default" }`), fully backward-compatible with its only existing
  call site (`main.tsx`, which renders `<LatencyChart />` with no props). Switching
  `accountId` triggers a new fetch generation; a stale in-flight response for a
  previous account is discarded by the generation guard, never applied to state.

### Tests
`src/pages/LatencyChart.test.tsx` (12 tests) and `src/utils/downsample.test.ts`
(2 tests) — 14 total, all passing:

Coverage includes: the 7 pre-existing UI tests (title/breadcrumb, HelpPopover a11y,
stat cards, chart bar a11y, caption, Escape-to-dismiss) unchanged in intent, plus new
coverage for loading state, stale-on-account-switch, empty state, error+retry, the
generation-counter race guard (validated specifically against this repo's
resolve-not-reject abort behavior via `vi.useFakeTimers()`), and downsampling
correctness (spike preservation, threshold behavior).

### Validation
- `npm run test` (vitest): all 14 tests pass.
- `npm run build`: fails with pre-existing, unrelated TypeScript errors in
  `src/pages/ApiDetailPage.tsx` (confirmed present on `main` prior to this branch,
  unrelated to this change).

### Scope
Changed: `src/pages/LatencyChart.tsx`, `src/pages/LatencyChart.test.tsx`,
`src/utils/downsample.ts` (new), `src/utils/downsample.test.ts` (new). No other
files touched — no auth, CI, dependency, or unrelated component changes.