### PR TITLE
feat(api-usage): virtualize large call-history tables with keyboard continuity

### DIFF
--- a/docs/VirtualizedCallHistory.md
+++ b/docs/VirtualizedCallHistory.md
@@ -1,0 +1,79 @@
+# Virtualized Call-History Table
+
+Issue #1006 — virtualize the API call-history table so it stays responsive
+and bounded as the number of recorded calls grows, without losing keyboard
+focus while the list scrolls or updates.
+
+## What changed
+
+- `src/hooks/useVirtualList.ts` — windowing hook. Given a scroll container,
+  an item count, and an estimated row height, it returns the visible window
+  (`startIndex`/`endIndex`), the window's pixel offset, the full list height,
+  plus `scrollToIndex`, `measure` (for real rendered heights), and
+  `getOffset` (exact item offsets).
+- `src/components/VirtualizedCallHistory.tsx` — the table shell. Renders the
+  sticky header, loading skeletons, the empty state, and only the rows in the
+  virtual window (absolutely positioned at their measured offsets inside a
+  full-height spacer). Owns roving-tabindex keyboard navigation.
+- `src/pages/ApiUsage.tsx` — swaps the inline `.map()` of `CallHistoryRow`
+  for `<VirtualizedCallHistory>`. No filter/export/expand behavior changed.
+- `src/components/CallHistoryRow.tsx` — new optional `viewButtonTabIndex`
+  prop so the table can implement roving tabindex.
+- `src/index.css` — the table is now a bounded internal scroll container
+  (`max-height: min(60vh, 640px)`, `overflow-y: auto`) with a sticky header.
+
+## Bounds (explicit)
+
+- Mounted rows ≤ `ceil(viewport / rowHeight) + 2 * overscan + 1`, regardless
+  of item count — plus at most **one** extra pinned row holding keyboard
+  focus when it is scrolled outside the window.
+- Window computation is O(log n) per scroll event (binary search over a
+  prefix array). The prefix array is rebuilt only when a measured row height
+  changes, never on scroll.
+- Measured heights are cached per index and bounded by the number of rows
+  ever rendered; unmeasured rows use the 64px estimate.
+- The full list height is an explicit spacer, so the scrollbar always
+  reflects the true total.
+
+## Keyboard continuity
+
+Roving tabindex: only the active row's "View/Hide" button is in the tab
+order. While focused in the list:
+
+| Key         | Action                      |
+| ----------- | --------------------------- |
+| ArrowDown   | next row                    |
+| ArrowUp     | previous row                |
+| Home / End  | first / last row            |
+| PageDown/Up | one viewport of rows        |
+
+The focused row is scrolled into view on navigation. If the list scrolls
+under it (pointer scroll) or updates (new calls prepended), the row stays
+mounted — pinned at its exact offset and sharing the same React key as its
+in-window copy, so focus never drops. Before anything is focused, the tab
+stop follows the window's first row so Tab always lands on a visible row.
+
+## Correctness under updates
+
+Virtualization windows the DOM only; rows are always rendered from the
+caller's `calls` array (the source of truth). There is no data cache, so
+stale or incorrect rows cannot be served. Rows are keyed by window index,
+so in-place data changes reuse the DOM node (matching non-virtualized
+behavior where the focused element keeps showing the same screen position).
+
+## Tests
+
+- `src/hooks/useVirtualList.test.tsx` — window bounds, scroll-driven windows,
+  measured heights, `getOffset`, `scrollToIndex` alignment, empty lists, and
+  a worst-case sweep asserting the window stays bounded at every offset.
+- `src/components/VirtualizedCallHistory.test.tsx` — bounded DOM for a
+  10,000-row list, scroll window updates, roving tabindex, Arrow/Home/End/
+  PageDown/PageUp navigation, focus survival under scroll-away and data
+  prepends, no stale data on array replacement, 50 rapid updates, empty and
+  loading states, and expand/collapse.
+
+Run them with:
+
+```bash
+npm test -- --run src/hooks/useVirtualList.test.tsx src/components/VirtualizedCallHistory.test.tsx
+```

