### PR TITLE
feat: provide complete keyboard navigation for api details (#1001)

### DIFF
--- a/src/components/ApiDetailStickyTOC.tsx
+++ b/src/components/ApiDetailStickyTOC.tsx
@@ -40,12 +40,18 @@ export function ApiDetailStickyTOC({ sections }: ApiDetailStickyTOCProps) {
     const section = document.getElementById(id);
     if (!section) return;
     window.history.replaceState(null, "", `#${id}`);
-    section.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+    if (typeof section.scrollIntoView === "function") {
+      section.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+    }
     setActiveId(id);
+    // Move focus to the target heading so keyboard and screen-reader users
+    // land on the referenced section (deterministic in-page navigation).
+    section.setAttribute("tabindex", "-1");
+    section.focus();
   };
   const links = <ol className="api-detail-toc__list">{sections.map(({ id, label }) => {
     const isActive = activeId === id;
-    return <li key={id} className="api-detail-toc__item"><a href={`#${id}`} aria-current={isActive ? "location" : undefined} className={isActive ? "api-detail-toc__link api-detail-toc__link--active" : "api-detail-toc__link"} onClick={(event) => jumpToSection(event, id)}>{label}</a></li>;
+    return <li key={id} className="api-detail-toc__item"><a href={`#${id}`} aria-current={isActive ? "location" : undefined} className={isActive ? "api-detail-toc__link api-detail-toc__link--active" : "api-detail-toc__link"} style={{ transition: prefersReducedMotion ? "none" : "color 200ms ease" }} onClick={(event) => jumpToSection(event, id)}>{label}</a></li>;
   })}</ol>;
   if (isCompact) return <details className="api-detail-toc api-detail-toc--compact no-print"><summary className="api-detail-toc__heading">On this page</summary>{links}</details>;
   return <nav aria-label="On this page" className="api-detail-toc no-print"><p className="api-detail-toc__heading">On this page</p>{links}</nav>;

--- a/src/components/EndpointGroupHover.test.tsx
+++ b/src/components/EndpointGroupHover.test.tsx
@@ -164,4 +164,17 @@ describe("EndpointGroupHover", () => {
     
     expect(screen.queryByLabelText("Forecast group preview")).toBeNull();
   });
+
+  it("closes the preview on Escape without moving focus off the trigger", () => {
+    render(<EndpointGroupHover groups={groups} />);
+
+    const trigger = screen.getByRole("button", { name: /forecast 2 endpoints/i });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Escape" });
+
+    // Preview is dismissed.
+    expect(screen.queryByLabelText("Forecast group preview")).toBeNull();
+    // Keyboard focus stays on the trigger (not stranded on <body>).
+    expect(document.activeElement).toBe(trigger);
+  });
 });

--- a/src/components/EndpointGroupHover.tsx
+++ b/src/components/EndpointGroupHover.tsx
@@ -96,8 +96,10 @@ export default function EndpointGroupHover({
                   onFocus={() => setActiveGroupId(group.id)}
                   onKeyDown={(event) => {
                     if (event.key === "Escape") {
+                      // Close the preview but keep keyboard focus on the
+                      // trigger so the user is not stranded on the body.
                       clearPreview();
-                      (event.currentTarget as HTMLButtonElement).blur();
+                      event.preventDefault();
                     }
                   }}
                 >

--- a/src/pages/ApiDetailPage.test.tsx
+++ b/src/pages/ApiDetailPage.test.tsx
@@ -694,17 +694,30 @@ describe("ApiDetailPage", () => {
       });
     });
 
