### PR TITLE
fix: persist marketplace filters in the URL without stale state (Clos…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^14.1.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1326,7 +1327,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",

--- a/src/hooks/useMarketplaceUrlState.test.tsx
+++ b/src/hooks/useMarketplaceUrlState.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, render, screen } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ReactNode } from "react";
+import { useMarketplaceUrlState } from "./useMarketplaceUrlState";
+
+/**
+ * Harness that exposes the live hook return value (via `captured`) and renders
+ * the raw `searchParams` string so tests can assert the URL is the only store.
+ */
+let captured: ReturnType<typeof useMarketplaceUrlState> | null = null;
+
+function Harness(): JSX.Element {
+  const state = useMarketplaceUrlState();
+  const [params] = useSearchParams();
+  captured = state;
+  return <div data-testid="params">{params.toString()}</div>;
+}
+
+function renderHookHarness(initialEntries: string[]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Harness />
+    </MemoryRouter>,
+  );
+}
+
+describe("useMarketplaceUrlState (URL is the single source of truth)", () => {
+  beforeEach(() => {
+    captured = null;
+  });
+  afterEach(() => {
+    captured = null;
+  });
+
+  it("derives every filter purely from the URL", () => {
+    renderHookHarness([
+      "/marketplace?q=weather&categories=AI/ML,Finance&statuses=down,maintenance&tag=geo&minPrice=1&maxPrice=9&popularity=newest&favorites=1&sort=price-asc",
+    ]);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.query).toBe("weather");
+    expect([...captured!.categories].sort()).toEqual(["AI/ML", "Finance"]);
+    expect([...captured!.statuses].sort()).toEqual(["down", "maintenance"]);
+    expect(captured!.tag).toBe("geo");
+    expect(captured!.minPrice).toBe(1);
+    expect(captured!.maxPrice).toBe(9);
+    expect(captured!.popularity).toBe("newest");
+    expect(captured!.favoritesOnly).toBe(true);
+    expect(captured!.sort).toBe("price-asc");
+  });
+
+  it("falls back to authoritative defaults when params are absent", () => {
+    renderHookHarness(["/marketplace"]);
+    expect(captured!.query).toBe("");
+    expect(captured!.categories.size).toBe(0);
+    expect(captured!.statuses.size).toBe(0);
+    expect(captured!.tag).toBeNull();
+    expect(captured!.minPrice).toBeNull();
+    expect(captured!.maxPrice).toBeNull();
+    expect(captured!.popularity).toBe("any");
+    expect(captured!.favoritesOnly).toBe(false);
+    expect(captured!.sort).toBe("popularity");
+  });
+
+  it("setters write ONLY to the URL — there is no second local mirror", () => {
+    const { getByTestId } = renderHookHarness(["/marketplace"]);
+
+    act(() => {
+      captured!.setCategories(new Set(["AI/ML"]));
+    });
+    expect(getByTestId("params").textContent).toContain("categories=AI%2FML");
+    expect([...captured!.categories]).toEqual(["AI/ML"]);
+
+    act(() => {
+      captured!.setStatuses(new Set(["down"]));
+    });
+    expect(getByTestId("params").textContent).toContain("statuses=down");
+
+    act(() => {
+      captured!.setTag("geo");
+    });
+    expect(getByTestId("params").textContent).toContain("tag=geo");
+
+    act(() => {
+      captured!.setMinPrice(2);
+    });
+    act(() => {
+      captured!.setMaxPrice(8);
+    });
+    act(() => {
+      captured!.setPopularity("newest");
+    });
+    act(() => {
+      captured!.setFavoritesOnly(true);
+    });
+    act(() => {
+      captured!.setSort("price-asc");
+    });
+    const params = getByTestId("params").textContent ?? "";
+    expect(params).toContain("minPrice=2");
+    expect(params).toContain("maxPrice=8");
+    expect(params).toContain("popularity=newest");
+    expect(params).toContain("favorites=1");
+    expect(params).toContain("sort=price-asc");
+  });
+
+  it("toggling a value off removes it from the URL entirely", () => {
+    const { getByTestId } = renderHookHarness([
+      "/marketplace?categories=AI/ML&favorites=1",
+    ]);
+
+    act(() => {
+      captured!.setCategories(new Set());
+    });
+    expect(getByTestId("params").textContent).not.toContain("categories");
+
+    act(() => {
+      captured!.setFavoritesOnly(false);
+    });
+    expect(getByTestId("params").textContent).not.toContain("favorites");
+  });
+
+  it("clearAll wipes every filter + cursor param from the URL", () => {
+    const { getByTestId } = renderHookHarness([
+      "/marketplace?q=weather&categories=AI/ML&statuses=down&tag=geo&minPrice=1&maxPrice=9&popularity=newest&favorites=1&sort=price-asc&cursor=abc",
+    ]);
+
+    act(() => {
+      captured!.clearAll();
+    });
+    expect(getByTestId("params").textContent).toBe("");
+  });
+
+  it("commitQuery updates the URL and the local draft synchronously", () => {
+    renderHookHarness(["/marketplace"]);
+
+    act(() => {
+      captured!.commitQuery("hello");
+    });
+    expect(captured!.query).toBe("hello");
+    expect(captured!.queryDraft).toBe("hello");
+    expect(screen.getByTestId("params").textContent).toContain("q=hello");
+  });
+});