--- a/src/components/CallHistoryRow.tsx
+++ b/src/components/CallHistoryRow.tsx
@@ -52,6 +52,12 @@ type Props = {
    * The current `call` is treated as "before" (A); `compareWith` is "after" (B).
    */
   compareWith?: CallRecord;
+  /**
+   * tabIndex for the row's expand/collapse button. Virtualized tables use
+   * roving tabindex (0 on the active row, -1 elsewhere) so only one row is
+   * in the tab order at a time; defaults to 0 (normal button behavior).
+   */
+  viewButtonTabIndex?: number;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -196,6 +202,7 @@ export default function CallHistoryRow({
   expanded,
   onToggleExpand,
   compareWith,
+  viewButtonTabIndex = 0,
 }: Props) {
   /**
    * Track whether the diff is showing "raw" or "diff" mode.
@@ -242,6 +249,7 @@ export default function CallHistoryRow({
             onClick={() => onToggleExpand(call.id)}
             aria-expanded={expanded}
             aria-controls={`call-details-${call.id}`}
+            tabIndex={viewButtonTabIndex}
           >
             {expanded ? 'Hide' : 'View'}
           </button>

--- a/src/components/VirtualizedCallHistory.test.tsx
+++ b/src/components/VirtualizedCallHistory.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * VirtualizedCallHistory — component tests.
+ *
+ * jsdom has no layout, so tests define the scroll container's `clientHeight`
+ * and `scrollTop` as own properties and dispatch scroll events; row heights
+ * default to the 64px estimate (jsdom reports offsetHeight 0 and the hook
+ * skips those measurements). All assertions are on DOM structure, focus,
+ * and data — never on pixel layout.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import VirtualizedCallHistory from './VirtualizedCallHistory';
+import type { CallRecord } from './CallHistoryRow';
+
+const ROW = 64; // matches the default estimateRowHeight
+const VIEWPORT = 400;
+const OVERSCAN = 5;
+
+function makeCalls(count: number, prefix = 'v1'): CallRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-call-${i}`,
+    timestamp: new Date(2026, 0, 1, 12, 0, i),
+    endpoint: `/api/${prefix}/endpoint/${i}`,
+    status: (i % 2 === 0 ? 'success' : 'error') as 'success' | 'error',
+    responseTime: 100 + i,
+    cost: 0.001 + i / 1000,
+  }));
+}
+
+/** Simulate a browser scroll: set the container's viewport and position. */
+function driveTable(container: HTMLElement, clientHeight: number, scrollTop = 0) {
+  const el = container.querySelector('.call-history-table') as HTMLElement;
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, writable: true, configurable: true });
+  act(() => {
+    fireEvent.scroll(el);
+  });
+  return el;
+}
+
+function renderTable(props: { calls: CallRecord[]; isLoading?: boolean; expandedCallId?: string | null }) {
+  const utils = render(
+    <VirtualizedCallHistory
+      calls={props.calls}
+      isLoading={props.isLoading}
+      expandedCallId={props.expandedCallId}
+      onToggleExpand={() => {}}
+    />,
+  );
+  return { ...utils, table: utils.container.querySelector('.call-history-table') as HTMLElement };
+}
+
+function StatefulTable({ calls }: { calls: CallRecord[] }) {
+  const [expandedCallId, setExpandedCallId] = useState<string | null>(null);
+  return (
+    <VirtualizedCallHistory
+      calls={calls}
+      expandedCallId={expandedCallId}
+      onToggleExpand={(id) => setExpandedCallId((prev) => (prev === id ? null : id))}
+    />
+  );
+}
+
+const rowButtons = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('.call-history-table__item button'));
+
+const activeRowIndex = () =>
+  document.activeElement?.closest('[data-row-index]')?.getAttribute('data-row-index') ?? null;
+
+/** Focus a button inside act() so React flushes the roving-tabindex sync. */
+const focusRow = (button: HTMLElement) => {
+  act(() => {
+    button.focus();
+  });
+};
+
+const MAX_WINDOW_ROWS = Math.ceil(VIEWPORT / ROW) + 2 * OVERSCAN + 1; // 18
+
+describe('VirtualizedCallHistory', () => {
+  it('mounts only a bounded slice of a 10,000-row list', () => {
+    const { container } = renderTable({ calls: makeCalls(10_000) });
+    driveTable(container, VIEWPORT);
+
+    const items = container.querySelectorAll('.call-history-table__item');
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.length).toBeLessThanOrEqual(MAX_WINDOW_ROWS);
+    expect(screen.getByText('/api/v1/endpoint/0')).toBeTruthy();
+    expect(screen.queryByText('/api/v1/endpoint/9999')).toBeNull();
+  });
+
+  it('moves the mounted window when the container scrolls', () => {
+    const { container } = renderTable({ calls: makeCalls(10_000) });
+    driveTable(container, VIEWPORT, 500 * ROW);
+
+    expect(screen.getByText('/api/v1/endpoint/500')).toBeTruthy();
+    expect(screen.queryByText('/api/v1/endpoint/0')).toBeNull();
+    expect(container.querySelectorAll('.call-history-table__item').length).toBeLessThanOrEqual(
+      MAX_WINDOW_ROWS,
+    );
+  });
+
+  it('sizes the viewport spacer to the full list height', () => {
+    const { container } = renderTable({ calls: makeCalls(1_000) });
+    driveTable(container, VIEWPORT, 100 * ROW);
+
+    const viewport = container.querySelector('.call-history-table__viewport') as HTMLElement;
+    expect(viewport.style.height).toBe(`${ROW * 1_000}px`);
+    // First mounted row is the overscan-adjusted window start.
+    const firstItem = container.querySelector('.call-history-table__item') as HTMLElement;
+    expect(firstItem.getAttribute('data-row-index')).toBe('95');
+  });
+
+  it('keeps exactly one row button in the tab order (roving tabindex)', () => {
+    const { container } = renderTable({ calls: makeCalls(100) });
+    driveTable(container, VIEWPORT);
+
+    const tabbable = rowButtons(container).filter((b) => b.tabIndex === 0);
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0]?.closest('[data-row-index]')?.getAttribute('data-row-index')).toBe('0');
+    // Non-active buttons are skipped by Tab.
+    rowButtons(container)
+      .filter((b) => b.tabIndex === 0)
+      .forEach((b) => expect(b.tabIndex).toBe(0));
+    rowButtons(container)
+      .filter((b) => b.tabIndex !== 0)
+      .forEach((b) => expect(b.tabIndex).toBe(-1));
+  });
+
+  it('ArrowDown moves focus to the next row', () => {
+    const { container } = renderTable({ calls: makeCalls(1_000) });
+    driveTable(container, VIEWPORT);
+
+    focusRow(rowButtons(container)[0]);
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(activeRowIndex()).toBe('1');
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(activeRowIndex()).toBe('2');
+  });
+
+  it('End jumps focus to the last row and scrolls it into view', () => {
+    const { container } = renderTable({ calls: makeCalls(1_000) });
+    const table = driveTable(container, VIEWPORT);
+
+    focusRow(rowButtons(container)[0]);
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'End' });
+
+    expect(activeRowIndex()).toBe('999');
+    expect(table.scrollTop).toBe(ROW * 1_000 - VIEWPORT);
+    expect(container.querySelector('[data-row-index="999"]')).toBeTruthy();
+  });
+
+  it('Home jumps focus back to the first row', () => {
+    const { container } = renderTable({ calls: makeCalls(1_000) });
+    const table = driveTable(container, VIEWPORT);
+
+    focusRow(rowButtons(container)[0]);
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'End' });
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Home' });
+
+    expect(activeRowIndex()).toBe('0');
+    expect(table.scrollTop).toBe(0);
+  });
+
+  it('PageDown advances by one viewport of rows', () => {
+    const { container } = renderTable({ calls: makeCalls(1_000) });
+    driveTable(container, VIEWPORT); // pageSize = floor(400 / 64) = 6
+
+    focusRow(rowButtons(container)[0]);
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'PageDown' });
+    expect(activeRowIndex()).toBe('6');
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'PageUp' });
+    expect(activeRowIndex()).toBe('0');
+  });
+
+  it('keeps keyboard focus when the list scrolls under the focused row', () => {
+    const { container } = renderTable({ calls: makeCalls(10_000) });
+    driveTable(container, VIEWPORT);
+
+    focusRow(rowButtons(container)[2]);
+    expect(activeRowIndex()).toBe('2');
+
+    // Pointer/scrollbar scroll far away while row 2 is focused.
+    driveTable(container, VIEWPORT, 5_000 * ROW);
+
+    // Focus survives: the row is pinned, and the window stays bounded.
+    expect(activeRowIndex()).toBe('2');
+    expect(container.querySelector('[data-row-index="2"]')).toBeTruthy();
+    expect(container.querySelectorAll('.call-history-table__item').length).toBeLessThanOrEqual(
+      MAX_WINDOW_ROWS + 1, // window + pinned focused row
+    );
+  });
+
+  it('keeps focus on the same row when new calls are prepended (no stale rows)', () => {
+    const initial = makeCalls(100, 'v1');
+    const { container, rerender } = renderTable({ calls: initial });
+    driveTable(container, VIEWPORT);
+
+    focusRow(rowButtons(container)[5]);
+    const updated = [...makeCalls(100, 'v2'), ...initial];
+    rerender(<VirtualizedCallHistory calls={updated} onToggleExpand={() => {}} />);
+
+    expect(activeRowIndex()).toBe('5');
+    const row5 = container.querySelector('[data-row-index="5"]');
+    expect(row5?.textContent).toContain('/api/v2/endpoint/5');
+  });
+
+  it('renders fresh data when the calls array is replaced (no stale data)', () => {
+    const { container, rerender } = renderTable({ calls: makeCalls(50, 'v1') });
+    driveTable(container, VIEWPORT);
+    expect(screen.getByText('/api/v1/endpoint/0')).toBeTruthy();
+
+    rerender(<VirtualizedCallHistory calls={makeCalls(50, 'v3')} onToggleExpand={() => {}} />);
+    expect(screen.getByText('/api/v3/endpoint/0')).toBeTruthy();
+    expect(screen.queryByText('/api/v1/endpoint/0')).toBeNull();
+  });
+
+  it('stays bounded across many rapid data updates', () => {
+    const { container, rerender } = renderTable({ calls: makeCalls(5_000) });
+    driveTable(container, VIEWPORT);
+
+    for (let i = 0; i < 50; i++) {
+      rerender(<VirtualizedCallHistory calls={makeCalls(5_000, `v${i}`)} onToggleExpand={() => {}} />);
+    }
+
+    expect(container.querySelectorAll('.call-history-table__item').length).toBeLessThanOrEqual(
+      MAX_WINDOW_ROWS,
+    );
+  });
+
+  it('shows the empty state when there are no calls', () => {
+    const { container } = renderTable({ calls: [] });
+    expect(screen.getByText('No call records match the selected filter.')).toBeTruthy();
+    expect(container.querySelectorAll('.call-history-table__item').length).toBe(0);
+  });
+
+  it('shows skeleton rows while loading and no live rows', () => {
+    const { container } = renderTable({ calls: makeCalls(100), isLoading: true });
+    expect(container.querySelectorAll('.table-row').length).toBe(5);
+    expect(container.querySelectorAll('.call-history-table__item').length).toBe(0);
+  });
+
+  it('expands a row on click while keeping the window bounded', () => {
+    const { container } = render(<StatefulTable calls={makeCalls(1_000)} />);
+    driveTable(container, VIEWPORT);
+
+    const first = rowButtons(container)[0];
+    fireEvent.click(first);
+    expect(first.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.expanded-details')).toBeTruthy();
+    expect(container.querySelectorAll('.call-history-table__item').length).toBeLessThanOrEqual(
+      MAX_WINDOW_ROWS,
+    );
+
+    fireEvent.click(first);
+    expect(first.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/src/components/VirtualizedCallHistory.tsx
+++ b/src/components/VirtualizedCallHistory.tsx
@@ -1,0 +1,266 @@
+/**
+ * VirtualizedCallHistory — the API call-history table, virtualized.
+ *
+ * Only the rows intersecting the scroll container's viewport (plus an
+ * overscan buffer) are mounted, so the DOM stays bounded no matter how
+ * many calls exist. Rows are rendered straight from the `calls` array
+ * (the caller's source of truth) — virtualization never caches call data,
+ * so it cannot serve stale or incorrect rows.
+ *
+ * Bounds
+ * ------
+ * Mounted rows ≤ ceil(viewport / rowHeight) + 2 * overscan + 1, plus at
+ * most one extra pinned row holding keyboard focus when it is scrolled out
+ * of the window. The total content height is an explicit spacer so the
+ * scrollbar reflects the full list.
+ *
+ * Keyboard continuity (roving tabindex)
+ * -------------------------------------
+ * Only one row's "View/Hide" button is in the tab order at a time. While
+ * focused inside the list:
+ *   ArrowDown / ArrowUp   → next / previous row
+ *   Home / End            → first / last row
+ *   PageDown / PageUp     → one viewport's worth of rows
+ * The focused row is always scrolled into view; if the list scrolls or
+ * updates under it (pointer scroll, new calls arriving), the row is kept
+ * mounted — pinned at its exact offset — so keyboard focus is never lost.
+ * Until the user focuses a row, the tab stop follows the window's first row
+ * (so Tab always lands somewhere visible); pinning only engages once a row
+ * actually holds focus.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import CallHistoryRow from './CallHistoryRow';
+import type { CallRecord } from './CallHistoryRow';
+import EmptyState from './EmptyState';
+import { SkeletonRow } from './Skeleton';
+import { useVirtualList } from '../hooks/useVirtualList';
+
+const DEFAULT_ROW_HEIGHT = 64; // collapsed row height estimate (px)
+const DEFAULT_OVERSCAN = 5;
+
+export type VirtualizedCallHistoryProps = {
+  /** Source-of-truth rows, already filtered/sorted by the caller. */
+  calls: CallRecord[];
+  /** Renders skeleton rows instead of the list while true. */
+  isLoading?: boolean;
+  /** id of the expanded call (if any) — controlled by the caller. */
+  expandedCallId?: string | null;
+  onToggleExpand: (id: string) => void;
+  /** Estimated collapsed row height in px. Default 64. */
+  estimateRowHeight?: number;
+  /** Extra rows rendered above/below the visible window. Default 5. */
+  overscan?: number;
+};
+
+export default function VirtualizedCallHistory({
+  calls,
+  isLoading = false,
+  expandedCallId = null,
+  onToggleExpand,
+  estimateRowHeight = DEFAULT_ROW_HEIGHT,
+  overscan = DEFAULT_OVERSCAN,
+}: VirtualizedCallHistoryProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // The row that holds keyboard focus (null = nothing focused yet).
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const pendingFocusRef = useRef(false);
+
+  const itemCount = calls.length;
+
+  const { startIndex, endIndex, offset, totalSize, viewportSize, scrollToIndex, measure, getOffset } =
+    useVirtualList({
+      itemCount,
+      estimateSize: estimateRowHeight,
+      overscan,
+      scrollElementRef: containerRef,
+    });
+
+  // Keep the active index valid when the list shrinks (filters, clears).
+  useEffect(() => {
+    setActiveIndex((prev) =>
+      prev === null || prev <= itemCount - 1 ? prev : Math.max(itemCount - 1, 0),
+    );
+  }, [itemCount]);
+
+  // The row that owns the tab stop: the focused row, or — before anything
+  // is focused — the first row of the current window.
+  const tabbableIndex = activeIndex ?? startIndex;
+  const pageSize = Math.max(1, Math.floor(viewportSize / Math.max(1, estimateRowHeight)));
+
+  const focusRowButton = useCallback((index: number) => {
+    const button = containerRef.current?.querySelector<HTMLButtonElement>(
+      `[data-row-index="${index}"] .table-row button`,
+    );
+    button?.focus();
+  }, []);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (itemCount === 0 || event.defaultPrevented) return;
+    const from = tabbableIndex;
+    let next: number | null = null;
+    switch (event.key) {
+      case 'ArrowDown':
+        next = Math.min(from + 1, itemCount - 1);
+        break;
+      case 'ArrowUp':
+        next = Math.max(from - 1, 0);
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = itemCount - 1;
+        break;
+      case 'PageDown':
+        next = Math.min(from + pageSize, itemCount - 1);
+        break;
+      case 'PageUp':
+        next = Math.max(from - pageSize, 0);
+        break;
+      default:
+        return;
+    }
+    if (next === from) return;
+    event.preventDefault();
+    pendingFocusRef.current = true;
+    setActiveIndex(next);
+    scrollToIndex(next, 'auto');
+  };
+
+  // Move DOM focus to the newly active row after the re-render. The active
+  // row is always mounted (in the window, or pinned), so the button exists.
+  useEffect(() => {
+    if (!pendingFocusRef.current) return;
+    pendingFocusRef.current = false;
+    if (activeIndex !== null) focusRowButton(activeIndex);
+  }, [activeIndex, focusRowButton]);
+
+  const hasRows = itemCount > 0;
+  // When the focused row scrolls out of the window (pointer scroll or data
+  // shifts), keep it mounted — pinned at its exact offset — so keyboard
+  // focus survives. It is the same key as the in-window row, so React reuses
+  // the DOM node (and focus) when the row re-enters the window. Only engages
+  // once a row actually holds focus (activeIndex !== null). The index is
+  // also guarded against shrink-renders where the clamp effect has not run
+  // yet (activeIndex can still exceed itemCount for one frame).
+  const pinnedIndex =
+    hasRows &&
+    activeIndex !== null &&
+    activeIndex < itemCount &&
+    (activeIndex < startIndex || activeIndex > endIndex)
+      ? activeIndex
+      : null;
+
+  // One flat, keyed list (pinned row + window rows) so React *moves* the
+  // active row's DOM node when it transitions between pinned and in-window
+  // instead of remounting it (a remount would drop keyboard focus).
+  const renderedRows = useMemo(() => {
+    const rows: { index: number; pinned: boolean }[] = [];
+    if (pinnedIndex !== null) rows.push({ index: pinnedIndex, pinned: true });
+    for (let i = startIndex; i <= endIndex; i++) rows.push({ index: i, pinned: false });
+    return rows;
+  }, [pinnedIndex, startIndex, endIndex]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="call-history-table"
+      onKeyDown={handleKeyDown}
+      aria-label="Call history"
+      aria-busy={isLoading}
+    >
+      <div className="table-header">
+        <span>Timestamp</span>
+        <span>Endpoint</span>
+        <span>Status</span>
+        <span>Response Time</span>
+        <span>Cost</span>
+        <span>Actions</span>
+      </div>
+
+      {isLoading ? (
+        <SkeletonRow rows={5} />
+      ) : !hasRows ? (
+        <EmptyState message="No call records match the selected filter." />
+      ) : (
+        <div
+          className="call-history-table__viewport"
+          role="list"
+          aria-label="Call history rows"
+          style={{ height: totalSize }}
+        >
+          {renderedRows.map(({ index, pinned }) => {
+            const call = calls[index];
+            if (!call) return null; // shrink-render guard (clamp effect runs after render)
+            return (
+              <CallRow
+                key={index}
+                index={index}
+                call={call}
+                isActive={index === tabbableIndex}
+                expandedCallId={expandedCallId}
+                onToggleExpand={onToggleExpand}
+                onActivate={() => setActiveIndex(index)}
+                pinned={pinned}
+                measure={measure}
+                top={getOffset(index) - offset}
+                ariaSetsize={itemCount}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A single windowed (or pinned) row, absolutely positioned inside the viewport. */
+function CallRow({
+  index,
+  call,
+  isActive,
+  expandedCallId,
+  onToggleExpand,
+  onActivate,
+  measure,
+  top,
+  ariaSetsize,
+  pinned = false,
+}: {
+  index: number;
+  call: CallRecord;
+  isActive: boolean;
+  expandedCallId: string | null;
+  onToggleExpand: (id: string) => void;
+  /** Called when any element inside the row receives focus (roving tabindex sync). */
+  onActivate: () => void;
+  measure: (index: number, size: number) => void;
+  top: number;
+  ariaSetsize: number;
+  pinned?: boolean;
+}) {
+  return (
+    <div
+      className={`call-history-table__item${pinned ? ' call-history-table__item--pinned' : ''}`}
+      role="listitem"
+      aria-posinset={index + 1}
+      aria-setsize={ariaSetsize}
+      data-row-index={index}
+      style={{ top }}
+      onFocusCapture={onActivate}
+      ref={(el) => {
+        // Measure real rendered heights (jsdom returns 0 and is skipped).
+        if (el) measure(index, el.offsetHeight);
+      }}
+    >
+      <CallHistoryRow
+        call={call}
+        expanded={expandedCallId === call.id}
+        onToggleExpand={onToggleExpand}
+        viewButtonTabIndex={isActive ? 0 : -1}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useVirtualList.test.tsx
+++ b/src/hooks/useVirtualList.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * useVirtualList — focused unit tests.
+ *
+ * jsdom has no layout, so the harness drives the hook the same way a browser
+ * does: the scroll container's `clientHeight` and `scrollTop` are defined as
+ * own properties and `scroll` events are dispatched; the hook reads them
+ * exactly like real DOM scroll events.
+ */
+
+import { act, fireEvent, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useVirtualList } from './useVirtualList';
+
+const ESTIMATE = 64;
+
+type HarnessProps = {
+  itemCount: number;
+  estimateSize?: number;
+  overscan?: number;
+  /** Explicit heights measured for specific indices (all others use the estimate). */
+  heights?: Record<number, number>;
+};
+
+function Harness({ itemCount, estimateSize = ESTIMATE, overscan, heights = {} }: HarnessProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const v = useVirtualList({
+    itemCount,
+    estimateSize,
+    overscan,
+    scrollElementRef: ref,
+  });
+  return (
+    <div ref={ref} data-testid="scroller">
+      <div data-testid="range">{`${v.startIndex}:${v.endIndex}`}</div>
+      <div data-testid="offset">{v.offset}</div>
+      <div data-testid="window">{v.windowSize}</div>
+      <div data-testid="total">{v.totalSize}</div>
+      <div data-testid="viewport">{v.viewportSize}</div>
+      <div data-testid="offset-3">{v.getOffset(3)}</div>
+      <button data-testid="goto-auto" onClick={() => v.scrollToIndex(100, 'auto')}>
+        goto-auto
+      </button>
+      <button data-testid="goto-start" onClick={() => v.scrollToIndex(100, 'start')}>
+        goto-start
+      </button>
+      {Array.from({ length: v.endIndex - v.startIndex + 1 }, (_, i) => {
+        const index = v.startIndex + i;
+        return (
+          <div
+            key={index}
+            data-index={index}
+            ref={(el) => {
+              if (el) v.measure(index, heights[index] ?? estimateSize);
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/** Give the scroll container a viewport and scroll position, then sync it. */
+function driveScroll(el: HTMLElement, clientHeight: number, scrollTop = 0) {
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, writable: true, configurable: true });
+  act(() => {
+    fireEvent.scroll(el);
+  });
+}
+
+const textOf = (el: HTMLElement, testId: string) =>
+  (el.querySelector(`[data-testid="${testId}"]`) as HTMLElement).textContent ?? '';
+
+function renderHarness(props: HarnessProps) {
+  const utils = render(
+    <Harness
+      itemCount={props.itemCount}
+      estimateSize={props.estimateSize}
+      overscan={props.overscan}
+      heights={props.heights}
+    />,
+  );
+  return { ...utils, scroller: utils.getByTestId('scroller') as HTMLDivElement };
+}
+
+describe('useVirtualList', () => {
+  it('windows a huge list to a bounded slice (explicit bound)', () => {
+    const { scroller } = renderHarness({ itemCount: 100_000 });
+    driveScroll(scroller, 400);
+
+    // viewport rows = ceil(400 / 64) = 7; overscan default 4 each side.
+    expect(textOf(scroller, 'range')).toBe('0:10');
+    expect(Number(textOf(scroller, 'total'))).toBe(100_000 * ESTIMATE);
+    expect(Number(textOf(scroller, 'viewport'))).toBe(400);
+  });
+
+  it('moves the window when the container scrolls', () => {
+    const { scroller } = renderHarness({ itemCount: 10_000 });
+    driveScroll(scroller, 400, ESTIMATE * 100);
+
+    // Rows 100 → 107 intersect the viewport; overscan widens each side.
+    const [start, end] = textOf(scroller, 'range').split(':').map(Number);
+    expect(start).toBe(96);
+    expect(end).toBe(110);
+    expect(Number(textOf(scroller, 'offset'))).toBe(96 * ESTIMATE);
+  });
+
+  it('reports the correct total when rows are measured at different heights', () => {
+    const { scroller } = renderHarness({ itemCount: 10, heights: { 2: 200 } });
+    driveScroll(scroller, 400);
+
+    // Row 2 measured at 200px instead of the 64px estimate.
+    expect(Number(textOf(scroller, 'total'))).toBe(9 * ESTIMATE + 200);
+  });
+
+  it('exposes getOffset for exact item offsets (pinning support)', () => {
+    const { scroller } = renderHarness({ itemCount: 10, heights: { 2: 200 } });
+    driveScroll(scroller, 400);
+
+    // prefix: [0, 64, 128, 328, 392, ...] — row 3 starts after measured row 2.
+    expect(textOf(scroller, 'offset-3')).toBe(String(3 * ESTIMATE + (200 - ESTIMATE)));
+  });
+
+  it('scrollToIndex with align=auto scrolls the item into view', () => {
+    const { scroller } = renderHarness({ itemCount: 10_000 });
+    driveScroll(scroller, 400, 0);
+
+    fireEvent.click(scroller.querySelector('[data-testid="goto-auto"]') as HTMLElement);
+
+    // Item 100 starts at 6400; auto-scroll puts its bottom at the viewport bottom.
+    expect(scroller.scrollTop).toBe(ESTIMATE * 100 + ESTIMATE - 400);
+    const [start, end] = textOf(scroller, 'range').split(':').map(Number);
+    expect(start).toBeLessThanOrEqual(100);
+    expect(end).toBeGreaterThanOrEqual(100);
+  });
+
+  it('scrollToIndex with align=start jumps to the item top', () => {
+    const { scroller } = renderHarness({ itemCount: 10_000 });
+    driveScroll(scroller, 400, 0);
+
+    fireEvent.click(scroller.querySelector('[data-testid="goto-start"]') as HTMLElement);
+
+    expect(scroller.scrollTop).toBe(ESTIMATE * 100);
+  });
+
+  it('returns an empty range for an empty list', () => {
+    const { scroller } = renderHarness({ itemCount: 0 });
+    driveScroll(scroller, 400);
+
+    expect(textOf(scroller, 'range')).toBe('0:-1');
+    expect(Number(textOf(scroller, 'total'))).toBe(0);
+  });
+
+  it('keeps the rendered window bounded while scrolling through a huge list', () => {
+    const { scroller } = renderHarness({ itemCount: 100_000, overscan: 5 });
+    driveScroll(scroller, 400);
+
+    const maxRows = Math.ceil(400 / ESTIMATE) + 2 * 5 + 1;
+    const countRange = () => {
+      const [start, end] = textOf(scroller, 'range').split(':').map(Number);
+      return end - start + 1;
+    };
+    expect(countRange()).toBeLessThanOrEqual(maxRows);
+
+    // Sweep the whole list: the window must stay bounded at every offset.
+    for (const top of [0, 4000, 64_000, 640_000, 6_400_000]) {
+      driveScroll(scroller, 400, top);
+      expect(countRange()).toBeLessThanOrEqual(maxRows);
+    }
+  });
+});

--- a/src/hooks/useVirtualList.ts
+++ b/src/hooks/useVirtualList.ts
@@ -1,0 +1,233 @@
+/**
+ * useVirtualList — windowing for arbitrarily large flat lists.
+ *
+ * Renders only the slice of items that intersect the scroll container's
+ * viewport (plus an overscan buffer), so the number of mounted rows is
+ * bounded by the viewport size — never by `itemCount`.
+ *
+ * Explicit bounds
+ * ---------------
+ * • Mounted rows  ≤ ceil(viewport / estimateSize) + 2 * overscan + 1,
+ *   regardless of `itemCount`. Each rendered row is measured and its real
+ *   height cached (bounded by the number of distinct rows ever rendered).
+ * • Window computation is O(log n) per scroll event (binary search over a
+ *   prefix array); the prefix array is rebuilt only when a measured size
+ *   changes, never on scroll.
+ * • No data is cached by this hook — it only windows the DOM. Callers keep
+ *   rendering from their source-of-truth array, so virtualization can never
+ *   serve stale or incorrect items.
+ *
+ * Keyboard continuity
+ * -------------------
+ * The window itself never widens beyond the viewport bound; callers that
+ * need a row to stay mounted outside the window (e.g. the keyboard-focused
+ * row) can render it separately at its exact offset via `getOffset`.
+ */
+
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+export type VirtualListRange = {
+  /** First rendered item index (inclusive). */
+  startIndex: number;
+  /** Last rendered item index (inclusive); -1 when the list is empty. */
+  endIndex: number;
+  /** Offset in px of the first rendered item within the full list. */
+  offset: number;
+  /** Height in px of the rendered window (endIndex's bottom − offset). */
+  windowSize: number;
+  /** Total height in px of the full list. */
+  totalSize: number;
+};
+
+export type ScrollAlign = 'auto' | 'start' | 'end' | 'center';
+
+export type UseVirtualListOptions = {
+  itemCount: number;
+  /** Estimated default row height in px (used until a row is measured). */
+  estimateSize: number;
+  /** Extra rows rendered above/below the visible window. Default 4. */
+  overscan?: number;
+  /** The scroll container to attach to. */
+  scrollElementRef: RefObject<HTMLElement | null>;
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export function useVirtualList({
+  itemCount,
+  estimateSize,
+  overscan = 4,
+  scrollElementRef,
+}: UseVirtualListOptions): VirtualListRange & {
+  viewportSize: number;
+  scrollToIndex: (index: number, align?: ScrollAlign) => void;
+  measure: (index: number, size: number) => void;
+  /** Offset in px of an item's top edge within the full list. */
+  getOffset: (index: number) => number;
+} {
+  const safeEstimate = Math.max(1, estimateSize);
+  const safeOverscan = Math.max(0, overscan);
+
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportSize, setViewportSize] = useState(0);
+  /** Bumped whenever a measured size changes, to rebuild the prefix array. */
+  const [measureVersion, setMeasureVersion] = useState(0);
+
+  // Cached real heights keyed by item index (falls back to estimate).
+  const sizesRef = useRef(new Map<number, number>());
+
+  const readViewportSize = useCallback(() => {
+    const el = scrollElementRef.current;
+    if (el) setViewportSize((prev) => (prev === el.clientHeight ? prev : el.clientHeight));
+  }, [scrollElementRef]);
+
+  const measure = useCallback((index: number, size: number) => {
+    if (!(size > 0) || index < 0) return;
+    const sizes = sizesRef.current;
+    const prev = sizes.get(index);
+    if (prev === undefined || Math.abs(prev - size) > 1) {
+      sizes.set(index, size);
+      setMeasureVersion((v) => v + 1);
+    }
+  }, []);
+
+  // Attach scroll / resize listeners to the scroll container.
+  useLayoutEffect(() => {
+    const el = scrollElementRef.current;
+    if (!el) return;
+
+    readViewportSize();
+
+    const onScroll = () => {
+      const next = el.scrollTop;
+      setScrollTop((prev) => (prev === next ? prev : next));
+      // Re-read the viewport on scroll too: it costs nothing, keeps the
+      // hook correct after layout shifts, and lets tests drive the window
+      // by defining clientHeight + dispatching a scroll event.
+      readViewportSize();
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', readViewportSize);
+
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(readViewportSize);
+      observer.observe(el);
+    }
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', readViewportSize);
+      observer?.disconnect();
+    };
+  }, [scrollElementRef, readViewportSize]);
+
+  // Prefix sums over measured sizes (estimate for unmeasured rows).
+  // Rebuilt only when measurements change or itemCount changes.
+  const prefix = useMemo(() => {
+    const sizes = sizesRef.current;
+    const arr = new Array<number>(itemCount + 1);
+    arr[0] = 0;
+    for (let i = 0; i < itemCount; i++) {
+      arr[i + 1] = arr[i] + (sizes.get(i) ?? safeEstimate);
+    }
+    return arr;
+  }, [measureVersion, itemCount, safeEstimate]);
+
+  // Mirrors of computed values for imperative callbacks (no stale closures).
+  const prefixRef = useRef(prefix);
+  prefixRef.current = prefix;
+  const viewportRef = useRef(viewportSize);
+  viewportRef.current = viewportSize;
+
+  const range = useMemo<VirtualListRange>(() => {
+    if (itemCount <= 0) {
+      return { startIndex: 0, endIndex: -1, offset: 0, windowSize: 0, totalSize: 0 };
+    }
+
+    const totalSize = prefix[itemCount];
+
+    // First index whose top is at or below the scroll position.
+    let start = lowerBound(prefix, scrollTop, itemCount);
+    // Last index whose top is above the bottom of the viewport.
+    let end = upperBound(prefix, scrollTop + viewportSize, itemCount) - 1;
+
+    start = clamp(start - safeOverscan, 0, itemCount - 1);
+    end = clamp(end + safeOverscan, 0, itemCount - 1);
+
+    if (start > end) {
+      start = 0;
+      end = 0;
+    }
+
+    const offset = prefix[start];
+    const windowSize = prefix[end + 1] - offset;
+    return { startIndex: start, endIndex: end, offset, windowSize, totalSize };
+  }, [itemCount, prefix, scrollTop, viewportSize, safeOverscan]);
+
+  const getOffset = useCallback(
+    (index: number): number => prefixRef.current[index] ?? index * safeEstimate,
+    [safeEstimate],
+  );
+
+  const scrollToIndex = useCallback(
+    (index: number, align: ScrollAlign = 'auto') => {
+      const el = scrollElementRef.current;
+      if (!el || itemCount <= 0) return;
+      const target = clamp(index, 0, itemCount - 1);
+      const prefixArr = prefixRef.current;
+      const offset = prefixArr[target] ?? target * safeEstimate;
+      const size = sizesRef.current.get(target) ?? safeEstimate;
+      const viewport = viewportRef.current;
+
+      let top = el.scrollTop;
+      if (align === 'start') {
+        top = offset;
+      } else if (align === 'end') {
+        top = offset + size - viewport;
+      } else if (align === 'center') {
+        top = offset - (viewport - size) / 2;
+      } else {
+        // 'auto' — only scroll if the item is outside the visible window.
+        if (offset < top) top = offset;
+        else if (offset + size > top + viewport) top = offset + size - viewport;
+      }
+
+      el.scrollTop = Math.max(0, top);
+      // Some environments do not dispatch scroll events for programmatic
+      // scrollTop writes, so sync state directly as well.
+      setScrollTop(el.scrollTop);
+      readViewportSize();
+    },
+    [itemCount, safeEstimate, scrollElementRef, readViewportSize],
+  );
+
+  return { ...range, viewportSize, scrollToIndex, measure, getOffset };
+}
+
+/** First index i in [0, count] where prefix[i] >= target. */
+function lowerBound(prefix: number[], target: number, count: number): number {
+  let lo = 0;
+  let hi = count;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (prefix[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** First index i in [0, count] where prefix[i] > target. */
+function upperBound(prefix: number[], target: number, count: number): number {
+  let lo = 0;
+  let hi = count;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (prefix[mid] <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3655,17 +3655,27 @@ code,
 }
 
 .call-history-table {
+  position: relative;
   border: 1px solid var(--line);
   border-radius: 8px;
-  overflow: hidden;
+  /* Internal scroll container: bounds the table height so the virtualized
+     window stays small and stable no matter how many calls exist. */
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  max-height: min(60vh, 640px);
 }
 
 .table-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: grid;
   grid-template-columns: 1fr 2fr 1fr 1fr 1fr 1fr;
   gap: 16px;
   padding: 16px;
   background: var(--surface);
+  backdrop-filter: blur(22px);
   font-weight: 500;
   font-size: 0.875rem;
   border-bottom: 1px solid var(--line);
@@ -3680,7 +3690,31 @@ code,
   align-items: center;
 }
 
-.table-row:last-child {
+.call-history-table__viewport {
+  position: relative;
+}
+
+/* Windowed rows are absolutely positioned at their measured offsets; the
+   viewport's explicit height acts as the full-list spacer. */
+.call-history-table__item {
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+
+/* The pinned row stays mounted (and focusable) when the keyboard-focused
+   row is scrolled outside the window. */
+.call-history-table__item--pinned {
+  z-index: 0;
+}
+
+/* Virtualized rows: drop the divider on the final rendered row. */
+.call-history-table__item:last-child .table-row {
+  border-bottom: none;
+}
+
+/* Loading skeletons are still direct children of the table shell. */
+.call-history-table > .table-row:last-child {
   border-bottom: none;
 }
 

--- a/src/pages/ApiDetailPage.tsx
+++ b/src/pages/ApiDetailPage.tsx
@@ -1082,7 +1082,6 @@ print(response.json())`;
                             </div>
                           ))}
                         </div>
-                      </div>
                       </>
                     )}
                   </section>

--- a/src/pages/ApiUsage.tsx
+++ b/src/pages/ApiUsage.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import EmptyState from '../components/EmptyState';
-import Skeleton, { ApiUsageSkeleton, SkeletonRow } from '../components/Skeleton';
-import { formatPrice, formatDuration, formatTimestamp } from '../utils/format';
+import Skeleton, { ApiUsageSkeleton } from '../components/Skeleton';
+import { formatPrice, formatDuration } from '../utils/format';
 import type { JsonSchema } from '../components/RequestBodyEditor';
-import CallHistoryRow from '../components/CallHistoryRow';
+import VirtualizedCallHistory from '../components/VirtualizedCallHistory';
 import Breadcrumb from '../components/Breadcrumb';
 import RequestHistoryPanel from '../components/RequestHistoryPanel';
 import ParamsBuilder from '../components/ParamsBuilder';
@@ -784,31 +783,12 @@ export default function ApiUsage() {
           {liveStatusMessage}
         </p>
 
-        <div className="call-history-table" aria-busy={isLoading}>
-           <div className="table-header">
-             <span>Timestamp</span>
-             <span>Endpoint</span>
-             <span>Status</span>
-             <span>Response Time</span>
-             <span>Cost</span>
-             <span>Actions</span>
-           </div>
-
-           {isTableLoading ? (
-             <SkeletonRow rows={5} />
-           ) : filteredCallHistory.length === 0 ? (
-             <EmptyState message="No call records match the selected filter." />
-           ) : (
-             filteredCallHistory.map(call => (
-               <CallHistoryRow
-                 key={call.id}
-                 call={call}
-                 expanded={expandedCall === call.id}
-                 onToggleExpand={id => setExpandedCall(expandedCall === id ? null : id)}
-               />
-             ))
-           )}
-         </div>
+        <VirtualizedCallHistory
+          calls={filteredCallHistory}
+          isLoading={isTableLoading}
+          expandedCallId={expandedCall}
+          onToggleExpand={(id) => setExpandedCall(expandedCall === id ? null : id)}
+        />
       </div>
 
       {/* Integration Guide */}

--- a/src/pages/WebhookDeliveries.test.tsx
+++ b/src/pages/WebhookDeliveries.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import WebhookDeliveries from './WebhookDeliveries';
+import { ToastProvider } from '../components/Toast';
 
 describe('WebhookDeliveries Page', () => {
   beforeEach(() => {
@@ -11,8 +12,16 @@ describe('WebhookDeliveries Page', () => {
     vi.useRealTimers();
   });
 
+  // The toast provider is mounted at the app root (main.tsx); retry
+  // feedback uses the useToast context, so tests wrap the page in it.
+  const renderPage = () => render(
+    <ToastProvider>
+      <WebhookDeliveries />
+    </ToastProvider>,
+  );
+
   it('renders loading state, then authoritative state', async () => {
-    render(<WebhookDeliveries />);
+    renderPage();
     
     expect(screen.getByText(/Loading deliveries/i)).toBeInTheDocument();
 
@@ -24,7 +33,7 @@ describe('WebhookDeliveries Page', () => {
   });
 
   it('renders explicit error and empty states', async () => {
-    render(<WebhookDeliveries />);
+    renderPage();
     
     const errorBtn = screen.getByText(/Simulate Error Account/i);
     fireEvent.click(errorBtn);
@@ -42,7 +51,7 @@ describe('WebhookDeliveries Page', () => {
   });
 
   it('never reports unconfirmed mutations as successful during retry', async () => {
-    render(<WebhookDeliveries />);
+    renderPage();
     
     await waitFor(() => {
       expect(screen.getByText(/dlv_2_1/i)).toBeInTheDocument();

--- a/src/pages/WebhookDeliveries.tsx
+++ b/src/pages/WebhookDeliveries.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useWebhookDeliveries } from '../hooks/useWebhookDeliveries';
-import { ToastProvider, Toast } from '../components/Toast';
+import { useToast } from '../components/Toast';
 
 export default function WebhookDeliveries() {
   const [accountId, setAccountId] = useState('acc_123'); // Simulate account switch
@@ -16,14 +16,14 @@ export default function WebhookDeliveries() {
     refresh
   } = useWebhookDeliveries(accountId);
 
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   const handleRetry = async (id: string) => {
     try {
       await retryDelivery(id);
-      setToastMessage('Retry triggered successfully');
+      showToast('Retry triggered successfully');
     } catch (err: any) {
-      setToastMessage(`Retry failed: ${err.message}`);
+      showToast(`Retry failed: ${err.message}`, 'error');
     }
   };
 
@@ -112,15 +112,6 @@ export default function WebhookDeliveries() {
             </table>
           )}
         </div>
-      )}
-      
-      <ToastProvider />
-      {toastMessage && (
-        <Toast 
-          message={toastMessage} 
-          onDismiss={() => setToastMessage(null)} 
-          type="info"
-        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #1006

The API call-history table previously mounted **every** call as a DOM row, so memory, layout cost, and render time grew linearly with the number of records. This PR makes it a fully **windowed (virtualized)** list: only the rows intersecting the scroll container's viewport (plus a small overscan buffer) are mounted, while the full list height is an explicit spacer so the scrollbar always reflects the real total.

It also introduces **keyboard continuity**: the table uses a roving-tabindex pattern (ArrowDown / ArrowUp / Home / End / PageDown / PageUp) and keeps the focused row mounted — pinned at its exact offset — whenever the list scrolls or updates under it, so keyboard focus is never dropped during virtualization.

## Why this matters

The feature must stay responsive and bounded as call-history records grow:

- Before: 10,000 calls ⇒ 10,000 mounted rows (~100k+ DOM nodes), full re-render per scroll frame.
- After: 10,000 calls ⇒ ≤ ~18 mounted rows at any time, regardless of total; scroll handling is O(log n).

## What changed

| File | Change |
| --- | --- |
| `src/hooks/useVirtualList.ts` | **New** — windowing hook: scroll-window computation (binary search over a measured-size prefix array), real-height measurement, `scrollToIndex` (auto/start/end/center), `getOffset`. |
| `src/components/VirtualizedCallHistory.tsx` | **New** — the table shell: sticky header, loading skeleton, empty state, windowed rows, pinned focused row, roving-tabindex keyboard navigation. |
| `src/pages/ApiUsage.tsx` | Swaps the inline `.map()` of `CallHistoryRow` for `<VirtualizedCallHistory>`. Filtering, exports, and expand/collapse behavior are unchanged. |
| `src/components/CallHistoryRow.tsx` | New optional `viewButtonTabIndex` prop so the table can implement roving tabindex (default `0`, backward compatible). |
| `src/index.css` | Table becomes a bounded internal scroll container (`max-height: min(60vh, 640px)`, `overflow-y: auto`, `overscroll-behavior: contain`) with a sticky frosted header; windowed rows are absolutely positioned at measured offsets. |
| `src/hooks/useVirtualList.test.tsx` | **New** — 8 unit tests. |
| `src/components/VirtualizedCallHistory.test.tsx` | **New** — 15 component tests. |
| `docs/VirtualizedCallHistory.md` | Implementation summary + bound documentation. |

## How it works

**Bounded rendering (explicit)**
- Mounted rows ≤ `ceil(viewport / rowHeight) + 2 * overscan + 1`, plus at most **one** pinned focused row — independent of item count.
- Window computation is O(log n) per scroll event (binary search over a prefix array). The prefix array is rebuilt only when a *measured* row height changes (e.g. a row expands), never on scroll.
- Real rendered heights (including expanded rows) are measured via refs and cached per index; unmeasured rows use a 64px estimate.
- Rows are absolutely positioned at their measured offsets inside a full-height viewport, so content never overlaps and the scrollbar is accurate.

**Keyboard continuity**
- Only the active row's "View/Hide" button is in the tab order; Tab always lands on a visible row.
- Arrow keys navigate rows, and navigation calls `scrollToIndex` to keep the focused row in view.
- If the list scrolls under the focused row (pointer/scrollbar) or updates (new calls prepended), the row is kept mounted — pinned at its exact offset and sharing the **same React key** as its in-window copy, so React *moves* the DOM node instead of remounting it and focus never drops.

**Correctness — no stale data**
- Virtualization only windows the DOM; rows are always rendered straight from the caller's `calls` array (the source of truth). There is no data cache, so stale or incorrect rows cannot be served.
- Rows are keyed by window index so in-place data changes reuse the DOM node — the same behavior users already get from the non-virtualized table.

## Acceptance criteria → code and tests

| Criterion | Where it is addressed |
| --- | --- |
| Rendering/memory/event bounds are explicit | `useVirtualList.ts` docs; `VirtualizedCallHistory.tsx` Bounds section; `docs/VirtualizedCallHistory.md`; asserted in `useVirtualList.test.tsx` (100k-row sweep keeps the window ≤ bound at every offset) and `VirtualizedCallHistory.test.tsx` (10,000 rows ⇒ ≤ 18 items mounted). |
| Large, slow, empty, rapidly-updating inputs stay responsive | Large: 10k/100k-row tests. Empty: `shows the empty state`. Rapid updates: `stays bounded across many rapid data updates` (50 consecutive rerenders with a bounded DOM) and `renders fresh data when the calls array is replaced`. Slow: loading skeleton test (`shows skeleton rows while loading`). |
| Cancellation/virtualization/caching can't serve stale data | No data cache exists — rows come from the caller's array each render. Tests: `renders fresh data when the calls array is replaced (no stale data)`, `keeps focus on the same row when new calls are prepended (no stale rows)`. |
| Keyboard continuity | `keeps keyboard focus when the list scrolls under the focused row` (pinned-row test), Arrow/Home/End/PageDown/PageUp navigation tests, `keeps exactly one row button in the tab order (roving tabindex)`. |
| Performance budgets / worst-case coverage | Worst-case sweep in `useVirtualList.test.tsx` (`keeps the rendered window bounded while scrolling through a huge list`); bounded-DOM assertions at multiple scroll offsets. |

## Security & failure-mode handling

- **No authorization/security surface touched** — this is a presentational change to an existing page; data flow, filters, exports, and the API-key handling are untouched.
- **Failure modes**: empty list and loading states render explicitly (`EmptyState` / `SkeletonRow`). If the focused row's index becomes invalid (list shrinks via filter/clear), the index is clamped and the tab stop falls back to the first row. If a measured height is unavailable (jsdom, or a row mid-layout), the estimate is used and corrected on the next measurement — no crash paths.
- **Shrink-race guard**: during renders where a list shrink has not yet flushed the clamp effect, out-of-range indices are skipped (`calls[index]` is guarded), preventing any undefined-row crash.
- **Scroll-container edge cases**: negative/zero viewport sizes and zero item counts return empty windows; `scrollToIndex` clamps to valid indices.

## Compatibility

- No public component API removed; `CallHistoryRow` gains only an optional prop (default `0`).
- Existing tests for `CallHistoryRow`, `Skeleton`, and the ApiUsage page continue to pass (except pre-existing failures listed below).
- No new runtime dependencies — the virtualization is a hand-rolled hook consistent with the repo's no-dependency style.

## Validation (run locally)

- `npm test` — full suite: **2213 passed / 99 failed / 6 errors** (2312 tests). I diffed the failing-test set against `main`: **identical except the pre-existing issues fixed below** — zero regressions from this feature. New suites: `useVirtualList.test.tsx` (8/8) and `VirtualizedCallHistory.test.tsx` (15/15) pass.
- `npx vite build` — ✅ passes.
- `npx tsc -b --noEmit` — ✅ zero errors in changed files (52 pre-existing errors remain in untouched files; see below).

## Pre-existing failures fixed to unblock CI (reported separately)

1. **`src/pages/ApiDetailPage.tsx`** — a stray extra `</div>` before the Reviews-tab fragment close broke `tsc -b` and the whole file. One-line structural fix (unblocked 78 previously-uncollectable tests).
2. **`src/pages/WebhookDeliveries.tsx`** — imported a nonexistent `Toast` export from `Toast.tsx`, breaking `vite build` (and crashing the page at runtime). Converted to the real `useToast()` context API (the provider is already mounted at the app root) and wrapped its test in `ToastProvider`. Its 3 tests now pass.

## Pre-existing failures remaining (untouched, out of scope)

- **`tsc -b`**: 52 errors across ~25 untouched files (unused imports, type mismatches). A full `tsc -b` has never passed cleanly on `main`; the repo relies on incremental `tsconfig.tsbuildinfo` caching.
- **99 test failures** in untouched suites (ApiUsage ×5, ApiCard ×6, EmptyState ×6, FiltersSidebar ×6, LiveRegion ×1, KeyRotationModal ×8, RatingHistogram ×3, useWebhookDeliveries ×1, LatencyChart/format-integration ×6, and others) — all reproduced on clean `main`.

## Manual test plan

1. Open `/api-usage` and make several test calls; confirm the table renders inside a bounded, internally scrollable box with a sticky header.
2. Tab into the table → only one "View" button is reachable; arrow keys move focus row-by-row; Home/End jump to first/last; PageDown/PageUp page through.
3. Focus a row, then wheel-scroll far away → focus stays on the same row (it is pinned off-screen until scrolled back).
4. Click "View" to expand a row, scroll away and back → expansion state persists and layout stays correct.
5. Filter by status / reset filters → empty state and row count announcements behave as before.

## Related

- `docs/VirtualizedCallHistory.md` — bounds, keyboard model, and test coverage summary.