### PR TITLE
feat(frontend): make quota updates race-safe across tabs

### DIFF
--- a/src/api/quotaApi.test.ts
+++ b/src/api/quotaApi.test.ts
@@ -1,0 +1,48 @@
+import { createQuotaApi, QuotaConflictError } from "../api/quotaApi";
+
+describe("createQuotaApi", () => {
+  it("returns a default record for an unknown account", async () => {
+    const api = createQuotaApi();
+    const rec = await api.fetchQuota("unknown");
+    expect(rec.value).toBe(0);
+    expect(rec.version).toBe(1);
+    expect(typeof rec.updatedAt).toBe("number");
+  });
+
+  it("seeds initial values", async () => {
+    const api = createQuotaApi({ initial: { a: 10 } });
+    const rec = await api.fetchQuota("a");
+    expect(rec.value).toBe(10);
+    expect(rec.version).toBe(1);
+  });
+
+  it("bumps the version on a successful update and persists it", async () => {
+    const api = createQuotaApi({ initial: { a: 10 } });
+    const before = await api.fetchQuota("a");
+    const after = await api.updateQuota("a", 20, before.version);
+    expect(after.value).toBe(20);
+    expect(after.version).toBe(2);
+
+    const refetched = await api.fetchQuota("a");
+    expect(refetched.value).toBe(20);
+    expect(refetched.version).toBe(2);
+  });
+
+  it("rejects an update based on a stale version with QuotaConflictError", async () => {
+    const api = createQuotaApi({ initial: { a: 10 } });
+    const v1 = await api.fetchQuota("a");
+    await api.updateQuota("a", 20, v1.version); // -> v2
+
+    await expect(api.updateQuota("a", 30, v1.version)).rejects.toBeInstanceOf(
+      QuotaConflictError,
+    );
+  });
+
+  it("rejects an aborted fetch with an AbortError", async () => {
+    const api = createQuotaApi({ latencyMs: 50 });
+    const controller = new AbortController();
+    const promise = api.fetchQuota("a", controller.signal);
+    controller.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/src/api/quotaApi.ts
+++ b/src/api/quotaApi.ts
@@ -1,0 +1,136 @@
+/**
+ * quotaApi.ts
+ *
+ * Simulated, backend-shaped quota API used by the race-safe quota store.
+ *
+ * The API models a real server with a per-account authoritative record that
+ * carries a monotonically increasing `version`. Optimistic clients must submit
+ * their update together with the `version` they based it on (the
+ * "base version"); if that base is stale (another update already landed), the
+ * server rejects with {@link QuotaConflictError}. This is exactly the failure
+ * mode the store must handle across concurrent requests and tabs.
+ *
+ * Every call accepts an optional `AbortSignal` so in-flight requests can be
+ * cancelled when a newer request supersedes them or the user switches account.
+ */
+
+export interface QuotaRecord {
+  accountId: string;
+  /** Authoritative quota value (e.g. requests-per-window). */
+  value: number;
+  /** Server version; bumped on every successful mutation. */
+  version: number;
+  /** Server timestamp of the last authoritative change. */
+  updatedAt: number;
+}
+
+/** Raised when an update is based on a stale server version. */
+export class QuotaConflictError extends Error {
+  public readonly serverVersion: number;
+
+  constructor(serverVersion: number, accountId: string) {
+    super(
+      `Quota update rejected: a newer version (v${serverVersion}) already exists for "${accountId}".`,
+    );
+    this.name = "QuotaConflictError";
+    this.serverVersion = serverVersion;
+  }
+}
+
+export interface QuotaApi {
+  fetchQuota(accountId: string, signal?: AbortSignal): Promise<QuotaRecord>;
+  updateQuota(
+    accountId: string,
+    value: number,
+    baseVersion: number,
+    signal?: AbortSignal,
+  ): Promise<QuotaRecord>;
+}
+
+export interface CreateQuotaApiOptions {
+  /** Base artificial latency (ms) applied to every request. */
+  latencyMs?: number;
+  /** Seed values keyed by accountId. Missing accounts default to value 0. */
+  initial?: Record<string, number>;
+}
+
+function abortError(): Error {
+  const err = new Error("The operation was aborted.");
+  err.name = "AbortError";
+  return err;
+}
+
+function delay(latencyMs: number, signal?: AbortSignal): Promise<void> {
+  if (latencyMs <= 0) {
+    return signal?.aborted ? Promise.reject(abortError()) : Promise.resolve();
+  }
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+    const timer = setTimeout(resolve, latencyMs);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(abortError());
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Creates an in-memory quota API. Two store instances that share the same
+ * `QuotaApi` therefore share the same "server", which is how cross-tab
+ * consistency is exercised in tests.
+ */
+export function createQuotaApi(
+  options: CreateQuotaApiOptions = {},
+): QuotaApi {
+  const latency = options.latencyMs ?? 0;
+  const server = new Map<string, QuotaRecord>();
+
+  for (const [accountId, value] of Object.entries(options.initial ?? {})) {
+    server.set(accountId, {
+      accountId,
+      value,
+      version: 1,
+      updatedAt: Date.now(),
+    });
+  }
+
+  function readOrInit(accountId: string): QuotaRecord {
+    let rec = server.get(accountId);
+    if (!rec) {
+      rec = { accountId, value: 0, version: 1, updatedAt: Date.now() };
+      server.set(accountId, rec);
+    }
+    return rec;
+  }
+
+  return {
+    async fetchQuota(accountId, signal) {
+      await delay(latency, signal);
+      const rec = readOrInit(accountId);
+      return { ...rec };
+    },
+
+    async updateQuota(accountId, value, baseVersion, signal) {
+      await delay(latency, signal);
+      const current = readOrInit(accountId);
+      if (baseVersion !== current.version) {
+        throw new QuotaConflictError(current.version, accountId);
+      }
+      const next: QuotaRecord = {
+        accountId,
+        value,
+        version: current.version + 1,
+        updatedAt: Date.now(),
+      };
+      server.set(accountId, next);
+      return { ...next };
+    },
+  };
+}

--- a/src/components/QuotaManager.css
+++ b/src/components/QuotaManager.css
@@ -1,0 +1,110 @@
+.quota-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 12px;
+  background: var(--surface, #fff);
+  max-width: 420px;
+}
+
+.quota-manager__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.quota-manager__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.quota-manager__account-switch select {
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, #e5e7eb);
+}
+
+.quota-manager__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.quota-manager__field input {
+  padding: 0.5rem 0.625rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, #e5e7eb);
+  font-size: 0.95rem;
+}
+
+.quota-manager__field input:disabled {
+  opacity: 0.6;
+}
+
+.quota-manager__status-row {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+}
+
+.quota-manager__status--loading {
+  color: var(--text-muted, #6b7280);
+}
+
+.quota-manager__status--saving {
+  color: var(--accent, #2563eb);
+}
+
+.quota-manager__status--ready {
+  color: var(--success, #16a34a);
+}
+
+.quota-manager__status--stale {
+  color: var(--warning, #b45309);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.quota-manager__status--error,
+.quota-manager__error {
+  color: var(--danger, #dc2626);
+}
+
+.quota-manager__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.quota-manager__save,
+.quota-manager__retry,
+.quota-manager__link {
+  cursor: pointer;
+  border-radius: 8px;
+  border: 1px solid var(--border, #e5e7eb);
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  background: var(--surface, #fff);
+}
+
+.quota-manager__save {
+  background: var(--accent, #2563eb);
+  color: #fff;
+  border-color: transparent;
+}
+
+.quota-manager__save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.quota-manager__visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}

--- a/src/components/QuotaManager.test.tsx
+++ b/src/components/QuotaManager.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import QuotaManager from "./QuotaManager";
+import { QuotaStore } from "../state/quotaStore";
+import { makeFakeApi } from "../state/quotaTestUtils";
+
+function record(accountId: string, value: number, version: number) {
+  return { accountId, value, version, updatedAt: version };
+}
+
+function setup(props: { accountId?: string; accounts?: string[] } = {}) {
+  const fake = makeFakeApi();
+  const store = new QuotaStore({ api: fake.api, tabId: "test" });
+  render(<QuotaManager store={store} {...props} />);
+  return { fake, store };
+}
+
+describe("QuotaManager", () => {
+  it("shows a loading state then the authoritative value", async () => {
+    const { fake } = setup({ accountId: "a" });
+    expect(screen.getByText(/Loading quota/i)).toBeTruthy();
+
+    await act(async () => {
+      fake.resolveFetch(0, record("a", 100, 1));
+    });
+
+    expect(screen.queryByText(/Loading quota/i)).toBeNull();
+    expect(screen.getByDisplayValue("100")).toBeTruthy();
+  });
+
+  it("renders an error state with a retry control", async () => {
+    const { fake } = setup({ accountId: "a" });
+    await act(async () => {
+      fake.rejectFetch(0, new Error("boom"));
+    });
+
+    expect(screen.getByText(/Could not load quota/i)).toBeTruthy();
+    const retry = screen.getByRole("button", { name: /Retry/i });
+    expect(retry).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(retry);
+      fake.resolveFetch(1, record("a", 100, 1));
+    });
+
+    expect(screen.getByDisplayValue("100")).toBeTruthy();
+  });
+
+  it("never reports an unconfirmed mutation as successful", async () => {
+    const { fake } = setup({ accountId: "a" });
+    await act(async () => {
+      fake.resolveFetch(0, record("a", 100, 1));
+    });
+
+    const input = screen.getByDisplayValue("100") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "150" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Save quota/i }));
+    });
+
+    // While in-flight, the status must read "Saving…", never "Synced".
+    expect(screen.getAllByText(/Saving/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Synced/i)).toBeNull();
+    expect(input.value).toBe("150"); // optimistic draft still shown
+
+    await act(async () => {
+      fake.resolveUpdate(0, record("a", 150, 2));
+    });
+
+    expect(screen.getByText(/Synced/i)).toBeTruthy();
+  });
+
+  it("surfaces a failure and supports retry", async () => {
+    const { fake } = setup({ accountId: "a" });
+    await act(async () => {
+      fake.resolveFetch(0, record("a", 100, 1));
+    });
+
+    const input = screen.getByDisplayValue("100") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "150" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Save quota/i }));
+      fake.rejectUpdate(0, new Error("Network down"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/Network down/i)).toBeTruthy();
+    const retry = screen.getByRole("button", { name: /Retry/i });
+    expect(retry).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(retry);
+      fake.resolveUpdate(1, record("a", 150, 2)); // re-submit
+    });
+
+    expect(screen.getByText(/Synced/i)).toBeTruthy();
+  });
+
+  it("shows a stale banner after a cross-tab conflict reconciliation", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    const store = new QuotaStore({ api: fake.api, tabId: "test" });
+    render(<QuotaManager store={store} accountId="a" />);
+
+    await act(async () => {
+      fake.resolveFetch(0, record("a", 100, 1));
+    });
+
+    const input = screen.getByDisplayValue("100") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "150" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Save quota/i }));
+      fake.rejectLastUpdateConflict(2, "a");
+    });
+    // Let the conflict catch run and open the reconcile fetch.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fake.resolveFetch(1, record("a", 100, 2)); // reconcile to server
+    });
+
+    expect(screen.getByText(/Updated in another tab/i)).toBeTruthy();
+  });
+
+  it("switches accounts without mixing their values", async () => {
+    const { fake, store } = setup({
+      accountId: "a",
+      accounts: ["a", "b"],
+    });
+
+    await act(async () => {
+      fake.resolveFetch(0, record("a", 100, 1));
+    });
+    expect(screen.getByDisplayValue("100")).toBeTruthy();
+
+    const select = screen.getByLabelText(/Account/i) as HTMLSelectElement;
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "b" } });
+      fake.resolveFetch(1, record("b", 50, 1));
+    });
+
+    expect(store.getSnapshot().currentAccountId).toBe("b");
+    expect(screen.getByDisplayValue("50")).toBeTruthy();
+  });
+});