-    it("tab buttons (role='tab') are reachable via keyboard", () => {
+    it("tab buttons follow the APG roving tabindex pattern (one tabbable, rest via arrow keys)", () => {
       renderWithProviders(<ApiDetailPage />);
       settleLoadingState();
 
       const tabs = screen.getAllByRole("tab");
       expect(tabs.length).toBeGreaterThanOrEqual(6); // All 6 tab items
 
-      // Verify no tab has tabIndex={-1} (all should be reachable)
+      // Exactly one tab is in the tab order at a time (the active tab); the
+      // others use tabIndex=-1 and are reached with ArrowLeft / ArrowRight.
+      const tabbable = tabs.filter((tab) => (tab as HTMLElement).tabIndex === 0);
+      expect(tabbable.length).toBe(1);
+
       tabs.forEach((tab) => {
-        expect((tab as HTMLElement).tabIndex).not.toBe(-1);
+        const t = tab as HTMLElement;
+        expect(t.tabIndex === 0 || t.tabIndex === -1).toBe(true);
       });
+
+      // ArrowRight from the active tab moves focus to the next tab (keyboard
+      // reachability without Tab).
+      const activeTab = tabbable[0];
+      fireEvent.keyDown(activeTab, { key: "ArrowRight" });
+      const focused = document.activeElement as HTMLElement;
+      expect(focused.getAttribute("role")).toBe("tab");
+      expect(focused).not.toBe(activeTab);
     });
 
     it("select element in reviews tab is keyboard-focusable", () => {
@@ -750,6 +763,10 @@ describe("ApiDetailPage", () => {
 
       interactiveElements.forEach((el) => {
         const htmlEl = el as HTMLElement;
+        // The Tabs component intentionally sets `outline: none` inline and
+        // restores the ring via a `:focus-visible` CSS rule (see focus.css /
+        // issue #541), so it is exempt from this check.
+        if (htmlEl.closest('[role="tablist"]')) return;
         const inlineOutline = htmlEl.style.outline;
         // Inline outline:none would suppress the :focus-visible ring
         expect(inlineOutline).not.toBe("none");
@@ -771,8 +788,10 @@ describe("ApiDetailPage", () => {
       });
       expect(dialog).toBeTruthy();
 
-      // Dialog should be focusable
-      expect((dialog as HTMLElement).tabIndex).not.toBe(-1);
+      // The dialog is a modal: focus must move into it on open (deterministic
+      // focus management) so keyboard users are not stranded on the trigger.
+      const focused = document.activeElement as HTMLElement;
+      expect(dialog.contains(focused)).toBe(true);
 
       // Check inputs inside dialog are focusable
       const inputs = dialog.querySelectorAll("input, button");
@@ -782,6 +801,126 @@ describe("ApiDetailPage", () => {
           expect(htmlInput.tabIndex).not.toBe(-1);
         }
       });
+    });
+  });
+
+  describe("save endpoint dialog focus management", () => {
+    function openSaveDialog() {
+      fireEvent.click(screen.getByRole("tab", { name: "Documentation" }));
+      const saveButtons = screen.getAllByRole("button", {
+        name: /Save endpoint to collection/i,
+      });
+      fireEvent.click(saveButtons[0]);
+      const dialog = screen.getByRole("dialog", {
+        name: /Save endpoint to collection/i,
+      });
+      return { dialog, trigger: saveButtons[0] };
+    }
+
+    function dialogFocusable(dialog: HTMLElement) {
+      return Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          "button:not([disabled]), input:not([disabled]), [href], select:not([disabled]), [tabindex]:not([tabindex='-1'])",
+        ),
+      );
+    }
+
+    it("moves focus into the dialog when it opens", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const { dialog } = openSaveDialog();
+      // Focus should land on the first focusable control inside the dialog.
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    it("is labelled by its visible title", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const { dialog } = openSaveDialog();
+      expect(dialog.getAttribute("aria-labelledby")).toBe("endpoint-save-dialog-title");
+      const title = document.getElementById("endpoint-save-dialog-title");
+      expect(title?.textContent).toBe("Save endpoint to collection");
+    });
+
+    it("traps Tab focus within the dialog", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const { dialog } = openSaveDialog();
+      const focusable = dialogFocusable(dialog);
+      expect(focusable.length).toBeGreaterThan(1);
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      // Shift+Tab from the first control wraps to the last (focus stays inside).
+      first.focus();
+      fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).toBe(last);
+
+      // Tab from the last control wraps back to the first.
+      last.focus();
+      fireEvent.keyDown(dialog, { key: "Tab" });
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).toBe(first);
+    });
+
+    it("restores focus to the trigger button when closed with Escape", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const { dialog, trigger } = openSaveDialog();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      expect(document.activeElement).toBe(trigger);
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("announces when the dialog opens and closes", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      openSaveDialog();
+      const polite = document.querySelector('[data-testid="live-region"]');
+      expect(polite?.textContent).toContain("Save endpoint dialog opened");
+
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      expect(polite?.textContent).toContain("Save endpoint dialog closed");
+    });
+  });
+
+  describe("in-page TOC keyboard navigation", () => {
+    it("moves focus to the target heading when a TOC link is activated", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      fireEvent.click(screen.getByRole("tab", { name: "Documentation" }));
+      const nav = screen.getByRole("navigation", { name: "On this page" });
+      const link = nav.querySelector('a[href="#toc-endpoints"]') as HTMLAnchorElement;
+      expect(link).toBeTruthy();
+
+      fireEvent.click(link);
+
+      const heading = document.getElementById("toc-endpoints");
+      expect(heading).toBeTruthy();
+      // Heading becomes the active element and is programmatically focusable.
+      expect(document.activeElement).toBe(heading);
+      expect(heading?.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  describe("assertive live region (errors / status)", () => {
+    it("renders a dedicated assertive live region for status changes", () => {
+      renderWithProviders(<ApiDetailPage />);
+      settleLoadingState();
+
+      const region = document.querySelector("[aria-live='assertive']");
+      expect(region).toBeTruthy();
+      expect(region?.getAttribute("role")).toBe("alert");
     });
   });
 
@@ -1014,17 +1153,18 @@ describe("ApiDetailPage", () => {
   });
 
   it("interactive elements are focusable (issue #541)", () => {
-    render(<ApiDetailPage />);
+    renderWithProviders(<ApiDetailPage />);
     settleLoadingState();
 
+    // Only the active tab is in the tab order (roving tabindex). Focus it via
+    // the real focus method so document.activeElement reflects it.
     const tabs = screen.getAllByRole("tab");
-    tabs.forEach(tab => {
-      fireEvent.focus(tab);
-      expect(document.activeElement).toBe(tab);
-    });
+    const activeTab = tabs.find((tab) => (tab as HTMLElement).tabIndex === 0) as HTMLElement;
+    activeTab.focus();
+    expect(document.activeElement).toBe(activeTab);
 
     const connectButton = screen.getByRole("button", { name: /Connect API/i });
-    fireEvent.focus(connectButton);
+    connectButton.focus();
     expect(document.activeElement).toBe(connectButton);
   });
 });

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useRef, useCallback } from "react";
 import CodeExample from "../components/CodeExample";
 import Breadcrumb from "../components/Breadcrumb";
 import TestInBrowser from "../components/TestInBrowser";
-import Skeleton, { ApiDetailPageSkeleton } from "../components/Skeleton";
+import { ApiDetailPageSkeleton } from "../components/Skeleton";
 import EmbedPreview from "../components/EmbedPreview";
 import Tabs from "../components/Tabs";
 import useDocumentTitle from "../hooks/useDocumentTitle";
@@ -20,7 +20,6 @@ import { CheckIcon } from "../components/icons";
 import { copyToClipboard, getInsomniaImportUrl, getPostmanImportUrl } from "../utils/postman";
 import SubscribeButton from "../components/SubscribeButton";
 import StatusBadge, { apiStatusToVariant } from "../components/StatusBadge";
-import SubscribeCTA from "./SubscribeCTA";
 import { useToast } from "../components/Toast";
 import { useCollections } from "../state/collectionsStore";
 import RelatedApisRail from "../components/RelatedApisRail";
@@ -29,7 +28,6 @@ import KbdHint from "../components/KbdHint";
 import { SHORTCUTS } from "../hooks/useGlobalShortcuts";
 import PlanBadge from "../components/PlanBadge";
 import LiveRegion from "../components/LiveRegion";
-import StatusBadge, { apiStatusToVariant } from "../components/StatusBadge";
 
 /**
  * ApiDetailPage
@@ -119,7 +117,13 @@ const API_DETAIL_SHORTCUTS = SHORTCUTS.filter(
 
 // ── Endpoint save controls ───────────────────────────────────────────────────
 
-function EndpointSaveButton({ endpointId }: { endpointId: string }) {
+function EndpointSaveButton({
+  endpointId,
+  onAnnounce,
+}: {
+  endpointId: string;
+  onAnnounce?: (message: string) => void;
+}) {
   const {
     collections,
     isEndpointSaved,
@@ -141,10 +145,41 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
   useEffect(() => {
     if (!open) return;
 
+    // Move focus into the dialog (first focusable control, else the dialog
+    // container itself) so keyboard users are not stranded on the trigger.
+    const panel = panelRef.current;
+    const focusable = panel
+      ? Array.from(
+          panel.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          ),
+        )
+      : [];
+    (focusable[0] ?? panel ?? buttonRef.current)?.focus();
+
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.preventDefault();
         setOpen(false);
         buttonRef.current?.focus();
+        onAnnounce?.("Save endpoint dialog closed");
+        return;
+      }
+      if (e.key === "Tab" && panel) {
+        // Focus trap — keep Tab / Shift+Tab cycling within the dialog.
+        if (focusable.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
 
@@ -156,6 +191,7 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
         !buttonRef.current.contains(e.target as Node)
       ) {
         setOpen(false);
+        onAnnounce?.("Save endpoint dialog closed");
       }
     };
 
@@ -165,7 +201,15 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
       document.removeEventListener("keydown", handleKey);
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [open]);
+  }, [open, onAnnounce]);
+
+  const handleToggleOpen = () => {
+    setOpen((prev) => {
+      const next = !prev;
+      if (next) onAnnounce?.("Save endpoint dialog opened");
+      return next;
+    });
+  };
 
   const handleCreateCollection = useCallback(() => {
     const trimmed = newName.trim();
@@ -203,7 +247,7 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
         ref={buttonRef}
         onClick={(e) => {
           e.stopPropagation();
-          setOpen((prev) => !prev);
+          handleToggleOpen();
         }}
         className="icon-button"
         aria-label={isSaved ? "Saved endpoint" : "Save endpoint to collection"}
@@ -220,7 +264,8 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
           role="dialog"
           className="endpoint-save-popover"
           aria-modal="true"
-          aria-label="Save endpoint to collection"
+          aria-labelledby="endpoint-save-dialog-title"
+          tabIndex={-1}
           onClick={(e) => e.stopPropagation()}
           style={{
             position: "absolute",
@@ -235,18 +280,19 @@ function EndpointSaveButton({ endpointId }: { endpointId: string }) {
             padding: "var(--mkt-space-lg)",
           }}
         >
-          <p
-            style={{
-              margin: 0,
-              fontSize: "var(--mkt-font-size-micro)",
-              fontWeight: 700,
-              color: "var(--muted)",
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-            }}
-          >
-            Save to collection
-          </p>
+            <p
+              id="endpoint-save-dialog-title"
+              style={{
+                margin: 0,
+                fontSize: "var(--mkt-font-size-micro)",
+                fontWeight: 700,
+                color: "var(--muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+              }}
+            >
+              Save endpoint to collection
+            </p>
 
           {collections.length === 0 && !showNewInput && (
             <div style={{ marginTop: "var(--mkt-space-lg)", display: "flex", flexDirection: "column", gap: "var(--mkt-space-md)" }}>
@@ -352,6 +398,7 @@ export default function ApiDetailPage({ onBack }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [reviewSort, setReviewSort] = useState<ReviewSort>("newest");
   const [announcement, setAnnouncement] = useState("");
+  const [assertiveAnnouncement, setAssertiveAnnouncement] = useState("");
   const { showToast } = useToast();
 
   const handleTabChange = useCallback((newTab: TabType) => {
@@ -549,9 +596,6 @@ print(response.json())`;
 
   return (
     <div className="api-detail-page">
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {isLoading ? "Loading API details…" : `Loaded ${api.name}`}
-      </div>
       <div className="api-detail-container">
         <Breadcrumb
           items={[
@@ -724,7 +768,10 @@ print(response.json())`;
                                       title="Open in Postman"
                                       onClick={() => {
                                         const url = getPostmanImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
-                                        copyToClipboard(url).then((ok) => showToast(ok ? "Postman import URL copied" : "Failed to copy", ok ? "success" : "error"));
+                                        copyToClipboard(url).then((ok) => {
+                                          showToast(ok ? "Postman import URL copied" : "Failed to copy", ok ? "success" : "error");
+                                          setAssertiveAnnouncement(ok ? "Postman import URL copied to clipboard" : "Failed to copy Postman import URL");
+                                        });
                                       }}
                                     >
                                       <Icons.ExternalLink size={14} />
@@ -737,13 +784,16 @@ print(response.json())`;
                                       title="Open in Insomnia"
                                       onClick={() => {
                                         const url = getInsomniaImportUrl(ep.method, ep.url, ep.title, API_BASE_URL);
-                                        copyToClipboard(url).then((ok) => showToast(ok ? "Insomnia import URL copied" : "Failed to copy", ok ? "success" : "error"));
+                                        copyToClipboard(url).then((ok) => {
+                                          showToast(ok ? "Insomnia import URL copied" : "Failed to copy", ok ? "success" : "error");
+                                          setAssertiveAnnouncement(ok ? "Insomnia import URL copied to clipboard" : "Failed to copy Insomnia import URL");
+                                        });
                                       }}
                                     >
                                       <Icons.ExternalLink size={14} />
                                       <span>Insomnia</span>
                                     </button>
-                                    <EndpointSaveButton endpointId={ep.id} />
+                                    <EndpointSaveButton endpointId={ep.id} onAnnounce={setAnnouncement} />
                                   </div>
                                 </div>
                               </div>
@@ -949,8 +999,6 @@ print(response.json())`;
                           className="reviews-sort-controls no-print"
                           style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16, flexWrap: "wrap" }}
                         >
-                          <label htmlFor="review-sort" style={{ fontSize: 13, color: "var(--muted)", whiteSpace: "nowrap" }}>
-                        <div style={{ display: "flex", alignItems: "center", gap: "var(--mkt-space-lg)", marginBottom: "var(--mkt-space-xl)", flexWrap: "wrap" }}>
                           <label htmlFor="review-sort" style={{ fontSize: "var(--mkt-font-size-sm)", color: "var(--muted)", whiteSpace: "nowrap" }}>
                             Sort by
                           </label>
@@ -1035,6 +1083,7 @@ print(response.json())`;
                             </div>
                           ))}
                         </div>
+                      </div>
                       </>
                     )}
                   </section>
@@ -1131,7 +1180,8 @@ print(response.json())`;
         {/* /api-detail-shell */}
       </div>
       {/* /api-detail-container */}
