### PR TITLE
feat: preserve contrast when themes switch dynamically (#1000)

### DIFF
--- a/src/ThemeContext.test.tsx
+++ b/src/ThemeContext.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+/** Controllable matchMedia mock so we can simulate OS theme-preference changes. */
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(e: { matches: boolean }) => void>();
+  const mql = {
+    matches: initialDark,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null as null | ((e: { matches: boolean }) => void),
+    addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => listeners.delete(cb),
+    addListener: (cb: (e: { matches: boolean }) => void) => listeners.add(cb),
+    removeListener: (cb: (e: { matches: boolean }) => void) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia = ((
+    query: string,
+  ) => ({ ...mql, media: query })) as typeof window.matchMedia;
+  return {
+    setDark(next: boolean) {
+      mql.matches = next;
+      listeners.forEach((cb) => cb({ matches: next }));
+    },
+  };
+}
+
+/** jsdom doesn't always implement rAF; provide a deterministic shim. */
+beforeEach(() => {
+  (window as unknown as { requestAnimationFrame: typeof window.requestAnimationFrame }).requestAnimationFrame =
+    ((cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number) as typeof window.requestAnimationFrame;
+  (window as unknown as { cancelAnimationFrame: typeof window.cancelAnimationFrame }).cancelAnimationFrame =
+    ((id: number) => clearTimeout(id)) as typeof window.cancelAnimationFrame;
+  document.documentElement.removeAttribute('data-theme');
+  document.documentElement.classList.remove('theme-transitions-ready');
+});
+
+function renderTheme() {
+  return renderHook(() => useTheme(), {
+    wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
+  });
+}
+
+describe('ThemeProvider preserves operability when switching themes dynamically', () => {
+  it('applies the light data-theme attribute and updates actualTheme', () => {
+    installMatchMedia(false);
+    const { result } = renderTheme();
+    act(() => result.current.setTheme('light'));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(result.current.actualTheme).toBe('light');
+  });
+
+  it('applies the dark data-theme attribute and updates actualTheme', () => {
+    installMatchMedia(false);
+    const { result } = renderTheme();
+    act(() => result.current.setTheme('dark'));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(result.current.actualTheme).toBe('dark');
+  });
+
+  it('follows the OS preference in "system" mode and updates when it changes', () => {
+    const media = installMatchMedia(false); // OS = light
+    const { result } = renderTheme();
+    act(() => result.current.setTheme('system'));
+    expect(result.current.actualTheme).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    // Simulate the user switching their OS to dark at runtime.
+    act(() => media.setDark(true));
+    expect(result.current.actualTheme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    // And back to light.
+    act(() => media.setDark(false));
+    expect(result.current.actualTheme).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('enables theme transitions after first paint (gated by theme-transitions-ready)', () => {
+    installMatchMedia(false);
+    vi.useFakeTimers();
+    renderTheme();
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(document.documentElement.classList.contains('theme-transitions-ready')).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('toggles the isTransitioning flag around a theme switch', () => {
+    installMatchMedia(false);
+    const { result } = renderTheme();
+    act(() => result.current.setTheme('light'));
+    expect(result.current.isTransitioning).toBe(true);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,17 @@
   --modal-bg: linear-gradient(180deg, rgba(20, 27, 50, 0.98), rgba(12, 18, 34, 0.98));
   --visited: #a78bfa;
 
+  /* ── Theme-agnostic display / glyph tokens ─────────────────────────────
+     These carry foreground colours that must remain legible in BOTH themes.
+     They are defined per-theme (light + dark) so dynamic theme switching
+     never leaves a hardcoded light-on-dark colour behind on a light surface.
+     Each value is tuned to clear WCAG 2.1 AA (>= 4.5:1) against its
+     intended background token.                                            */
+  --display-404: #dbe5ff;       /* .not-found-code — on --page-bg */
+  --glyph-error: #ffd0d6;       /* .error-illustration span — on --page-bg */
+  --status-pending-fg: #ffe08a; /* .status-chip.pending — on --surface */
+  --status-approving-fg: #cbd9ff; /* .status-chip.approving — on --surface */
+
   /* HTTP Method Badge Tokens - Dark Theme (High Contrast / Accessible) */
   --method-get-bg: rgba(59, 130, 246, 0.16);
   --method-get-color: #60a5fa;
@@ -103,6 +114,13 @@
   --backdrop: rgba(255, 255, 255, 0.8);
   --modal-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 255, 0.98));
   --visited: #7c3aed;
+
+  /* ── Theme-agnostic display / glyph tokens (Light Theme) ───────────────
+     Dark foregrounds so they clear WCAG 2.1 AA against light surfaces. */
+  --display-404: #1e3a8a;
+  --glyph-error: #b91c1c;
+  --status-pending-fg: #854d0e;
+  --status-approving-fg: #1e40af;
 
   /* HTTP Method Badge Tokens - Light Theme (High Contrast / Accessible) */
   --method-get-bg: rgba(37, 99, 235, 0.1);
@@ -960,8 +978,8 @@ code,
 }
 
 .primary-button {
-  background: linear-gradient(135deg, #4e85ff, #6da6ff);
-  color: white;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 84%, #000000), var(--accent));
+  color: #ffffff;
   font-weight: 700;
 }
 
@@ -1091,7 +1109,7 @@ code,
 .error-illustration span {
   font-size: 2rem;
   font-weight: 700;
-  color: #ffd0d6;
+  color: var(--glyph-error);
 }
 
 .not-found-code {
@@ -1099,7 +1117,7 @@ code,
   font-size: clamp(4rem, 16vw, 8rem);
   line-height: 0.9;
   font-weight: 700;
-  color: #dbe5ff;
+  color: var(--display-404);
   letter-spacing: 0.04em;
 }
 
@@ -1367,7 +1385,7 @@ code,
   background:
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Ccircle cx='4' cy='4' r='1.2' fill='currentColor' fill-opacity='0.25'/%3E%3C/svg%3E") repeat,
     rgba(250, 204, 21, 0.12);
-  color: #ffe08a;
+  color: var(--status-pending-fg);
 }
 
 .status-chip.confirmed {
@@ -1390,7 +1408,7 @@ code,
   background:
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cline x1='0' y1='8' x2='8' y2='0' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='4' y1='8' x2='8' y2='4' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3Cline x1='0' y1='4' x2='4' y2='0' stroke='currentColor' stroke-width='1' stroke-opacity='0.2'/%3E%3C/svg%3E") repeat,
     rgba(78, 133, 255, 0.14);
-  color: #cbd9ff;
+  color: var(--status-approving-fg);
 }
 
 .status-chip.input {
@@ -6944,6 +6962,10 @@ code,
     --line-strong: rgba(0, 0, 0, 0.12) !important;
     --text: #1a2332 !important;
     --muted: #64748b !important;
+    --display-404: #1e3a8a !important;
+    --glyph-error: #b91c1c !important;
+    --status-pending-fg: #854d0e !important;
+    --status-approving-fg: #1e40af !important;
     --accent: #2563eb !important;
     --accent-strong: #059669 !important;
     --danger: #dc2626 !important;

--- a/src/pages/ThemeToggleA11y.test.tsx
+++ b/src/pages/ThemeToggleA11y.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from '../ThemeContext';
+import { ThemeToggle } from './ThemeToggle';
+
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(e: { matches: boolean }) => void>();
+  const mql = {
+    matches: initialDark,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null as null | ((e: { matches: boolean }) => void),
+    addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => listeners.delete(cb),
+    addListener: (cb: (e: { matches: boolean }) => void) => listeners.add(cb),
+    removeListener: (cb: (e: { matches: boolean }) => void) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia = ((
+    query: string,
+  ) => ({ ...mql, media: query })) as typeof window.matchMedia;
+  return { setDark: (v: boolean) => { mql.matches = v; listeners.forEach((l) => l({ matches: v })); } };
+}
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+}
+
+describe('ThemeToggle stays operable and announces theme changes', () => {
+  it('exposes an accessible name and a polite live region that reflects the theme', () => {
+    installMatchMedia(false);
+    renderToggle();
+
+    const toggle = screen.getByRole('button', { name: /toggle theme/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-pressed');
+
+    // The label is a polite live region that announces the active theme.
+    const live = within(toggle).getByText(/dark|light|system/i);
+    expect(live).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('keeps the toggle in the accessibility tree after switching to light', () => {
+    installMatchMedia(false);
+    renderToggle();
+
+    const toggle = screen.getByRole('button', { name: /toggle theme/i }) as HTMLButtonElement;
+    act(() => {
+      toggle.click(); // dark -> light
+    });
+
+    const updated = screen.getByRole('button', { name: /toggle theme/i });
+    expect(updated).toBeInTheDocument();
+    expect(updated.getAttribute('aria-label')).toMatch(/light/i);
+  });
+
+  it('the sticky action bar is inert/aria-hidden until revealed (no stray announcements)', () => {
+    installMatchMedia(false);
+    renderToggle();
+    const bar = screen.getByTestId('theme-sticky-bar');
+    expect(bar).toHaveAttribute('aria-hidden', 'true');
+    expect(bar).toHaveAttribute('inert');
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,69 +1,73 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
-// Mock matchMedia for components that use it (e.g., Tabs)
-// Use Object.defineProperty to properly set it on window
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+// Only install browser-global mocks when a DOM is present. Under the `node`
+// environment (e.g. pure-logic/contrast tests) these globals do not exist.
+if (typeof window !== "undefined") {
+  // Mock matchMedia for components that use it (e.g., Tabs)
+  // Use Object.defineProperty to properly set it on window
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
 
-// Mock localStorage globally for tests in jsdom/node contexts
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-  return {
-    getItem: (key: string) => {
-      const k = String(key);
-      return store[k] !== undefined ? store[k] : null;
-    },
-    setItem: (key: string, value: string) => {
-      const k = String(key);
-      store[k] = String(value);
-    },
-    clear: () => {
-      store = {};
-    },
-    removeItem: (key: string) => {
-      const k = String(key);
-      delete store[k];
-    },
-    get length() {
-      return Object.keys(store).length;
-    },
-    key: (index: number) => Object.keys(store)[index] || null,
-  };
-})();
+  // Mock localStorage globally for tests in jsdom/node contexts
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: (key: string) => {
+        const k = String(key);
+        return store[k] !== undefined ? store[k] : null;
+      },
+      setItem: (key: string, value: string) => {
+        const k = String(key);
+        store[k] = String(value);
+      },
+      clear: () => {
+        store = {};
+      },
+      removeItem: (key: string) => {
+        const k = String(key);
+        delete store[k];
+      },
+      get length() {
+        return Object.keys(store).length;
+      },
+      key: (index: number) => Object.keys(store)[index] || null,
+    };
+  })();
 
-Object.defineProperty(window, "localStorage", {
-  value: localStorageMock,
-  writable: true,
-});
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock,
+    writable: true,
+  });
 
-Object.defineProperty(globalThis, "localStorage", {
-  value: localStorageMock,
-  writable: true,
-});
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageMock,
+    writable: true,
+  });
 
-// Mock IntersectionObserver for components that use it (e.g., ThemeToggle sticky bar)
-const mockIntersectionObserver = vi.fn().mockImplementation((callback: IntersectionObserverCallback) => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-  trigger: (entries: IntersectionObserverEntry[]) => callback(entries, {} as IntersectionObserver),
-}));
+  // Mock IntersectionObserver for components that use it (e.g., ThemeToggle sticky bar)
+  const mockIntersectionObserver = vi.fn().mockImplementation((callback: IntersectionObserverCallback) => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+    trigger: (entries: IntersectionObserverEntry[]) => callback(entries, {} as IntersectionObserver),
+  }));
 
-Object.defineProperty(window, "IntersectionObserver", {
-  value: mockIntersectionObserver,
-  writable: true,
-  configurable: true,
-});
+  Object.defineProperty(window, "IntersectionObserver", {
+    value: mockIntersectionObserver,
+    writable: true,
+    configurable: true,
+  });
+}
 

--- a/src/utils/contrast.test.ts
+++ b/src/utils/contrast.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  getContrastRatio,
+  parseColor,
+  composite,
+  WCAG_AA_NORMAL,
+  WCAG_AA_LARGE,
+} from './contrast';
+
+// Lodaded directly from disk via an absolute path. (vitest's node-environment
+// wraps `node:fs`, so we avoid path composition that could be mis-resolved.)
+const CSS = readFileSync('/workspaces/Callora-Frontend/src/index.css', 'utf8');
+
+/** Extract the declaration body of a `[data-theme="..."]` block. */
+function themeBlock(theme: 'dark' | 'light'): string {
+  const match = CSS.match(new RegExp(`\\[data-theme="${theme}"\\]\\s*\\{([\\s\\S]*?)\\n\\}`));
+  if (!match) throw new Error(`Could not find [data-theme="${theme}"] block`);
+  return match[1];
+}
+
+/** Build a `{ '--token': 'value' }` map for a theme block. */
+function themeTokens(theme: 'dark' | 'light'): Record<string, string> {
+  const block = themeBlock(theme);
+  const tokens: Record<string, string> = {};
+  const re = /(--[\w-]+)\s*:\s*([^;]+);/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block))) {
+    tokens[m[1]] = m[2].trim();
+  }
+  return tokens;
+}
+
+/** Resolve a `var(--x)` reference (ignoring fallbacks) to its token value. */
+function resolve(value: string, tokens: Record<string, string>): string {
+  const m = value.match(/var\((--[\w-]+)(?:,\s*[^)]*)?\)/);
+  return m ? tokens[m[1]] ?? value : value;
+}
+
+/** Composite a token colour (possibly translucent) over the theme page background. */
+function effective(value: string, tokens: Record<string, string>): [number, number, number] | null {
+  const resolved = resolve(value, tokens);
+  const rgba = parseColor(resolved);
+  if (!rgba) return null;
+  const pageRgba = parseColor(resolve(tokens['--page-bg'], tokens));
+  if (!pageRgba) return null;
+  return composite(rgba, [pageRgba[0], pageRgba[1], pageRgba[2]]);
+}
+
+/** WCAG contrast ratio of two token names within one theme. */
+function ratioFor(fgToken: string, bgToken: string, tokens: Record<string, string>): number {
+  const fg = effective(tokens[fgToken], tokens);
+  const bg = effective(tokens[bgToken], tokens);
+  if (!fg || !bg) throw new Error(`Could not resolve ${fgToken} / ${bgToken}`);
+  return getContrastRatio([fg[0], fg[1], fg[2], 1], [bg[0], bg[1], bg[2], 1]);
+}
+
+const THEMES = ['dark', 'light'] as const;
+
+describe('theme tokens preserve WCAG AA contrast when switching themes', () => {
+  const textPairs: Array<[string, string]> = [
+    ['--text', '--page-bg'],
+    ['--muted', '--surface'],
+    ['--display-404', '--page-bg'],
+    ['--glyph-error', '--page-bg'],
+    ['--status-pending-fg', '--surface'],
+    ['--status-approving-fg', '--surface'],
+    ['--method-get-color', '--surface'],
+    ['--method-post-color', '--surface'],
+    ['--method-put-color', '--surface'],
+    ['--method-delete-color', '--surface'],
+    ['--method-patch-color', '--surface'],
+  ];
+
+  for (const theme of THEMES) {
+    const tokens = themeTokens(theme);
+
+    for (const [fg, bg] of textPairs) {
+      it(`${theme}: ${fg} on ${bg} meets WCAG AA (>=4.5:1)`, () => {
+        const ratio = ratioFor(fg, bg, tokens);
+        expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+      });
+    }
+
+    it(`${theme}: white text on --accent (primary buttons) meets >=3:1`, () => {
+      const fg = effective('#ffffff', tokens);
+      const bg = effective(tokens['--accent'], tokens);
+      expect(fg).not.toBeNull();
+      expect(bg).not.toBeNull();
+      const ratio = getContrastRatio(
+        [fg![0], fg![1], fg![2], 1],
+        [bg![0], bg![1], bg![2], 1],
+      );
+      expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_LARGE);
+    });
+  }
+});
+
+describe('contrast regressions are not reintroduced (no hardcoded colours)', () => {
+  // Strip comments so we only inspect real rules, never the explanatory
+  // example snippets that also appear in the stylesheet.
+  const CSS_NOCOMMENTS = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  /** Find the `color:` declaration inside a given selector rule and assert it uses a token. */
+  function colorDeclarationUsesToken(selector: string): boolean {
+    const escaped = selector.replace(/[.[>\s]/g, (c) => '\\' + c);
+    const re = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`);
+    const match = CSS_NOCOMMENTS.match(re);
+    if (!match) throw new Error(`Could not find rule for ${selector}`);
+    const colorDecl = match[1].match(/(?:^|[\s;{])color:\s*([^;]+);/);
+    if (!colorDecl) throw new Error(`No color declaration in ${selector}`);
+    return /var\(/.test(colorDecl[1]);
+  }
+
+  const selectors = [
+    '.not-found-code',
+    '.error-illustration span',
+    '.status-chip.pending',
+    '.status-chip.approving',
+  ];
+
+  for (const selector of selectors) {
+    it(`${selector} uses a theme token (not a hardcoded colour)`, () => {
+      expect(colorDeclarationUsesToken(selector)).toBe(true);
+    });
+  }
+});
+
+describe('contrast utility math', () => {
+  it('computes known WCAG ratios', () => {
+    // Black on white = 21:1, white on black = 21:1.
+    expect(getContrastRatio([0, 0, 0, 1], [255, 255, 255, 1])).toBeCloseTo(21, 1);
+    expect(getContrastRatio([255, 255, 255, 1], [0, 0, 0, 1])).toBeCloseTo(21, 1);
+  });
+
+  it('alpha-composites translucent surfaces over an opaque backdrop', () => {
+    // 50% black over white => mid grey (128) per channel.
+    expect(composite([0, 0, 0, 0.5], [255, 255, 255])).toEqual([128, 128, 128]);
+  });
+});

--- a/src/utils/contrast.ts
+++ b/src/utils/contrast.ts
@@ -1,0 +1,108 @@
+/**
+ * WCAG 2.1 contrast utilities.
+ *
+ * Used by automated accessibility tests to guarantee that token-driven
+ * foreground / background pairs clear the minimum contrast ratios required by
+ * WCAG 2.1 (AA: 4.5:1 for normal text, 3:1 for large text and UI components)
+ * in *both* light and dark themes. Keeping the math in one place means the
+ * theme stylesheets and the tests share a single source of truth.
+ */
+
+/** Parse a hex colour (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) into 0-255 channels. */
+export function parseHexColor(input: string): [number, number, number, number] | null {
+  let hex = input.trim().replace(/^#/, '');
+  if (hex.length === 3 || hex.length === 4) {
+    hex = hex
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  }
+  if (hex.length !== 6 && hex.length !== 8) return null;
+  if (!/^[0-9a-fA-F]+$/.test(hex)) return null;
+
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const a = hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1;
+  return [r, g, b, a];
+}
+
+/** Parse an `rgba()` / `rgb()` colour string into 0-255 channels + alpha. */
+export function parseRgbaColor(input: string): [number, number, number, number] | null {
+  const match = input
+    .trim()
+    .match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)$/i);
+  if (!match) return null;
+  const r = Number(match[1]);
+  const g = Number(match[2]);
+  const b = Number(match[3]);
+  const a = match[4] === undefined ? 1 : Number(match[4]);
+  if ([r, g, b, a].some((n) => Number.isNaN(n))) return null;
+  return [r, g, b, a];
+}
+
+/** Resolve a CSS colour string into 0-255 channels + alpha. Returns null if unsupported. */
+export function parseColor(input: string): [number, number, number, number] | null {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('#')) return parseHexColor(trimmed);
+  if (/^rgba?\(/i.test(trimmed)) return parseRgbaColor(trimmed);
+  return null;
+}
+
+/** Relative luminance (WCAG 2.1 §1.4.3) for an sRGB channel value (0-255). */
+function channelLuminance(value: number): number {
+  const c = value / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** Relative luminance (0-1) of a fully opaque colour. */
+export function getLuminance([r, g, b]: [number, number, number]): number {
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+/** Alpha-composite a foreground colour over an opaque background. */
+export function composite(
+  fg: [number, number, number, number],
+  bg: [number, number, number],
+): [number, number, number] {
+  const alpha = fg[3];
+  return [
+    Math.round(fg[0] * alpha + bg[0] * (1 - alpha)),
+    Math.round(fg[1] * alpha + bg[1] * (1 - alpha)),
+    Math.round(fg[2] * alpha + bg[2] * (1 - alpha)),
+  ];
+}
+
+/** Contrast ratio between two colours (1.0 - 21.0). */
+export function getContrastRatio(
+  a: [number, number, number, number],
+  b: [number, number, number, number],
+): number {
+  // Composite both colours over white so translucent/alpha colours compare
+  // against a consistent, opaque backdrop (the worst-case page surface).
+  const WHITE: [number, number, number] = [255, 255, 255];
+  const aOpaque = composite(a, WHITE);
+  const bOpaque = composite(b, WHITE);
+  const la = getLuminance(aOpaque);
+  const lb = getLuminance(bOpaque);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** WCAG AA normal-text threshold (4.5:1). */
+export const WCAG_AA_NORMAL = 4.5;
+/** WCAG AA large-text / non-text threshold (3:1). */
+export const WCAG_AA_LARGE = 3;
+
+/** True when the pair meets WCAG AA for normal-size text. */
+export function meetsWCAG_AA(a: string, b: string): boolean {
+  const ca = parseColor(a);
+  const cb = parseColor(b);
+  if (!ca || !cb) return false;
+  return getContrastRatio(ca, cb) >= WCAG_AA_NORMAL;
+}


### PR DESCRIPTION
## Summary

Dynamic theme switching (light ↔ dark, and `system` / OS-preference driven) previously left several UI surfaces with **hardcoded, theme-unaware colours** that became invisible — and therefore failed WCAG 2.1 AA — when the opposite theme was applied. This change makes those surfaces theme-token driven and adds automated contrast + interaction tests that guard the behaviour in **both** themes.

### Before / After

| Surface | Before (light mode) | After (both themes) |
| --- | --- | --- |
| `404` display number (`.not-found-code`) | `#dbe5ff` (light-on-light, ~1.3:1, invisible) | `--display-404` = `#1e3a8a` in light (≈9.5:1), `#dbe5ff` in dark |
| Error glyph (`.error-illustration span`) | `#ffd0d6` (low contrast on white) | `--glyph-error` = `#b91c1c` in light (≈5.9:1), `#ffd0d6` in dark |
| `pending` status chip text | `#ffe08a` (low contrast on light surface) | `--status-pending-fg` = `#854d0e` in light (≈6.3:1) |
| `approving` status chip text | `#cbd9ff` (low contrast on light surface) | `--status-approving-fg` = `#1e40af` in light (≈8:1) |
| Primary buttons (`.primary-button`) | Fixed `#4e85ff` gradient (ignored theme accent, 3.4:1 with white) | `var(--accent)` gradient (5.1:1 in light, theme-aware in dark) |

The status-chip pattern textures (`currentColor`) now also follow the token, so colour-blind / grayscale meaning is preserved automatically.

### Acceptance criteria → code & tests

- **AC1 — No hardcoded foreground colours survive a theme switch**
  - Code: `src/index.css` — four new per-theme tokens (`--display-404`, `--glyph-error`, `--status-pending-fg`, `--status-approving-fg`) wired into the four rules; `.primary-button` now uses `var(--accent)`. Same tokens added to the `@media print` block so print/forced-light output stays legible.
  - Test: `src/utils/contrast.test.ts` → *"contrast regressions are not reintroduced"* asserts each rule's `color` declaration references a `var()`.
- **AC2 — Text/background pairs meet WCAG AA in both themes**
  - Test: `src/utils/contrast.test.ts` → *"theme tokens preserve WCAG AA contrast when switching themes"* parses the real `[data-theme="dark"]` and `[data-theme="light"]` token blocks and asserts ≥4.5:1 for body/muted/display/glyph/status/method-colour pairs, and ≥3:1 for white-on-accent buttons, in **both** themes.
- **AC3 — Dynamic `system` switching stays operable without reload**
  - Code: `src/ThemeContext.tsx` already subscribes to `matchMedia('(prefers-color-scheme: dark)')`.
  - Test: `src/ThemeContext.test.tsx` → *"follows the OS preference in 'system' mode and updates when it changes"* drives the OS preference at runtime and asserts `actualTheme` + `data-theme` update to dark then back to light.
- **AC4 — Semantic announcements + keyboard operability intact across themes**
  - Code: `ThemeToggle` exposes `aria-label` + a `aria-live="polite"` label, and the sticky bar is `inert`/`aria-hidden` until revealed.
  - Test: `src/pages/ThemeToggleA11y.test.tsx` → asserts the toggle keeps an accessible name, the live region reflects the theme after switching, and the sticky bar is inert when hidden.
- **AC5 — Motion / reduced-motion preserved**
  - Existing `prefers-reduced-motion` gating in `src/index.css` is untouched; `ThemeContext` still adds `theme-transitions-ready` after first paint (tested) so transitions never block theme application.

### Accessibility & failure-mode handling

- **Fallback strategy:** every colour is now a design token resolved from the active theme, so a missing value degrades consistently rather than rendering an invisible hardcoded literal. The print block re-declares the new tokens with `!important` so forced-light/print output never regresses.
- **Colour is never the only signal:** status chips already pair colour with distinct SVG textures; this change keeps those textures bound to `currentColor`, so contrast fixes cannot silently remove the non-colour cue.
- **Reduced motion:** theme transitions remain opt-in via `theme-transitions-ready` and the `.no-theme-transition` escape hatch; `prefers-reduced-motion: reduce` users get no colour animation (CSS only).
- **Failure mode if a token is missing:** the contrast test would fail CI before shipping, catching regressions at the source rather than in production.

### Verification evidence

- `npx vitest run src/utils/contrast.test.ts src/ThemeContext.test.tsx src/pages/ThemeToggleA11y.test.tsx` → **all pass** (30 + 5 + 3 = 38 tests).
- New utility `src/utils/contrast.ts` provides reusable WCAG math (`getContrastRatio`, `parseColor`, `composite`, `meetsWCAG_AA`) shared by tests.
- Note: `npm run build` (`tsc -b`) currently fails on `main` in an **unrelated** file (`src/pages/ApiDetailPage.tsx`, pre-existing JSX parse error confirmed present without this branch) and the broader `npm test` suite has pre-existing failures unrelated to theming (e.g. `EmptyState.test.tsx`, `WebhookDeliveries.test.tsx`); this PR introduces no new test or type failures. Per the issue's out-of-scope list, those unrelated breakages were left untouched.

Closes #1000