--- a/src/components/QuotaManager.tsx
+++ b/src/components/QuotaManager.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from "react";
+import { QuotaStore, quotaStore } from "../state/quotaStore";
+import { useQuotaStore } from "../hooks/useQuotaStore";
+import "./QuotaManager.css";
+
+export interface QuotaManagerProps {
+  /** Store instance to bind to. Defaults to the shared singleton. */
+  store?: QuotaStore;
+  /** When provided, the manager tracks this account and switches on change. */
+  accountId?: string;
+  /** Accounts offered in the account switcher (issue #995: account-switch). */
+  accounts?: string[];
+  className?: string;
+}
+
+function parseQuota(raw: string): number {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * QuotaManager — renders quota state from the race-safe {@link QuotaStore}.
+ *
+ * Guarantees (issue #995):
+ *  - Never reports an unconfirmed mutation as successful: while a submit is
+ *    in-flight the status reads "Saving…", not "Saved".
+ *  - Explicitly renders loading, stale (updated elsewhere), error, and retry
+ *    states, plus an account switcher for the account-switch lifecycle.
+ *  - The displayed value always reflects authoritative server state; the input
+ *    is only an optimistic draft.
+ */
+export default function QuotaManager({
+  store = quotaStore,
+  accountId,
+  accounts,
+  className,
+}: QuotaManagerProps) {
+  const state = useQuotaStore(store);
+  const activeId = state.currentAccountId || accountId || "";
+  const slice = activeId
+    ? state.slices[activeId] ?? store.getSlice(activeId)
+    : store.getSlice(activeId);
+
+  const [draft, setDraft] = useState<string>(
+    slice.value !== null ? String(slice.value) : "",
+  );
+
+  // Track the active account.
+  useEffect(() => {
+    if (accountId) {
+      void store.selectAccount(accountId);
+    }
+  }, [accountId, store]);
+
+  // Keep the editable draft in sync with authoritative state, but don't fight
+  // the user while they are actively typing a new value.
+  const authoritative = slice.value !== null ? String(slice.value) : "";
+  useEffect(() => {
+    if (slice.pendingStatus !== "submitting") {
+      setDraft(authoritative);
+    }
+  }, [authoritative, slice.pendingStatus]);
+
+  const switchAccount = (next: string) => {
+    void store.selectAccount(next);
+  };
+
+  const handleSave = () => {
+    const value = parseQuota(draft);
+    void store.update(value);
+  };
+
+  const isLoading = slice.loadStatus === "loading" && slice.value === null;
+  const isError = slice.loadStatus === "error";
+  const isStale = slice.loadStatus === "stale";
+  const isSaving = slice.pendingStatus === "submitting";
+  const pendingError = slice.pendingStatus === "error" ? slice.pendingError : null;
+
+  return (
+    <section
+      className={`quota-manager${className ? ` ${className}` : ""}`}
+      aria-labelledby="quota-manager-title"
+    >
+      <header className="quota-manager__header">
+        <h2 id="quota-manager-title" className="quota-manager__title">
+          Quota
+        </h2>
+        {accounts && accounts.length > 0 && (
+          <label className="quota-manager__account-switch">
+            <span className="quota-manager__visually-hidden">Account</span>
+            <select
+              value={activeId}
+              onChange={(e) => switchAccount(e.target.value)}
+              aria-label="Select account"
+            >
+              {accounts.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </header>
+
+      {isLoading && (
+        <p className="quota-manager__status quota-manager__status--loading" role="status">
+          Loading quota…
+        </p>
+      )}
+
+      {isError && (
+        <div className="quota-manager__error" role="alert">
+          <p>Could not load quota{slice.loadError ? `: ${slice.loadError}` : "."}</p>
+          <button
+            type="button"
+            className="quota-manager__retry"
+            onClick={() => void store.refresh()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !isError && (
+        <>
+          {isStale && (
+            <p
+              className="quota-manager__status quota-manager__status--stale"
+              role="status"
+            >
+              Updated in another tab — review the latest value.
+              <button
+                type="button"
+                className="quota-manager__link"
+                onClick={() => void store.refresh()}
+              >
+                Refresh
+              </button>
+            </p>
+          )}
+
+          <div className="quota-manager__field">
+            <label htmlFor="quota-manager-input">Requests per window</label>
+            <input
+              id="quota-manager-input"
+              type="text"
+              inputMode="numeric"
+              value={draft}
+              disabled={isSaving}
+              onChange={(e) => setDraft(e.target.value)}
+              aria-describedby="quota-manager-status"
+            />
+          </div>
+
+          <div
+            id="quota-manager-status"
+            className="quota-manager__status-row"
+            aria-live="polite"
+          >
+            {isSaving && (
+              <span className="quota-manager__status quota-manager__status--saving">
+                Saving…
+              </span>
+            )}
+            {!isSaving && slice.loadStatus === "ready" && !pendingError && (
+              <span className="quota-manager__status quota-manager__status--ready">
+                Synced{slice.lastSyncedAt ? " just now" : ""}.
+              </span>
+            )}
+            {pendingError && (
+              <span
+                className="quota-manager__status quota-manager__status--error"
+                role="alert"
+              >
+                {pendingError}
+              </span>
+            )}
+          </div>
+
+          <div className="quota-manager__actions">
+            <button
+              type="button"
+              className="quota-manager__save"
+              onClick={handleSave}
+              disabled={isSaving || isStale}
+            >
+              {isSaving ? "Saving…" : "Save quota"}
+            </button>
+            {pendingError && (
+              <button
+                type="button"
+                className="quota-manager__retry"
+                onClick={() => void store.retry()}
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/hooks/useQuotaStore.ts
+++ b/src/hooks/useQuotaStore.ts
@@ -1,0 +1,14 @@
+import { useSyncExternalStore } from "react";
+import { QuotaState, QuotaStore, quotaStore } from "../state/quotaStore";
+
+/**
+ * Subscribe to the quota store. Pass a specific store instance (e.g. in tests)
+ * or omit to use the shared singleton.
+ */
+export function useQuotaStore(store: QuotaStore = quotaStore): QuotaState {
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+}

--- a/src/state/quotaStore.test.ts
+++ b/src/state/quotaStore.test.ts
@@ -1,0 +1,208 @@
+import { QuotaStore } from "./quotaStore";
+import { makeFakeApi, linkedChannels, tick } from "./quotaTestUtils";
+
+function record(accountId: string, value: number, version: number) {
+  return { accountId, value, version, updatedAt: version };
+}
+
+describe("QuotaStore — race safety", () => {
+  it("never lets a stale/out-of-order response overwrite a newer state", async () => {
+    const fake = makeFakeApi();
+    const store = new QuotaStore({ api: fake.api, tabId: "t1" });
+
+    const loadPromise = store.selectAccount("a"); // fetchCalls[0] (gen 1)
+    const refreshPromise = store.refresh(); // fetchCalls[1] (gen 2)
+
+    // Resolve the NEWER generation first.
+    fake.resolveFetch(1, record("a", 200, 2));
+    await refreshPromise;
+
+    expect(store.getSlice("a").value).toBe(200);
+    expect(store.getSlice("a").version).toBe(2);
+
+    // Now the OLDER response arrives late — it must be dropped.
+    fake.resolveFetch(0, record("a", 100, 1));
+    await tick();
+
+    expect(store.getSlice("a").value).toBe(200);
+    expect(store.getSlice("a").version).toBe(2);
+    await loadPromise;
+  });
+
+  it("abandons in-flight requests when switching accounts", async () => {
+    const fake = makeFakeApi();
+    const store = new QuotaStore({ api: fake.api, tabId: "t1" });
+
+    const aPromise = store.selectAccount("a"); // fetchCalls[0] for 'a'
+    // Switch before 'a' resolves; this should abort 'a's in-flight fetch.
+    const bPromise = store.selectAccount("b"); // fetchCalls[1] for 'b'
+    fake.resolveFetch(1, record("b", 50, 1));
+    await bPromise;
+    fake.resolveFetch(0, record("a", 100, 1)); // already aborted; harmless
+    await aPromise;
+
+    expect(store.getSnapshot().currentAccountId).toBe("b");
+    expect(store.getSlice("b").value).toBe(50);
+    // 'a' was never loaded because its request was abandoned.
+    expect(store.getSlice("a").value).toBeNull();
+  });
+
+  it("keeps other accounts cached and isolated after a switch", async () => {
+    const fake = makeFakeApi();
+    const store = new QuotaStore({ api: fake.api, tabId: "t1" });
+
+    const aPromise = store.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await aPromise;
+
+    const bPromise = store.selectAccount("b");
+    fake.resolveFetch(1, record("b", 50, 1));
+    await bPromise;
+
+    expect(store.getSnapshot().currentAccountId).toBe("b");
+    expect(store.getSlice("a").value).toBe(100); // untouched cache
+    expect(store.getSlice("b").value).toBe(50);
+  });
+});
+
+describe("QuotaStore — unconfirmed mutations are never reported as success", () => {
+  it("shows submitting state and leaves authoritative value unchanged until confirmation", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    const store = new QuotaStore({ api: fake.api, tabId: "t1" });
+
+    const loadP = store.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await loadP;
+
+    const updateP = store.update(150); // updateCalls[0]
+    // Synchronously after dispatch, the value is still authoritative.
+    expect(store.getSlice("a").pendingStatus).toBe("submitting");
+    expect(store.getSlice("a").value).toBe(100); // NOT 150
+    expect(store.getSlice("a").pendingValue).toBe(150);
+
+    fake.resolveUpdate(0, record("a", 150, 2));
+    await updateP;
+
+    expect(store.getSlice("a").pendingStatus).toBe("idle");
+    expect(store.getSlice("a").value).toBe(150);
+    expect(store.getSlice("a").pendingValue).toBeNull();
+  });
+
+  it("surfaces an error and allows retry on a network failure", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    const store = new QuotaStore({ api: fake.api, tabId: "t1" });
+
+    const loadP = store.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await loadP;
+
+    const updateP = store.update(150); // updateCalls[0]
+    fake.rejectUpdate(0, new Error("Network down"));
+    await updateP;
+
+    expect(store.getSlice("a").pendingStatus).toBe("error");
+    expect(store.getSlice("a").pendingError).toMatch(/Network down/i);
+    expect(store.getSlice("a").value).toBe(100); // reverted, not applied
+
+    // Retry -> re-submit (version is known, so no extra fetch needed).
+    const retryP = store.retry(); // updateCalls[1]
+    fake.resolveUpdate(1, record("a", 150, 2));
+    await retryP;
+
+    expect(store.getSlice("a").pendingStatus).toBe("idle");
+    expect(store.getSlice("a").value).toBe(150);
+    expect(store.getSlice("a").retryCount).toBeGreaterThan(0);
+  });
+});
+
+describe("QuotaStore — conflict handling", () => {
+  it("detects a version conflict and reconciles to server state", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    // Two stores share the SAME server (api) but do NOT cross-tab sync here.
+    const tab1 = new QuotaStore({ api: fake.api, tabId: "tab1" });
+    const tab2 = new QuotaStore({ api: fake.api, tabId: "tab2" });
+
+    const l1 = tab1.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await l1;
+
+    const l2 = tab2.selectAccount("a");
+    fake.resolveFetch(1, record("a", 100, 1));
+    await l2;
+
+    // tab1 commits 200 -> server becomes v2.
+    const u1 = tab1.update(200); // updateCalls[0]
+    fake.resolveUpdate(0, record("a", 200, 2));
+    await u1;
+
+    // tab2 submits 300 based on its stale v1 -> conflict.
+    const u2 = tab2.update(300); // updateCalls[1], base 1
+    fake.rejectLastUpdateConflict(2, "a");
+    await tick(); // let the catch run and start the reconcile fetch
+    fake.resolveFetch(2, record("a", 200, 2)); // fetchCalls[2]
+    await u2;
+
+    expect(tab2.getSlice("a").pendingStatus).toBe("error");
+    expect(tab2.getSlice("a").pendingError).toMatch(/Conflict/i);
+    expect(tab2.getSlice("a").value).toBe(200);
+    expect(tab2.getSlice("a").loadStatus).toBe("stale");
+  });
+});
+
+describe("QuotaStore — cross-tab synchronization", () => {
+  it("instantly applies a mutation made in another tab", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    const [ch1, ch2] = linkedChannels();
+    const tab1 = new QuotaStore({ api: fake.api, channel: ch1, tabId: "tab1" });
+    const tab2 = new QuotaStore({ api: fake.api, channel: ch2, tabId: "tab2" });
+
+    const l1 = tab1.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await l1;
+
+    const l2 = tab2.selectAccount("a");
+    fake.resolveFetch(1, record("a", 100, 1));
+    await l2;
+
+    // tab1 updates -> broadcasts -> tab2 reflects it WITHOUT its own fetch.
+    const u1 = tab1.update(200); // updateCalls[0]
+    fake.resolveUpdate(0, record("a", 200, 2));
+    await u1;
+    await tick();
+
+    expect(tab2.getSlice("a").value).toBe(200);
+    expect(tab2.getSlice("a").version).toBe(2);
+  });
+
+  it("supersedes a local pending mutation when another tab updates first", async () => {
+    const fake = makeFakeApi({ a: 100 });
+    const [ch1, ch2] = linkedChannels();
+    const tab1 = new QuotaStore({ api: fake.api, channel: ch1, tabId: "tab1" });
+    const tab2 = new QuotaStore({ api: fake.api, channel: ch2, tabId: "tab2" });
+
+    const l1 = tab1.selectAccount("a");
+    fake.resolveFetch(0, record("a", 100, 1));
+    await l1;
+
+    const l2 = tab2.selectAccount("a");
+    fake.resolveFetch(1, record("a", 100, 1));
+    await l2;
+
+    // tab2 starts a submit (kept in-flight) ...
+    const pending = tab2.update(999); // updateCalls[0], base 1, not resolved
+
+    // ... meanwhile tab1 commits 200 and broadcasts to tab2.
+    const u1 = tab1.update(200); // updateCalls[1]
+    fake.resolveUpdate(1, record("a", 200, 2));
+    await u1;
+    await tick();
+
+    expect(tab2.getSlice("a").pendingStatus).toBe("error");
+    expect(tab2.getSlice("a").value).toBe(200); // authoritative from tab1
+    expect(tab2.getSlice("a").loadStatus).toBe("stale");
+
+    // Resolve the now-superseded request so it can settle (no effect).
+    fake.resolveUpdate(0, record("a", 999, 3));
+    await pending;
+  });
+});

--- a/src/state/quotaStore.ts
+++ b/src/state/quotaStore.ts
@@ -1,0 +1,478 @@
+/**
+ * quotaStore.ts
+ *
+ * Race-safe, cross-tab quota state store.
+ *
+ * Design goals (issue #995):
+ *  1. Cross-tab synchronization — quota mutations in one tab instantly and
+ *     safely update (or invalidate) state in other open tabs via a
+ *     `BroadcastChannel` (with a `storage`-event fallback).
+ *  2. Race-condition safety — every fetch/update is tagged with a per-account
+ *     monotonic "generation" counter. Responses that arrive for a superseded
+ *     generation are dropped, so stale/out-of-order responses can never
+ *     overwrite a newer authoritative state. Long-running requests are also
+ *     aborted via `AbortController` when superseded or when the account changes.
+ *  3. Authoritative UI — the store separates the *authoritative* server value
+ *     from any *unconfirmed* optimistic value. The UI never reports an
+ *     unconfirmed mutation as successful: it shows "Saving…" until the server
+ *     confirms, and reverts on error.
+ *  4. Explicit lifecycle states — loading, stale, error, retry, and
+ *     account-switch are all first-class and observable.
+ *
+ * The store is framework-agnostic and exposes `subscribe`/`getSnapshot` so it
+ * can be consumed via React's `useSyncExternalStore`.
+ */
+
+import {
+  createQuotaApi,
+  QuotaApi,
+  QuotaConflictError,
+  QuotaRecord,
+} from "../api/quotaApi";
+
+export type LoadStatus = "loading" | "ready" | "stale" | "error";
+export type PendingStatus = "idle" | "submitting" | "error";
+
+export interface QuotaSlice {
+  accountId: string;
+  /** Authoritative server value (null until first successful load). */
+  value: number | null;
+  /** Authoritative server version (null until first successful load). */
+  version: number | null;
+  /** Server timestamp of the last authoritative change. */
+  updatedAt: number | null;
+  loadStatus: LoadStatus;
+  loadError: string | null;
+  /** Optimistic value being submitted but NOT yet confirmed by the server. */
+  pendingValue: number | null;
+  /** Last value the user attempted to submit (used by retry()). */
+  lastAttemptValue: number | null;
+  pendingStatus: PendingStatus;
+  pendingError: string | null;
+  lastSyncedAt: number | null;
+  /** Number of failed submit attempts for the current pending value. */
+  retryCount: number;
+}
+
+export interface QuotaState {
+  currentAccountId: string;
+  slices: Record<string, QuotaSlice>;
+}
+
+/** Message broadcast between tabs to keep quota state in sync. */
+export interface QuotaSyncMessage {
+  type: "quota:sync";
+  tabId: string;
+  accountId: string;
+  value: number;
+  version: number;
+  updatedAt: number;
+}
+
+/** Minimal channel abstraction so tests can inject a deterministic bus. */
+export interface QuotaChannel {
+  postMessage(msg: QuotaSyncMessage): void;
+  close(): void;
+  /** Registers the handler invoked when a message arrives from another tab. */
+  setHandler(cb: (msg: QuotaSyncMessage) => void): void;
+}
+
+export interface QuotaStoreOptions {
+  api?: QuotaApi;
+  channel?: QuotaChannel;
+  tabId?: string;
+  now?: () => number;
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    ((err as { name?: string }).name === "AbortError" ||
+      (err as { message?: string }).message === "The operation was aborted.")
+  );
+}
+
+function defaultSlice(accountId: string): QuotaSlice {
+  return {
+    accountId,
+    value: null,
+    version: null,
+    updatedAt: null,
+    loadStatus: "loading",
+    loadError: null,
+    pendingValue: null,
+    lastAttemptValue: null,
+    pendingStatus: "idle",
+    pendingError: null,
+    lastSyncedAt: null,
+    retryCount: 0,
+  };
+}
+
+/**
+ * Wraps a real `BroadcastChannel` (or a `storage`-event fallback) as a
+ * {@link QuotaChannel}. Falls back gracefully when `BroadcastChannel` is
+ * unavailable (e.g. older browsers, SSR).
+ */
+export function createQuotaChannel(name = "callora-quota"): QuotaChannel {
+  if (typeof BroadcastChannel !== "undefined") {
+    const bc = new BroadcastChannel(name);
+    return {
+      postMessage: (msg) => bc.postMessage(msg),
+      close: () => bc.close(),
+      setHandler: (cb) => {
+        bc.onmessage = (event: MessageEvent<QuotaSyncMessage>) =>
+          cb(event.data);
+      },
+    };
+  }
+
+  // Best-effort fallback using the `storage` event (fires only in *other*
+  // tabs, which is exactly what we need for cross-tab sync).
+  const handlerRef: { cb: ((msg: QuotaSyncMessage) => void) | null } = {
+    cb: null,
+  };
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", (event) => {
+      if (event.key === name && event.newValue) {
+        try {
+          handlerRef.cb?.(JSON.parse(event.newValue) as QuotaSyncMessage);
+        } catch {
+          /* ignore malformed payloads */
+        }
+      }
+    });
+  }
+  return {
+    postMessage: (msg) => {
+      try {
+        localStorage.setItem(name, JSON.stringify(msg));
+        localStorage.removeItem(name);
+      } catch {
+        /* storage unavailable – skip cross-tab sync */
+      }
+    },
+    close: () => {},
+    setHandler: (cb) => {
+      handlerRef.cb = cb;
+    },
+  };
+}
+
+export class QuotaStore {
+  private state: QuotaState;
+  private readonly listeners = new Set<() => void>();
+  private readonly api: QuotaApi;
+  private readonly channel: QuotaChannel | null;
+  private readonly tabId: string;
+  private readonly now: () => number;
+
+  /** Per-account monotonic generation; bumped whenever a new request starts. */
+  private readonly generation: Record<string, number> = {};
+  /** In-flight abort controllers keyed by `${accountId}:${kind}`. */
+  private readonly inflight: Record<string, AbortController> = {};
+
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly getSnapshot: () => QuotaState;
+
+  constructor(options: QuotaStoreOptions = {}) {
+    this.api = options.api ?? createQuotaApi();
+    this.channel = options.channel ?? null;
+    this.tabId = options.tabId ?? `tab_${Math.random().toString(36).slice(2)}`;
+    this.now = options.now ?? (() => Date.now());
+    this.state = {
+      currentAccountId: "",
+      slices: {},
+    };
+
+    this.subscribe = (listener: () => void) => {
+      this.listeners.add(listener);
+      return () => {
+        this.listeners.delete(listener);
+      };
+    };
+    this.getSnapshot = () => this.state;
+
+    if (this.channel) {
+      this.channel.setHandler((msg) => this.handleRemoteMessage(msg));
+    }
+  }
+
+  // ─── Public actions ───────────────────────────────────────────────────────
+
+  /** Switch the active account; abandons in-flight work for the prior account. */
+  selectAccount(accountId: string): Promise<void> {
+    const previous = this.state.currentAccountId;
+    if (previous && previous !== accountId) {
+      // Abandon any in-flight request for the account we are leaving so its
+      // (now-irrelevant) responses cannot mutate state later.
+      this.abort(previous, "fetch");
+      this.abort(previous, "update");
+    }
+
+    this.state = {
+      ...this.state,
+      currentAccountId: accountId,
+      slices: {
+        ...this.state.slices,
+        [accountId]: this.state.slices[accountId] ?? defaultSlice(accountId),
+      },
+    };
+    this.emit();
+
+    return this.load(accountId).then(() => undefined);
+  }
+
+  /** Refetch the current account's authoritative quota. */
+  refresh(): Promise<void> {
+    return this.load(this.state.currentAccountId).then(() => undefined);
+  }
+
+  /**
+   * Submit a quota update for the current account. Resolves (or rejects) once
+   * the request settles. The optimistic value is tracked but is NEVER reported
+   * as confirmed until the server responds successfully.
+   */
+  update(value: number): Promise<void> {
+    const accountId = this.state.currentAccountId;
+    const slice = this.state.slices[accountId];
+    if (!slice || slice.version === null) {
+      const err = new Error("Load the quota before updating it.");
+      this.patch(accountId, (s) => ({
+        ...s,
+        pendingStatus: "error",
+        pendingError: err.message,
+        lastAttemptValue: value,
+        pendingValue: null,
+        retryCount: (s.retryCount ?? 0) + 1,
+      }));
+      return Promise.reject(err);
+    }
+
+    const baseVersion = slice.version;
+    const gen = this.bumpGeneration(accountId);
+    this.abort(accountId, "update");
+    const controller = new AbortController();
+    this.inflight[`update:${accountId}`] = controller;
+
+    this.patch(accountId, (s) => ({
+      ...s,
+      pendingValue: value,
+      lastAttemptValue: value,
+      pendingStatus: "submitting",
+      pendingError: null,
+    }));
+
+    return this.api
+      .updateQuota(accountId, value, baseVersion, controller.signal)
+      .then((record) => {
+        if (gen !== this.generation[accountId]) return; // superseded
+        delete this.inflight[`update:${accountId}`];
+        this.applyLocalUpdate(accountId, record);
+        this.broadcast(record);
+      })
+      .catch((err) => {
+        if (gen !== this.generation[accountId]) return; // superseded/aborted
+        if (isAbortError(err)) return;
+        if (err instanceof QuotaConflictError) {
+          this.patch(accountId, (s) => ({
+            ...s,
+            pendingStatus: "error",
+            pendingError:
+              "Conflict: a newer quota already exists. Refresh and retry.",
+            pendingValue: null,
+            retryCount: (s.retryCount ?? 0) + 1,
+          }));
+          // Fetch the latest authoritative value so the UI can reconcile.
+          return this.load(accountId).then(() => undefined);
+        }
+        this.patch(accountId, (s) => ({
+          ...s,
+          pendingStatus: "error",
+          pendingError: (err as Error)?.message ?? "Update failed",
+          pendingValue: null,
+          retryCount: (s.retryCount ?? 0) + 1,
+        }));
+      });
+  }
+
+  /** Retry the last failed update for the current account. */
+  retry(): Promise<void> {
+    const accountId = this.state.currentAccountId;
+    const slice = this.state.slices[accountId];
+    if (!slice || slice.lastAttemptValue === null) {
+      return Promise.resolve();
+    }
+    const run = () => this.update(slice.lastAttemptValue as number);
+    if (slice.version === null) {
+      return this.load(accountId).then(run);
+    }
+    return run();
+  }
+
+  /** Test/utility helper: read a slice (falls back to a default). */
+  getSlice(accountId: string): QuotaSlice {
+    return this.state.slices[accountId] ?? defaultSlice(accountId);
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────────────
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+
+  private patch(
+    accountId: string,
+    fn: (slice: QuotaSlice) => QuotaSlice,
+  ): void {
+    const prev = this.state.slices[accountId] ?? defaultSlice(accountId);
+    const next = fn(prev);
+    this.state = {
+      ...this.state,
+      slices: { ...this.state.slices, [accountId]: next },
+    };
+    this.emit();
+  }
+
+  private bumpGeneration(accountId: string): number {
+    this.generation[accountId] = (this.generation[accountId] ?? 0) + 1;
+    return this.generation[accountId];
+  }
+
+  private abort(accountId: string, kind: "fetch" | "update"): void {
+    const key = `${kind}:${accountId}`;
+    const controller = this.inflight[key];
+    if (controller) {
+      controller.abort();
+      delete this.inflight[key];
+    }
+  }
+
+  private async load(accountId: string): Promise<QuotaRecord | null> {
+    if (!accountId) return null;
+    const gen = this.bumpGeneration(accountId);
+    this.abort(accountId, "fetch");
+    const controller = new AbortController();
+    this.inflight[`fetch:${accountId}`] = controller;
+
+    this.patch(accountId, (s) => ({
+      ...s,
+      loadStatus: s.value === null ? "loading" : s.loadStatus,
+      loadError: null,
+    }));
+
+    try {
+      const record = await this.api.fetchQuota(accountId, controller.signal);
+      if (gen !== this.generation[accountId]) return null; // superseded
+      delete this.inflight[`fetch:${accountId}`];
+      this.applyLocalFetch(accountId, record);
+      return record;
+    } catch (err) {
+      if (gen !== this.generation[accountId]) return null; // superseded
+      if (isAbortError(err)) return null;
+      this.patch(accountId, (s) => ({
+        ...s,
+        loadStatus: "error",
+        loadError: (err as Error)?.message ?? "Failed to load quota",
+      }));
+      return null;
+    }
+  }
+
+  private applyLocalFetch(accountId: string, record: QuotaRecord): void {
+    this.patch(accountId, (s) => ({
+      ...s,
+      value: record.value,
+      version: record.version,
+      updatedAt: record.updatedAt,
+      lastSyncedAt: this.now(),
+      loadError: null,
+      // If a mutation is in-flight, keep its indicator; if it failed, mark the
+      // freshly-fetched server state as stale so the user can reconcile.
+      loadStatus:
+        s.pendingStatus === "error"
+          ? "stale"
+          : s.pendingStatus === "submitting"
+            ? s.loadStatus
+            : "ready",
+    }));
+  }
+
+  private applyLocalUpdate(accountId: string, record: QuotaRecord): void {
+    this.patch(accountId, (s) => ({
+      ...s,
+      value: record.value,
+      version: record.version,
+      updatedAt: record.updatedAt,
+      lastSyncedAt: this.now(),
+      loadStatus: "ready",
+      loadError: null,
+      pendingStatus: "idle",
+      pendingValue: null,
+      pendingError: null,
+    }));
+  }
+
+  private broadcast(record: QuotaRecord): void {
+    this.channel?.postMessage({
+      type: "quota:sync",
+      tabId: this.tabId,
+      accountId: record.accountId,
+      value: record.value,
+      version: record.version,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  private handleRemoteMessage(msg: QuotaSyncMessage): void {
+    if (msg.tabId === this.tabId) return; // ignore our own echoes
+    this.applyRemote(msg.accountId, msg);
+  }
+
+  /**
+   * Apply an authoritative change that originated in another tab. We only apply
+   * it when it is strictly newer than what we already know, and we never let it
+   * silently discard a local pending mutation — instead we surface the conflict
+   * so the user can reconcile.
+   */
+  private applyRemote(accountId: string, msg: QuotaSyncMessage): void {
+    const slice = this.state.slices[accountId];
+    if (slice && slice.version !== null && msg.version <= slice.version) {
+      return; // not newer – ignore
+    }
+
+    this.patch(accountId, (s) => {
+      const next: QuotaSlice = {
+        ...s,
+        value: msg.value,
+        version: msg.version,
+        updatedAt: msg.updatedAt,
+        lastSyncedAt: this.now(),
+      };
+
+      if (s.pendingStatus === "submitting" || s.pendingStatus === "error") {
+        // A remote change supersedes our local (unconfirmed or failed) attempt.
+        next.pendingStatus = "error";
+        next.pendingError =
+          s.pendingStatus === "submitting"
+            ? "Another tab updated this quota. Review and retry."
+            : s.pendingError;
+        next.pendingValue = null; // revert optimistic display
+        next.loadStatus = "stale";
+      } else if (s.loadStatus === "error") {
+        next.loadStatus = "ready";
+        next.loadError = null;
+      } else {
+        next.loadStatus = "ready";
+      }
+      return next;
+    });
+  }
+}
+
+/** Shared singleton used by the UI (one per app instance / tab). */
+export const quotaStore = new QuotaStore({
+  api: createQuotaApi(),
+  channel: createQuotaChannel(),
+});

--- a/src/state/quotaTestUtils.ts
+++ b/src/state/quotaTestUtils.ts
@@ -1,0 +1,158 @@
+/**
+ * Test helpers for quota store / component tests.
+ *
+ * `makeFakeApi` returns a fully controllable {@link QuotaApi}: every request is
+ * recorded and can be resolved/rejected manually, which lets tests exercise
+ * out-of-order, stale, conflicting, and cross-tab scenarios deterministically.
+ *
+ * `linkedChannels` creates two {@link QuotaChannel}s that deliver messages to
+ * each other, simulating two browser tabs sharing a `BroadcastChannel`.
+ */
+
+import {
+  QuotaApi,
+  QuotaRecord,
+  QuotaConflictError,
+} from "../api/quotaApi";
+import { QuotaChannel, QuotaSyncMessage } from "./quotaStore";
+
+export class Deferred<T> {
+  promise: Promise<T>;
+  resolve!: (value: T) => void;
+  reject!: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((res, rej) => {
+      this.resolve = res;
+      this.reject = rej;
+    });
+  }
+}
+
+function abortError(): Error {
+  const err = new Error("The operation was aborted.");
+  err.name = "AbortError";
+  return err;
+}
+
+export interface FakeApiHandle {
+  api: QuotaApi;
+  fetchCalls: { accountId: string; deferred: Deferred<QuotaRecord>; signal?: AbortSignal }[];
+  updateCalls: {
+    accountId: string;
+    value: number;
+    baseVersion: number;
+    deferred: Deferred<QuotaRecord>;
+    signal?: AbortSignal;
+  }[];
+  seed: (accountId: string, value: number, version?: number) => void;
+  resolveFetch: (index: number, record: QuotaRecord) => void;
+  resolveLastFetch: (record: QuotaRecord) => void;
+  rejectFetch: (index: number, err: unknown) => void;
+  resolveUpdate: (index: number, record: QuotaRecord) => void;
+  resolveLastUpdate: (record: QuotaRecord) => void;
+  rejectUpdate: (index: number, err: unknown) => void;
+  rejectLastUpdateConflict: (serverVersion: number, accountId: string) => void;
+}
+
+export function makeFakeApi(initial: Record<string, number> = {}): FakeApiHandle {
+  const server = new Map<string, QuotaRecord>();
+  for (const [accountId, value] of Object.entries(initial)) {
+    server.set(accountId, { accountId, value, version: 1, updatedAt: 1 });
+  }
+
+  const fetchCalls: FakeApiHandle["fetchCalls"] = [];
+  const updateCalls: FakeApiHandle["updateCalls"] = [];
+
+  const api: QuotaApi = {
+    fetchQuota(accountId, signal) {
+      const d = new Deferred<QuotaRecord>();
+      signal?.addEventListener("abort", () => d.reject(abortError()), {
+        once: true,
+      });
+      fetchCalls.push({ accountId, deferred: d, signal });
+      return d.promise;
+    },
+    updateQuota(accountId, value, baseVersion, signal) {
+      const d = new Deferred<QuotaRecord>();
+      signal?.addEventListener("abort", () => d.reject(abortError()), {
+        once: true,
+      });
+      updateCalls.push({ accountId, value, baseVersion, deferred: d, signal });
+      return d.promise;
+    },
+  };
+
+  return {
+    api,
+    fetchCalls,
+    updateCalls,
+    seed(accountId, value, version = 1) {
+      server.set(accountId, { accountId, value, version, updatedAt: 1 });
+    },
+    resolveFetch(index, record) {
+      fetchCalls[index].deferred.resolve(record);
+    },
+    resolveLastFetch(record) {
+      this.resolveFetch(fetchCalls.length - 1, record);
+    },
+    rejectFetch(index, err) {
+      fetchCalls[index].deferred.reject(err);
+    },
+    resolveUpdate(index, record) {
+      updateCalls[index].deferred.resolve(record);
+    },
+    resolveLastUpdate(record) {
+      this.resolveUpdate(updateCalls.length - 1, record);
+    },
+    rejectUpdate(index, err) {
+      updateCalls[index].deferred.reject(err);
+    },
+    rejectLastUpdateConflict(serverVersion, accountId) {
+      this.rejectUpdate(
+        updateCalls.length - 1,
+        new QuotaConflictError(serverVersion, accountId),
+      );
+    },
+  };
+}
+
+/** Two channels that forward messages to each other (simulated tabs). */
+export function linkedChannels(): [QuotaChannel, QuotaChannel] {
+  let handlerA: ((msg: QuotaSyncMessage) => void) | null = null;
+  let handlerB: ((msg: QuotaSyncMessage) => void) | null = null;
+
+  const channelA: QuotaChannel = {
+    postMessage: (msg) => {
+      try {
+        handlerB?.(msg);
+      } catch {
+        /* a receiver error must not break the sender */
+      }
+    },
+    close: () => {},
+    setHandler: (cb) => {
+      handlerA = cb;
+    },
+  };
+  const channelB: QuotaChannel = {
+    postMessage: (msg) => {
+      try {
+        handlerA?.(msg);
+      } catch {
+        /* a receiver error must not break the sender */
+      }
+    },
+    close: () => {},
+    setHandler: (cb) => {
+      handlerB = cb;
+    },
+  };
+
+  return [channelA, channelB];
+}
+
+/** Flush pending microtasks/macrotasks in tests. */
+export function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
## Summary

* `src/api/quotaApi.ts` — Simulated quota API with `AbortController` support and `QuotaConflictError` when a write is based on a stale server version.
* `src/state/quotaStore.ts` — Race-safe store featuring:
  * Per-account generation counter that drops superseded/out-of-order responses.
  * `AbortController` cancellation on supersede / account-switch.
  * Cross-tab sync via `BroadcastChannel` (with a storage-event fallback) — `applyRemote` instantly applies strictly-newer updates from other tabs and never clobbers local intent.
  * Clear separation of authoritative state from unconfirmed optimistic `pendingValue`, ensuring success is never reported early.
  * Explicit loading / ready / stale / error / retry / account-switch states.
* `src/hooks/useQuotaStore.ts` — Utilizes `useSyncExternalStore` hook.
* `src/components/QuotaManager.tsx + .css` — Accessible UI for all the above states.
* **Tests:** `quotaApi.test.ts`, `quotaStore.test.ts` (covering out-of-order, account-switch, conflict reconcile, two-tab sync/supersede), `QuotaManager.test.tsx`, plus `quotaTestUtils.ts` for deterministic fakes.

## Verification

* 19 new tests pass; new modules pass an isolated strict `tsc --noEmit` typecheck with zero errors.

Closes #995