--- a/src/hooks/useMarketplaceUrlState.ts
+++ b/src/hooks/useMarketplaceUrlState.ts
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { SortValue } from "../components/SortDropdown";
+
+export const DEFAULT_SORT: SortValue = "popularity";
+
+/** The full, URL-backed marketplace filter state. The URL is the single
+ *  source of truth: every value is derived from `searchParams` on render and
+ *  every setter only writes to the URL. There is no second, local mirror that
+ *  could drift out of sync (the "stale state" defect in #989). */
+export interface MarketplaceUrlState {
+  query: string;
+  queryDraft: string;
+  commitQuery: (value: string) => void;
+  setQueryDraft: (value: string) => void;
+  categories: Set<string>;
+  setCategories: (next: Set<string>) => void;
+  statuses: Set<string>;
+  setStatuses: (next: Set<string>) => void;
+  tag: string | null;
+  setTag: (tag: string | null) => void;
+  minPrice: number | null;
+  setMinPrice: (value: number | null) => void;
+  maxPrice: number | null;
+  setMaxPrice: (value: number | null) => void;
+  popularity: string;
+  setPopularity: (value: string) => void;
+  favoritesOnly: boolean;
+  setFavoritesOnly: (value: boolean) => void;
+  sort: SortValue;
+  setSort: (value: SortValue) => void;
+  clearAll: () => void;
+}
+
+const LIST_PARAMS = [
+  "q",
+  "categories",
+  "statuses",
+  "tag",
+  "minPrice",
+  "maxPrice",
+  "popularity",
+  "favorites",
+  "sort",
+  "cursor",
+] as const;
+
+function parseList(value: string | null): Set<string> {
+  if (!value) return new Set();
+  return new Set(
+    value
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+}
+
+function parseNumber(value: string | null): number | null {
+  if (value === null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function writeList(
+  params: URLSearchParams,
+  key: string,
+  next: Set<string>,
+): void {
+  if (next.size > 0) params.set(key, [...next].join(","));
+  else params.delete(key);
+}
+
+/**
+ * Hook that makes the URL the authoritative store for marketplace filters.
+ *
+ * - Reads are pure: derived from the live `searchParams` on every render, so
+ *   back/forward navigation, refreshes, and deep links always win.
+ * - Writes are pure URL mutations: no local state is cached, so a setter can
+ *   never report a mutation as successful while the URL disagrees.
+ * - `queryDraft` is the only local value and exists purely so the search input
+ *   feels responsive while typing; it is re-synced from the URL whenever the
+ *   URL changes, guaranteeing the field can never go stale after navigation.
+ */
+export function useMarketplaceUrlState(): MarketplaceUrlState {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Raw param strings — primitives whose identity is stable across renders
+  // while the URL is unchanged. We derive the parsed values from these so the
+  // derived objects keep a STABLE identity (see below). This matters because
+  // consumers (e.g. the cursor-reset effect in MarketplacePage) depend on the
+  // parsed values; a fresh object every render would make those effects fire
+  // on every render and clobber newer state (#989 race/stale concerns).
+  const query = searchParams.get("q") ?? "";
+  const categoriesParam = searchParams.get("categories");
+  const statusesParam = searchParams.get("statuses");
+  const tag = searchParams.get("tag") ?? null;
+  const minPriceParam = searchParams.get("minPrice");
+  const maxPriceParam = searchParams.get("maxPrice");
+  const popularity = searchParams.get("popularity") ?? "any";
+  const favoritesOnly = searchParams.get("favorites") === "1";
+  const sort = (searchParams.get("sort") ?? DEFAULT_SORT) as SortValue;
+
+  // Memoized so the returned Set/array identity only changes when the
+  // underlying param actually changes — never on an unrelated re-render.
+  const categories = useMemo(() => parseList(categoriesParam), [categoriesParam]);
+  const statuses = useMemo(() => parseList(statusesParam), [statusesParam]);
+  const minPrice = useMemo(() => parseNumber(minPriceParam), [minPriceParam]);
+  const maxPrice = useMemo(() => parseNumber(maxPriceParam), [maxPriceParam]);
+
+  const update = useCallback(
+    (mutate: (params: URLSearchParams) => void) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          mutate(next);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setCategories = useCallback(
+    (next: Set<string>) =>
+      update((p) => writeList(p, "categories", next)),
+    [update],
+  );
+
+  const setStatuses = useCallback(
+    (next: Set<string>) => update((p) => writeList(p, "statuses", next)),
+    [update],
+  );
+
+  const setTag = useCallback(
+    (next: string | null) =>
+      update((p) => {
+        if (next) p.set("tag", next);
+        else p.delete("tag");
+      }),
+    [update],
+  );
+
+  const setMinPrice = useCallback(
+    (value: number | null) =>
+      update((p) => {
+        if (value !== null) p.set("minPrice", String(value));
+        else p.delete("minPrice");
+      }),
+    [update],
+  );
+
+  const setMaxPrice = useCallback(
+    (value: number | null) =>
+      update((p) => {
+        if (value !== null) p.set("maxPrice", String(value));
+        else p.delete("maxPrice");
+      }),
+    [update],
+  );
+
+  const setPopularity = useCallback(
+    (value: string) =>
+      update((p) => {
+        if (value !== "any") p.set("popularity", value);
+        else p.delete("popularity");
+      }),
+    [update],
+  );
+
+  const setFavoritesOnly = useCallback(
+    (value: boolean) =>
+      update((p) => {
+        if (value) p.set("favorites", "1");
+        else p.delete("favorites");
+      }),
+    [update],
+  );
+
+  const setSort = useCallback(
+    (value: SortValue) =>
+      update((p) => {
+        if (value !== DEFAULT_SORT) p.set("sort", value);
+        else p.delete("sort");
+      }),
+    [update],
+  );
+
+  const setQuery = useCallback(
+    (value: string) =>
+      update((p) => {
+        if (value) p.set("q", value);
+        else p.delete("q");
+      }),
+    [update],
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        LIST_PARAMS.forEach((key) => next.delete(key));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  // Local draft for the search box only. Re-synced from the URL on every URL
+  // change so navigation (back/forward) cannot leave the field stale.
+  const [queryDraft, setQueryDraft] = useState(query);
+  useEffect(() => {
+    setQueryDraft(query);
+  }, [query]);
+
+  const commitQuery = useCallback(
+    (value: string) => {
+      setQueryDraft(value);
+      setQuery(value);
+    },
+    [setQuery],
+  );
+
+  return {
+    query,
+    queryDraft,
+    commitQuery,
+    setQueryDraft,
+    categories,
+    setCategories,
+    statuses,
+    setStatuses,
+    tag,
+    setTag,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    popularity,
+    setPopularity,
+    favoritesOnly,
+    setFavoritesOnly,
+    sort,
+    setSort,
+    clearAll,
+  };
+}

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -3,6 +3,8 @@ import { useSearchParams } from "react-router-dom";
 import ApiCard from "../components/ApiCard";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { useFavorites } from "../hooks/useFavorites";
+import { useMarketplaceUrlState } from "../hooks/useMarketplaceUrlState";
+import { useAccountContext } from "../hooks/useAccountContext";
 import SearchBar from "../components/SearchBar";
 import SortDropdown, { type SortValue } from "../components/SortDropdown";
 
@@ -43,132 +45,40 @@ export default function MarketplacePage(): JSX.Element {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [search, setSearchRaw] = useState(
-    () => searchParams.get("q") ?? "",
-  );
+  // Single source of truth for every marketplace filter: the URL. The hook
+  // derives each value from `searchParams` on render and only ever writes back
+  // to the URL, so back/forward, refreshes, and deep links can never leave the
+  // UI showing a stale, locally-cached filter (#989).
+  const {
+    query,
+    queryDraft,
+    commitQuery,
+    setQueryDraft,
+    categories,
+    setCategories,
+    statuses,
+    setStatuses,
+    tag,
+    setTag,
+    minPrice,
+    setMinPrice,
+    maxPrice,
+    setMaxPrice,
+    popularity,
+    setPopularity,
+    favoritesOnly,
+    setFavoritesOnly,
+    sort,
+    setSort,
+    clearAll,
+  } = useMarketplaceUrlState();
 
-  const setSearch = (v: string) => {
-    setSearchRaw(v);
-    setSearchParams((prev) => {
-      if (v) prev.set("q", v); else prev.delete("q");
-      return prev;
-    }, { replace: true });
-  };
+  const { favorites, toggleFavorite, isFavorite } = useFavorites();
 
   const [density, setDensity] = useState<DensityPreference>(() =>
     readDensityPreference(),
   );
-  const debouncedSearch = useDebounce(search, 300);
-  // ── Filter persistence in URL ──────────────────────────────────────────────
-  const [selectedCategories, setSelectedCategoriesRaw] = useState<Set<string>>(
-    () => {
-      const raw = searchParams.get("categories");
-      return raw ? new Set(raw.split(",").filter(Boolean)) : new Set();
-    },
-  );
-  const setSelectedCategories = (next: Set<string>) => {
-    setSelectedCategoriesRaw(next);
-    setSearchParams(
-      (prev) => {
-        if (next.size > 0) prev.set("categories", [...next].join(","));
-        else prev.delete("categories");
-        return prev;
-      },
-      { replace: true },
-    );
-  };
-
-  const [selectedStatuses, setSelectedStatuses] = useState<Set<string>>(
-    () => {
-      const raw = searchParams.get("statuses");
-      return raw ? new Set(raw.split(",").filter(Boolean)) : new Set();
-    },
-  );
-
-  const [selectedTag, setSelectedTagRaw] = useState<string | null>(() =>
-    searchParams.get("tag"),
-  );
-  const setSelectedTag = (tag: string | null) => {
-    setSelectedTagRaw(tag);
-    setSearchParams(
-      (prev) => {
-        if (tag) prev.set("tag", tag);
-        else prev.delete("tag");
-        return prev;
-      },
-      { replace: true },
-    );
-  };
-
-  const [minPrice, setMinPriceRaw] = useState<number | null>(() => {
-    const v = searchParams.get("minPrice");
-    return v ? Number(v) : null;
-  });
-  const setMinPrice = (v: number | null) => {
-    setMinPriceRaw(v);
-    setSearchParams(
-      (prev) => {
-        if (v !== null) prev.set("minPrice", String(v));
-        else prev.delete("minPrice");
-        return prev;
-      },
-      { replace: true },
-    );
-  };
-
-  const [maxPrice, setMaxPriceRaw] = useState<number | null>(() => {
-    const v = searchParams.get("maxPrice");
-    return v ? Number(v) : null;
-  });
-  const setMaxPrice = (v: number | null) => {
-    setMaxPriceRaw(v);
-    setSearchParams(
-      (prev) => {
-        if (v !== null) prev.set("maxPrice", String(v));
-        else prev.delete("maxPrice");
-        return prev;
-      },
-      { replace: true },
-    );
-  };
-
-  const [popularity, setPopularityRaw] = useState<string>(
-    () => searchParams.get("popularity") ?? "any",
-  );
-  const setPopularity = (v: string) => {
-    setPopularityRaw(v);
-    setSearchParams(
-      (prev) => {
-        if (v !== "any") prev.set("popularity", v);
-        else prev.delete("popularity");
-        return prev;
-      },
-      { replace: true },
-    );
-  };
-  const { favorites, toggleFavorite, isFavorite } = useFavorites();
-
-  const [favoritesOnly, setFavoritesOnlyRaw] = useState(
-    () => searchParams.get("favorites") === "1",
-  );
-  const setFavoritesOnly = (v: boolean) => {
-    setFavoritesOnlyRaw(v);
-    setSearchParams((prev) => {
-      if (v) prev.set("favorites", "1"); else prev.delete("favorites");
-      return prev;
-    }, { replace: true });
-  };
-
-  const sortParam = (searchParams.get("sort") ?? "popularity") as SortValue;
-  const setSortParam = (value: SortValue) => {
-    setSearchParams(
-      (prev) => {
-        prev.set("sort", value);
-        return prev;
-      },
-      { replace: true },
-    );
-  };
+  const debouncedQuery = useDebounce(query, 300);
 
   const [showFiltersMobile, setShowFiltersMobile] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -177,8 +87,13 @@ export default function MarketplacePage(): JSX.Element {
 
   const filtersTriggerRef = useRef<HTMLButtonElement>(null);
   const isInitialMount = useRef(true);
+  // Monotonic sequence that guards the loading transition: only the latest
+  // in-flight load may flip `isLoading` off, so a stale timer from an earlier
+  // navigation can never overwrite the loading state of a newer one (#989).
+  const requestSeqRef = useRef(0);
 
   useEffect(() => {
+    const seq = ++requestSeqRef.current;
     const abortController = new AbortController();
     const prefersReducedMotion =
       typeof window !== "undefined" &&
@@ -187,12 +102,12 @@ export default function MarketplacePage(): JSX.Element {
     trackFetch(
       new Promise<void>((resolve) => {
         if (prefersReducedMotion) {
-          setIsLoading(false);
+          if (seq === requestSeqRef.current) setIsLoading(false);
           resolve();
         } else {
           const timer = setTimeout(() => {
             if (!abortController.signal.aborted) {
-              setIsLoading(false);
+              if (seq === requestSeqRef.current) setIsLoading(false);
               resolve();
             }
           }, LOADING_DELAY_MS);
@@ -212,24 +127,24 @@ export default function MarketplacePage(): JSX.Element {
 
   const hasActiveFilters = () => {
     return (
-      search.trim() !== "" ||
-      selectedCategories.size > 0 ||
-      selectedTag !== null ||
+      query.trim() !== "" ||
+      categories.size > 0 ||
+      tag !== null ||
       minPrice !== null ||
       maxPrice !== null ||
       popularity !== "any" ||
       favoritesOnly ||
-      selectedStatuses.size > 0
+      statuses.size > 0
     );
   };
 
   const activeFilterCount =
-    selectedCategories.size +
+    categories.size +
     (minPrice !== null ? 1 : 0) +
     (maxPrice !== null ? 1 : 0) +
     (popularity !== "any" ? 1 : 0) +
     (favoritesOnly ? 1 : 0) +
-    (selectedStatuses.size > 0 ? 1 : 0);
+    (statuses.size > 0 ? 1 : 0);
 
   const handleRetryFetch = async () => {
     setFetchError(null);
@@ -250,12 +165,26 @@ export default function MarketplacePage(): JSX.Element {
     announceTimerRef.current = setTimeout(() => setAnnouncement(""), 3000);
   }, []);
 
+  // Account-switch reset. Marketplace filters are scoped to the active account
+  // (favorites, category availability, etc.), so when the account changes we
+  // clear every filter + cursor from the URL. This guarantees the new account
+  // starts from authoritative, non-stale state instead of inheriting a previous
+  // account's selections (stale-state guard for #989).
+  const { account } = useAccountContext();
+  const accountIdRef = useRef(account?.id);
+  useEffect(() => {
+    if (accountIdRef.current === account?.id) return;
+    accountIdRef.current = account?.id;
+    clearAll();
+    announce("Switched account. Marketplace filters were reset.");
+  }, [account?.id, clearAll, announce]);
+
   // Filter and sort items
   const filtered = useMemo(() => {
     let items = MOCK_APIS.slice();
 
-    if (debouncedSearch.trim()) {
-      const q = debouncedSearch.toLowerCase();
+    if (debouncedQuery.trim()) {
+      const q = debouncedQuery.toLowerCase();
       items = items.filter((a) => {
         return (
           a.name.toLowerCase().includes(q) ||
@@ -266,24 +195,22 @@ export default function MarketplacePage(): JSX.Element {
       });
     }
 
-    if (selectedCategories.size > 0) {
-      items = items.filter((a) => selectedCategories.has(a.category ?? ""));
+    if (categories.size > 0) {
+      items = items.filter((a) => categories.has(a.category ?? ""));
     }
 
-    if (selectedStatuses.size > 0) {
-      items = items.filter((a) => a.status && selectedStatuses.has(a.status));
+    if (statuses.size > 0) {
+      items = items.filter((a) => a.status && statuses.has(a.status));
     }
 
     if (favoritesOnly) {
       items = items.filter((a) => favorites.includes(a.id));
     }
 
-    if (selectedTag) {
-      const normalizedSelectedTag = selectedTag.toLowerCase();
+    if (tag) {
+      const normalizedTag = tag.toLowerCase();
       items = items.filter((a) =>
-        (a.tags || []).some(
-          (tag) => tag.toLowerCase() === normalizedSelectedTag,
-        ),
+        (a.tags || []).some((t) => t.toLowerCase() === normalizedTag),
       );
     }
 
@@ -306,17 +233,17 @@ export default function MarketplacePage(): JSX.Element {
       );
     }
 
-    if (sortParam === "price-asc")
+    if (sort === "price-asc")
       items = items.sort((a, b) => a.pricePerRequest - b.pricePerRequest);
-    if (sortParam === "latency-asc")
+    if (sort === "latency-asc")
       items = items.sort(
         (a, b) =>
           (a.stats?.avgResponseMs ?? Number.MAX_SAFE_INTEGER) -
           (b.stats?.avgResponseMs ?? Number.MAX_SAFE_INTEGER),
       );
-    if (sortParam === "popularity")
+    if (sort === "popularity")
       items = items.sort((a, b) => (b.usageCount ?? 0) - (a.usageCount ?? 0));
-    if (sortParam === "newest")
+    if (sort === "newest")
       items = items.sort(
         (a, b) =>
           Date.parse(b.createdAt ?? "1970-01-01") -
@@ -325,15 +252,15 @@ export default function MarketplacePage(): JSX.Element {
 
     return items;
   }, [
-    debouncedSearch,
-    selectedCategories,
-    selectedTag,
+    debouncedQuery,
+    categories,
+    tag,
     minPrice,
     maxPrice,
     popularity,
     favoritesOnly,
-    sortParam,
-    selectedStatuses,
+    sort,
+    statuses,
   ]);
 
   // ── Cursor pagination ──────────────────────────────────────────────────
@@ -373,14 +300,14 @@ export default function MarketplacePage(): JSX.Element {
     }
     resetCursor();
   }, [
-    debouncedSearch,
-    selectedCategories,
-    selectedTag,
+    debouncedQuery,
+    categories,
+    tag,
     minPrice,
     maxPrice,
     popularity,
-    sortParam,
-    selectedStatuses,
+    sort,
+    statuses,
     favoritesOnly,
     resetCursor,
   ]);
@@ -407,59 +334,50 @@ export default function MarketplacePage(): JSX.Element {
   const prevTag = useRef<string | null>(null);
   useEffect(() => {
     const prev = prevTag.current;
-    if (selectedTag !== prev) {
-      if (selectedTag) {
-        announce(`Filtering by tag: ${selectedTag}`);
+    if (tag !== prev) {
+      if (tag) {
+        announce(`Filtering by tag: ${tag}`);
       } else {
         announce("Tag filter removed.");
       }
-      prevTag.current = selectedTag;
+      prevTag.current = tag;
     }
-  }, [selectedTag, announce]);
+  }, [tag, announce]);
 
-  const handleTagClick = (tag: string) => {
-    setSelectedTag(
-      selectedTag?.toLowerCase() === tag.toLowerCase() ? null : tag,
-    );
+  const handleTagClick = (clickedTag: string) => {
+    setTag(tag?.toLowerCase() === clickedTag.toLowerCase() ? null : clickedTag);
   };
 
   // Handlers
   const toggleCategory = (c: string) => {
-    const copy = new Set(selectedCategories);
+    const copy = new Set(categories);
     if (copy.has(c)) copy.delete(c);
     else copy.add(c);
-    setSelectedCategories(copy);
+    setCategories(copy);
   };
 
   const toggleStatus = (s: string) => {
-    const copy = new Set(selectedStatuses);
+    const copy = new Set(statuses);
     if (copy.has(s)) copy.delete(s);
     else copy.add(s);
-    setSelectedStatuses(copy);
+    setStatuses(copy);
   };
 
   const clearCategories = () => {
-    setSelectedCategories(new Set());
+    setCategories(new Set());
   };
 
   const clearFilters = () => {
-    setSelectedCategories(new Set());
-    setSelectedTag(null);
-    setMinPrice(null);
-    setMaxPrice(null);
-    setPopularity("any");
-    setFavoritesOnly(false);
-    setSelectedStatuses(new Set());
-    setSortParam("popularity");
-    setSearch("");
+    clearAll();
     announce("All filters cleared. Showing all APIs.");
     setPageSize(12);
   };
 
   const handlePageChange = () => {
+    const seq = ++requestSeqRef.current;
     setIsPageLoading(true);
     requestAnimationFrame(() => {
-      setIsPageLoading(false);
+      if (seq === requestSeqRef.current) setIsPageLoading(false);
     });
   };
 
@@ -500,7 +418,7 @@ export default function MarketplacePage(): JSX.Element {
         <h1>API Marketplace</h1>
         <div className="marketplace-search-row">
           <div className="marketplace-search">
-            <SearchBar value={search} onChange={setSearch} />
+            <SearchBar value={queryDraft} onChange={commitQuery} />
           </div>
           <div
             className="marketplace-density-toggle"
@@ -525,7 +443,7 @@ export default function MarketplacePage(): JSX.Element {
             </button>
           </div>
         </div>
-        <SortDropdown value={sortParam} onChange={setSortParam} />
+        <SortDropdown value={sort} onChange={setSort} />
       </div>
 
       {/* Rail of APIs with the most recent usage */}
@@ -535,7 +453,7 @@ export default function MarketplacePage(): JSX.Element {
       <div className="marketplace-layout">
         <aside className="marketplace-sidebar">
           <FiltersSidebar
-            selectedCategories={selectedCategories}
+            selectedCategories={categories}
             toggleCategory={toggleCategory}
             minPrice={minPrice}
             maxPrice={maxPrice}
@@ -546,7 +464,7 @@ export default function MarketplacePage(): JSX.Element {
             clearFilters={clearFilters}
             favoritesOnly={favoritesOnly}
             toggleFavoritesOnly={() => setFavoritesOnly(!favoritesOnly)}
-            selectedStatuses={selectedStatuses}
+            selectedStatuses={statuses}
             toggleStatus={toggleStatus}
             resultCount={filtered.length}
           />
@@ -580,17 +498,17 @@ export default function MarketplacePage(): JSX.Element {
                   {" "}APIs
                 </>
               )}
-              {selectedTag && (
+              {tag && (
                 <span className="marketplace-active-tag" aria-live="polite">
-                  Filtered by tag: #{selectedTag}
+                  Filtered by tag: #{tag}
                 </span>
               )}
             </div>
 
             <div className="marketplace-actions">
               <select
-                value={sortParam}
-                onChange={(e) => setSortParam(e.target.value as SortValue)}
+                value={sort}
+                onChange={(e) => setSort(e.target.value as SortValue)}
               >
                 <option value="relevance">Relevance</option>
                 <option value="priceAsc">Price: low → high</option>
@@ -621,15 +539,15 @@ export default function MarketplacePage(): JSX.Element {
 
           <CategoryPills
             categories={ALL_CATEGORIES}
-            selectedCategories={selectedCategories}
+            selectedCategories={categories}
             toggleCategory={toggleCategory}
             clearCategories={clearCategories}
           />
 
           <ApiTagFilter
             tags={allTags}
-            selectedTag={selectedTag}
-            onTagChange={setSelectedTag}
+            selectedTag={tag}
+            onTagChange={setTag}
           />
 
           {fetchError ? (
@@ -683,7 +601,7 @@ export default function MarketplacePage(): JSX.Element {
                   density={density}
                   onViewDetails={handleViewDetails}
                   onTagClick={handleTagClick}
-                  activeTag={selectedTag}
+                  activeTag={tag}
                 />
               ))}
             </div>
@@ -714,7 +632,7 @@ export default function MarketplacePage(): JSX.Element {
         open={showFiltersMobile}
         onClose={() => setShowFiltersMobile(false)}
         resultCount={filtered.length}
-        selectedCategories={selectedCategories}
+        selectedCategories={categories}
         toggleCategory={toggleCategory}
         minPrice={minPrice}
         maxPrice={maxPrice}
@@ -725,7 +643,7 @@ export default function MarketplacePage(): JSX.Element {
         clearFilters={clearFilters}
         favoritesOnly={favoritesOnly}
         toggleFavoritesOnly={() => setFavoritesOnly(!favoritesOnly)}
-        selectedStatuses={selectedStatuses}
+        selectedStatuses={statuses}
         toggleStatus={toggleStatus}
         triggerRef={filtersTriggerRef}
       />

--- a/src/pages/MarketplacePage.urlState.test.tsx
+++ b/src/pages/MarketplacePage.urlState.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useNavigate } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import MarketplacePage from "./MarketplacePage";
+import { CollectionsProvider } from "../state/collectionsStore";
+import { AccountProvider } from "../hooks/useAccountContext";
+import { switchAccount } from "../state/accountStore";
+
+function matchMediaStub(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+/** A tiny control that drives real router navigation (the same gesture the
+ *  browser back/forward buttons produce) without the data-router fetch that
+ *  `createMemoryRouter` triggers under jsdom. */
+function NavButtons() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate(-1)}>
+        back
+      </button>
+      <button type="button" onClick={() => navigate(1)}>
+        forward
+      </button>
+    </>
+  );
+}
+
+function renderWithRouter(
+  initialEntries: string[],
+  initialIndex = 0,
+  withAccount = true,
+) {
+  const inner = (
+    <Routes>
+      <Route
+        path="/marketplace"
+        element={
+          <>
+            <MarketplacePage />
+            <NavButtons />
+          </>
+        }
+      />
+    </Routes>
+  );
+  const tree = withAccount ? (
+    <AccountProvider>
+      <CollectionsProvider>{inner}</CollectionsProvider>
+    </AccountProvider>
+  ) : (
+    <CollectionsProvider>{inner}</CollectionsProvider>
+  );
+  return render(
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      {tree}
+    </MemoryRouter>,
+  );
+}
+
+function settleTimers() {
+  act(() => {
+    vi.advanceTimersByTime(2000);
+  });
+}
+
+describe("MarketplacePage – URL authority & no stale state (#989)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    matchMediaStub(false);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("refresh/deep-link restores the exact filters from the URL (authoritative)", () => {
+    renderWithRouter([
+      "/marketplace?statuses=down&q=weather&categories=AI/ML",
+    ]);
+    settleTimers();
+
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(true);
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe(
+      "weather",
+    );
+    expect(
+      (screen.getByLabelText(/AI\/ML/i) as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("browser BACK removes a filter so the UI cannot show stale local state", () => {
+    renderWithRouter(["/marketplace", "/marketplace?statuses=down"], 1);
+    settleTimers();
+
+    // Filter is active on the forward entry.
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(true);
+
+    // Navigate back — the URL loses the param.
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    settleTimers();
+
+    // UI must follow the URL, not a cached local mirror.
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+
+  it("browser FORWARD re-applies the filter from the URL", () => {
+    renderWithRouter(["/marketplace", "/marketplace?statuses=down"], 1);
+    settleTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    settleTimers();
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "forward" }));
+    settleTimers();
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("concurrent rapid filter toggles: the newest state wins (no overwrite)", () => {
+    renderWithRouter(["/marketplace"]);
+    settleTimers();
+
+    const operational = screen.getByLabelText(/operational/i);
+    const degraded = screen.getByLabelText(/degraded/i);
+
+    // Rapidly toggle operational on, then off, then degraded on — all in the
+    // same tick. Only the latest intent (degraded) must survive.
+    fireEvent.click(operational);
+    fireEvent.click(operational);
+    fireEvent.click(degraded);
+    settleTimers();
+
+    expect((operational as HTMLInputElement).checked).toBe(false);
+    expect((degraded as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("search input stays in sync after navigating back to a query-less URL", () => {
+    renderWithRouter(["/marketplace", "/marketplace?q=weather"], 1);
+    settleTimers();
+
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe(
+      "weather",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    settleTimers();
+
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe("");
+  });
+
+  it("account switch resets filters so a previous account's state can't leak", () => {
+    // Reduced motion => initial loading resolves without a real timer.
+    matchMediaStub(true);
+    renderWithRouter(["/marketplace?statuses=down&favorites=1"]);
+    // AccountProvider seeds accounts + becomes ready within the initial render.
+    settleTimers();
+
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(true);
+
+    act(() => {
+      switchAccount("account-2");
+    });
+    settleTimers();
+
+    expect(
+      (screen.getByLabelText(/down/i) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(
+      (
+        screen.getByRole("checkbox", {
+          name: /favorites only/i,
+        }) as HTMLInputElement
+      ).checked,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #989 

Pull Request: Persist marketplace filters in the URL without stale state (Closes #989)

## Summary

This change makes the URL the single source of truth for marketplace
filters so that browser back/forward navigation, refreshes, and deep links
can never leave the UI showing stale, locally-cached filter values (#989).

Previously `MarketplacePage` maintained two competing sources of truth:
local `useState` mirrors (seeded once from the URL at mount) and
`useSearchParams`. The local mirrors never re-synced when the URL changed via
back/forward, refresh, deep link, or account switch, so the UI could
disagree with the URL (the "stale state" defect).

## Acceptance criteria

- Authoritative state, no unconfirmed-success: every filter value is derived
  from `useSearchParams` on each render, and every setter only writes the URL.
  There is no second local mirror that could report a mutation as successful
  while the URL disagrees.
- Explicit states: the loading skeleton, empty / filtered empty state,
  error + retry, and cancellation (AbortController) paths are preserved, and
  an explicit account-switch state now resets filters and announces the reset.
- Race-safe: a monotonic `requestSeqRef` guards the loading transition and the
  page-loading flip so a stale timer / requestAnimationFrame callback cannot
  overwrite newer state. Cursor-pagination reset is preserved, and filter
  values are memoized so unrelated re-renders cannot clobber cursor state.
- Regression coverage: new hook unit tests prove URL authority; new component
  tests cover back/forward sync, refresh restore, concurrent newest-wins
  toggles, and account-switch reset.

## Changes

- src/hooks/useMarketplaceUrlState.ts (new): extracted, unit-testable hook.
  Pure URL derivation + pure URL-mutation setters; the only local value is the
  search input draft, which re-syncs from the URL on navigation. Derived Sets
  (categories, statuses) and numbers (min/max price) are memoized on the raw
  param strings so their identity is stable across unrelated re-renders.
- src/pages/MarketplacePage.tsx: consumes the hook instead of local mirrors;
  adds account-switch reset + requestSeqRef race guard; keeps all existing
  loading / empty / error / retry / cancellation paths intact.
- src/hooks/useMarketplaceUrlState.test.tsx (new): proves the URL is the only
  store (derives from params, setters write only the URL, clearAll wipes all).
- src/pages/MarketplacePage.urlState.test.tsx (new): regression coverage for
  refresh restore, browser back/forward sync, concurrent newest-wins toggles,
  search input re-sync after back, and account-switch filter reset.

## Security / failure handling

- No secrets are involved. Account switch clears only URL filter params
  (never any credential/token) and re-derives from the new account.
- Authorization, correctness, compatibility, and CI safeguards are unchanged.
- Scope is strictly limited to marketplace filter state; no public behavior
  outside this issue was altered.

## Validation

- `vitest` is green for the new suites (12 passing tests).
- Existing `MarketplacePage` tests show no new regressions (identical pass
  count before and after this change).
- `tsc -b` reports no errors in the changed files.

Unrelated pre-existing failures (not introduced by this change, reported
separately):
- The 4 failing `MarketplacePage` empty-state tests already fail on `main`.
- `tsc` errors in `ApiDetailPage.tsx` are pre-existing and unrelated.

Closes #989

…es #989)

Make the URL the single source of truth for marketplace filters so back/ forward navigation, refreshes, and deep links can never leave the UI showing stale, locally-cached values (#989).

Acceptance criteria
- Authoritative state, no unconfirmed-success: every filter is derived from useSearchParams on each render and every setter only writes the URL (no second local mirror that could disagree with the URL).
- Explicit states: keep loading skeleton, empty/filtered empty state, error + retry, and cancellation (AbortController); add an explicit account-switch state that resets filters and announces the reset.
- Race-safe: a monotonic requestSeqRef guards the loading transition and the page-loading flip so a stale timer/rAF cannot overwrite newer state; cursor pagination reset is preserved and filter values are memoized so unrelated re-renders cannot clobber cursor state.
- Regression coverage: new hook unit tests prove URL authority; new component tests cover back/forward sync, refresh restore, concurrent newest-wins toggles, and account-switch reset.

Security/failure handling: no secrets involved; account switch clears only URL filter params and re-derives from the new account. Scope kept to the marketplace filter state.

Validation: vitest green for the new suites; existing MarketplacePage tests show no new regressions. The 4 failing MarketplacePage empty-state tests and the tsc errors in ApiDetailPage.tsx are pre-existing on main and unrelated.