-      <LiveRegion>{announcement}</LiveRegion>
+      <LiveRegion message={announcement} />
+      <LiveRegion assertive message={assertiveAnnouncement} regionId="api-detail-assertive" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements complete, accessible keyboard navigation, focus management, and
semantic announcements for the API details flow (issue #1001), covering the
Overview / Documentation / Pricing / Examples / Reviews / Embed tabs, the
endpoint save dialog, the sticky in-page TOC, and the endpoint group previews.

### Before / After

| Area | Before | After |
| --- | --- | --- |
| Save endpoint dialog | `role="dialog"` opened with **no focus moved in** and **no focus trap**; focus could escape to the page | Focus is **moved into** the dialog on open, **trapped** (Tab/Shift+Tab cycle inside), and **restored** to the trigger on Escape/close |
| Live announcements | `LiveRegion` was rendered but **never announced** anything (the page passed the message as `children` while the component only renders its `message` prop) | Message is passed via `message` prop; load, tab switch, sort, cost-calculator, and dialog open/close announcements now reach assistive tech |
| Status / error announcements | Only toasts (polite) | Added a dedicated **assertive** `aria-live` region for copy success/failure and other status changes |
| In-page TOC navigation | Clicking a TOC link scrolled but left focus elsewhere | Activating a TOC link now **moves focus to the target heading** (`tabindex=-1` + focus) so keyboard/SR users land on the section |
| Endpoint group preview | Escape **blurred** the trigger, stranding focus on `<body>` | Escape closes the preview and **keeps focus on the trigger** |
| prefers-reduced-motion | TOC link transitions/scroll not consistently handled | TOC collapses link `transition` to `none` and uses instant scroll; dialog has no motion dependency |

### Acceptance criteria → implementation

- **Fully keyboard-operable with deterministic focus movement** — `EndpointSaveButton` focus trap + focus-into/on-open + focus restoration (`src/pages/ApiDetailPage.tsx`), TOC focus-to-heading (`src/components/ApiDetailStickyTOC.tsx`), EndpointGroupHover Escape focus retention (`src/components/EndpointGroupHover.tsx`).
- **Semantic announcements for loading / status / errors / success** — `LiveRegion` `message` prop fix + new assertive region; load/tab/sort/cost/dialog announcements (`src/pages/ApiDetailPage.tsx`).
- **prefers-reduced-motion, color, zoom, contrast preserved** — TOC transition/scroll handling; existing reduced-motion paths in `ApiDetailPage` and `Tabs` retained; no new animations or color/zoom/contrast regressions.

### Failure-mode handling

- Dialog open with no focusable child falls back to focusing the dialog container, then the trigger.
- Click-outside and Escape both close the dialog and restore focus to the trigger.
- `scrollIntoView` is guarded for environments without it (e.g. jsdom/SSR); focus is still moved to the heading.
- The assertive region only announces when there is content; empty state is `aria-hidden`.

### Tests added / updated

- `src/pages/ApiDetailPage.test.tsx`: focus moves into dialog on open, dialog labelled by visible title, Tab focus trap, focus restoration on Escape, open/close announcements, TOC focus movement to heading, assertive live region presence; aligned pre-existing roving-tabindex / outline / focus tests with correct APG behaviour.
- `src/components/EndpointGroupHover.test.tsx`: Escape closes preview without moving focus off the trigger.
- `src/components/ApiDetailStickyTOC.test.tsx`: reduced-motion inline transition assertions now satisfied.

### Verification evidence

- `npx vitest run` for the touched suites (ApiDetailPage, ApiDetailStickyTOC, EndpointGroupHover, EndpointPreview, Tabs): **141 passing**.
- `tsc` reports **no errors** in the three changed source files (`ApiDetailPage.tsx`, `ApiDetailStickyTOC.tsx`, `EndpointGroupHover.tsx`).
- Pre-existing, out-of-scope failures on `main` (e.g. a syntax error in `MarketplacePage.tsx`, and unrelated test failures in `ApiUsage`/`ApiCard`/`EmptyState`/`FiltersSidebar`/`OnboardingTour`/`SubscribeCTA`/`print.test`) are untouched and not introduced by this change.

Closes #1001