### PR TITLE
feat: mark risk scores stale when evidence expires (#998)

### DIFF
--- a/src/pages/RiskGauge.test.tsx
+++ b/src/pages/RiskGauge.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import RiskGaugePage from "./RiskGauge";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RiskGaugePage, { setRiskAssessmentOverride } from "./RiskGauge";
 import React from "react";
 
 vi.mock("../hooks/useDocumentTitle", () => ({
@@ -10,7 +10,18 @@ vi.mock("../hooks/useDocumentTitle", () => ({
 describe("RiskGaugePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const advanceAndFlush = async (ms: number) => {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+    });
+  };
 
   it("renders the page header", () => {
     render(<RiskGaugePage />);
@@ -32,44 +43,56 @@ describe("RiskGaugePage", () => {
     expect(svg).toBeTruthy();
   });
 
-  it("displays assessment results after clicking Run assessment", () => {
+  it("shows loading state while assessment is in progress", async () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    expect(screen.getByLabelText("Loading risk assessment")).toBeTruthy();
+    expect(screen.getByText("Assessing API risk…")).toBeTruthy();
+  });
+
+  it("displays assessment results after clicking Run assessment", async () => {
     render(<RiskGaugePage />);
     const runBtn = screen.getByText("Run assessment");
     fireEvent.click(runBtn);
+    await advanceAndFlush(1000);
     expect(screen.getByText("Breakdown")).toBeTruthy();
     expect(screen.getByText("Re-assess")).toBeTruthy();
     expect(screen.getByText("Clear results")).toBeTruthy();
   });
 
-  it("shows metric rows after assessment runs", () => {
+  it("shows metric rows after assessment runs", async () => {
     render(<RiskGaugePage />);
     fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
     expect(screen.getByText("Reliability")).toBeTruthy();
     expect(screen.getByText("Security")).toBeTruthy();
     expect(screen.getByText("Compliance")).toBeTruthy();
     expect(screen.getByText("Latency")).toBeTruthy();
   });
 
-  it("returns to empty state after clearing results", () => {
+  it("returns to empty state after clearing results", async () => {
     render(<RiskGaugePage />);
     fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
     expect(screen.queryByText("No risk data yet")).toBeNull();
     fireEvent.click(screen.getByText("Clear results"));
     expect(screen.getByText("No risk data yet")).toBeTruthy();
     expect(screen.getByText("Run assessment")).toBeTruthy();
   });
 
-  it("re-runs assessment when Re-assess is clicked", () => {
+  it("re-runs assessment when Re-assess is clicked", async () => {
     render(<RiskGaugePage />);
     fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
     fireEvent.click(screen.getByText("Re-assess"));
-    // Should still show results after re-assessment
+    await advanceAndFlush(1000);
     expect(screen.getByText("Breakdown")).toBeTruthy();
   });
 
-  it("renders accessible progress bars for metrics", () => {
+  it("renders accessible progress bars for metrics", async () => {
     render(<RiskGaugePage />);
     fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
     const progressbars = document.querySelectorAll('[role="progressbar"]');
     expect(progressbars.length).toBe(4);
     progressbars.forEach((bar) => {
@@ -78,11 +101,78 @@ describe("RiskGaugePage", () => {
     });
   });
 
-  it("renders gauge SVG with correct ARIA label", () => {
+  it("renders gauge SVG with correct ARIA label", async () => {
     render(<RiskGaugePage />);
     fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
     const gauge = document.querySelector('[role="img"]');
     expect(gauge).toBeTruthy();
     expect(gauge?.getAttribute("aria-label")).toContain("Risk score");
+  });
+
+  it("shows stale warning after evidence expires", async () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
+    expect(screen.getByText("Breakdown")).toBeTruthy();
+
+    await advanceAndFlush(5 * 60 * 1000);
+
+    expect(screen.getByText("Evidence expired — results are stale")).toBeTruthy();
+    expect(screen.getByText("Re-assess now")).toBeTruthy();
+  });
+
+  it("reassessing clears stale state and loads fresh results", async () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
+
+    await advanceAndFlush(5 * 60 * 1000);
+
+    expect(screen.getByText("Evidence expired — results are stale")).toBeTruthy();
+    fireEvent.click(screen.getByText("Re-assess now"));
+    await advanceAndFlush(1000);
+
+    expect(screen.queryByText("Evidence expired — results are stale")).toBeNull();
+    expect(screen.getByText("Breakdown")).toBeTruthy();
+  });
+
+  it("shows error state when assessment fails and allows retry", async () => {
+    setRiskAssessmentOverride(() => Promise.reject(new Error("Assessment service unavailable. Please try again.")));
+
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+    await advanceAndFlush(1000);
+
+    expect(screen.getByText("Assessment failed")).toBeTruthy();
+    expect(screen.getByText("Retry")).toBeTruthy();
+
+    setRiskAssessmentOverride(null);
+
+    fireEvent.click(screen.getByText("Retry"));
+    await advanceAndFlush(1000);
+    expect(screen.getByText("Breakdown")).toBeTruthy();
+  });
+
+  it("prevents stale responses from overwriting newer state on rapid clicks", async () => {
+    render(<RiskGaugePage />);
+    const runBtn = screen.getByText("Run assessment");
+
+    fireEvent.click(runBtn);
+    fireEvent.click(runBtn);
+    fireEvent.click(runBtn);
+
+    await advanceAndFlush(1000);
+
+    const breakdowns = screen.queryAllByText("Breakdown");
+    expect(breakdowns.length).toBe(1);
+  });
+
+  it("never reports unconfirmed mutations as successful during loading", async () => {
+    render(<RiskGaugePage />);
+    fireEvent.click(screen.getByText("Run assessment"));
+
+    expect(screen.queryByText("Breakdown")).toBeNull();
+    expect(screen.getByLabelText("Loading risk assessment")).toBeTruthy();
   });
 });

--- a/src/pages/RiskGauge.tsx
+++ b/src/pages/RiskGauge.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState } from "react";
+import { useCallback, useId, useState, useRef, useEffect } from "react";
 import EmptyState from "../components/EmptyState";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 
@@ -12,6 +12,8 @@ export interface RiskAssessment {
   compliance: number;
   latency: number;
   notes: string;
+  evidenceTimestamp: number;
+  staleAfterMs: number;
 }
 
 const RISK_LABELS: Record<RiskLevel, string> = {
@@ -70,7 +72,6 @@ function GaugeArc({
       aria-label={`Risk score: ${score} out of 100, ${RISK_LABELS[level]}`}
       style={{ display: "block" }}
     >
-      {/* Background arc */}
       <path
         d={`M ${start.x} ${start.y} A ${r} ${r} 0 1 1 ${polar(ANGLE_OFFSET + ANGLE_RANGE, r, cx, cy).x} ${polar(ANGLE_OFFSET + ANGLE_RANGE, r, cx, cy).y}`}
         stroke="var(--line)"
@@ -79,7 +80,6 @@ function GaugeArc({
         strokeLinecap="round"
         opacity="0.25"
       />
-      {/* Filled arc */}
       <path
         d={`M ${start.x} ${start.y} A ${r} ${r} 0 ${angle > 0 ? 0 : 0} 1 ${end.x} ${end.y}`}
         stroke={color}
@@ -87,7 +87,6 @@ function GaugeArc({
         fill="none"
         strokeLinecap="round"
       />
-      {/* Score text */}
       <text
         x={cx}
         y={cy - 4}
@@ -190,6 +189,16 @@ function MetricRow({
   );
 }
 
+type AssessmentStatus = "idle" | "loading" | "ready" | "error";
+
+const STALE_AFTER_MS = 5 * 60 * 1000;
+
+let riskAssessmentOverride: (() => Promise<RiskAssessment>) | null = null;
+
+export function setRiskAssessmentOverride(fn: (() => Promise<RiskAssessment>) | null) {
+  riskAssessmentOverride = fn;
+}
+
 export default function RiskGaugePage() {
   useDocumentTitle(
     "Risk Assessment – Callora",
@@ -197,22 +206,104 @@ export default function RiskGaugePage() {
   );
 
   const [assessment, setAssessment] = useState<RiskAssessment | null>(null);
+  const [status, setStatus] = useState<AssessmentStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [isStale, setIsStale] = useState(false);
+
+  const operationRef = useRef(0);
+  const isMountedRef = useRef(true);
+  const staleTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (staleTimerRef.current !== null) {
+        window.clearTimeout(staleTimerRef.current);
+      }
+    };
+  }, []);
+
+  const clearStaleTimer = useCallback(() => {
+    if (staleTimerRef.current !== null) {
+      window.clearTimeout(staleTimerRef.current);
+      staleTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleStaleCheck = useCallback((timestamp: number, staleAfterMs: number) => {
+    clearStaleTimer();
+    const delay = Math.max(0, timestamp + staleAfterMs - Date.now());
+    staleTimerRef.current = window.setTimeout(() => {
+      if (isMountedRef.current) {
+        setIsStale(true);
+      }
+    }, delay);
+  }, [clearStaleTimer]);
 
   const runAssessment = useCallback(() => {
-    setAssessment({
-      score: 34,
-      level: "moderate",
-      reliability: 88,
-      security: 72,
-      compliance: 65,
-      latency: 42,
-      notes: "Overall API health is acceptable. Consider improving compliance documentation and monitoring endpoint latency.",
-    });
-  }, []);
+    const thisOp = ++operationRef.current;
+    clearStaleTimer();
+    setIsStale(false);
+    setErrorMessage("");
+    setStatus("loading");
+
+    const simulateApiCall = (): Promise<RiskAssessment> => {
+      if (riskAssessmentOverride) {
+        return riskAssessmentOverride();
+      }
+      return new Promise((resolve) => {
+        window.setTimeout(() => {
+          resolve({
+            score: 34,
+            level: "moderate",
+            reliability: 88,
+            security: 72,
+            compliance: 65,
+            latency: 42,
+            notes: "Overall API health is acceptable. Consider improving compliance documentation and monitoring endpoint latency.",
+            evidenceTimestamp: Date.now(),
+            staleAfterMs: STALE_AFTER_MS,
+          });
+        }, 800);
+      });
+    };
+
+    simulateApiCall()
+      .then((result) => {
+        if (!isMountedRef.current || thisOp !== operationRef.current) return;
+        setAssessment(result);
+        setStatus("ready");
+        scheduleStaleCheck(result.evidenceTimestamp, result.staleAfterMs);
+      })
+      .catch((err) => {
+        if (!isMountedRef.current || thisOp !== operationRef.current) return;
+        setStatus("error");
+        setErrorMessage(err instanceof Error ? err.message : "Assessment failed. Please retry.");
+      });
+  }, [scheduleStaleCheck, clearStaleTimer]);
 
   const clearAssessment = useCallback(() => {
+    clearStaleTimer();
+    setIsStale(false);
     setAssessment(null);
-  }, []);
+    setStatus("idle");
+    setErrorMessage("");
+  }, [clearStaleTimer]);
+
+  const handleRetry = useCallback(() => {
+    runAssessment();
+  }, [runAssessment]);
+
+  const handleReassess = useCallback(() => {
+    runAssessment();
+  }, [runAssessment]);
+
+  const effectiveStale = status === "ready" && isStale;
+  const showEmpty = status === "idle" || status === "error";
+  const showLoading = status === "loading";
+  const showResults = status === "ready" && !isStale;
+  const showStaleWarning = effectiveStale;
 
   return (
     <div
@@ -245,7 +336,7 @@ export default function RiskGaugePage() {
         </p>
       </header>
 
-      {assessment === null ? (
+      {showEmpty && status === "idle" ? (
         <section
           className="surface"
           aria-labelledby="risk-gauge-empty-heading"
@@ -261,7 +352,98 @@ export default function RiskGaugePage() {
             }}
           />
         </section>
-      ) : (
+      ) : showLoading ? (
+        <section
+          className="surface"
+          aria-labelledby="risk-gauge-loading-heading"
+          style={{
+            borderRadius: "16px",
+            overflow: "hidden",
+            padding: "clamp(20px, 3vw, 32px)",
+          }}
+        >
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label="Loading risk assessment"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "12px",
+              padding: "48px 24px",
+              color: "var(--muted)",
+              fontSize: "0.9375rem",
+            }}
+          >
+            <span
+              className="button-spinner"
+              aria-hidden="true"
+            />
+            Assessing API risk…
+          </div>
+        </section>
+      ) : status === "error" ? (
+        <section
+          className="surface"
+          aria-labelledby="risk-gauge-error-heading"
+          style={{
+            borderRadius: "16px",
+            overflow: "hidden",
+            padding: "clamp(20px, 3vw, 32px)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "16px",
+              padding: "48px 24px",
+              textAlign: "center",
+            }}
+          >
+            <p
+              style={{
+                margin: 0,
+                fontSize: "1.125rem",
+                fontWeight: 600,
+                color: "var(--text)",
+              }}
+            >
+              Assessment failed
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: "0.9375rem",
+                color: "var(--muted)",
+                maxWidth: "480px",
+              }}
+            >
+              {errorMessage}
+            </p>
+            <div style={{ display: "flex", gap: "12px", marginTop: "8px" }}>
+              <button
+                type="button"
+                className="primary-button"
+                onClick={handleRetry}
+                aria-label="Retry risk assessment"
+              >
+                Retry
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={clearAssessment}
+                aria-label="Clear and start over"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </section>
+      ) : showResults && assessment !== null ? (
         <section
           className="surface"
           style={{
@@ -272,7 +454,6 @@ export default function RiskGaugePage() {
           }}
           aria-label="Risk assessment results"
         >
-          {/* Gauge + Summary */}
           <div
             style={{
               display: "flex",
@@ -293,10 +474,20 @@ export default function RiskGaugePage() {
               >
                 {assessment.notes}
               </p>
+              <p
+                style={{
+                  margin: "8px 0 0",
+                  fontSize: "0.75rem",
+                  color: "var(--muted)",
+                  opacity: 0.7,
+                }}
+              >
+                Evidence collected{" "}
+                {new Date(assessment.evidenceTimestamp).toLocaleString()}
+              </p>
             </div>
           </div>
 
-          {/* Metric breakdown */}
           <div
             style={{
               display: "grid",
@@ -321,7 +512,6 @@ export default function RiskGaugePage() {
             <MetricRow label="Latency" value={assessment.latency} />
           </div>
 
-          {/* Actions */}
           <div
             style={{
               display: "flex",
@@ -343,14 +533,115 @@ export default function RiskGaugePage() {
             <button
               type="button"
               className="primary-button"
-              onClick={runAssessment}
+              onClick={handleReassess}
               aria-label="Re-run risk assessment"
             >
               Re-assess
             </button>
           </div>
         </section>
-      )}
+      ) : showStaleWarning && assessment !== null ? (
+        <section
+          className="surface"
+          style={{
+            borderRadius: "16px",
+            padding: "clamp(20px, 3vw, 32px)",
+            display: "grid",
+            gap: "28px",
+          }}
+          aria-label="Stale risk assessment results"
+        >
+          <div
+            role="alert"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+              padding: "20px",
+              borderRadius: "12px",
+              background: "color-mix(in srgb, var(--warning) 12%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)",
+            }}
+          >
+            <p
+              style={{
+                margin: 0,
+                fontSize: "1rem",
+                fontWeight: 600,
+                color: "var(--warning)",
+              }}
+            >
+              Evidence expired — results are stale
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: "0.9375rem",
+                color: "var(--muted)",
+                lineHeight: "1.6",
+              }}
+            >
+              The evidence backing this assessment is older than{" "}
+              {Math.round(assessment.staleAfterMs / 60000)} minutes. Re-run the
+              assessment for current risk data.
+            </p>
+            <div style={{ display: "flex", gap: "12px", marginTop: "8px" }}>
+              <button
+                type="button"
+                className="primary-button"
+                onClick={handleReassess}
+                aria-label="Re-run risk assessment with fresh evidence"
+              >
+                Re-assess now
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={clearAssessment}
+                aria-label="Dismiss stale results"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "24px",
+              alignItems: "center",
+              opacity: 0.7,
+            }}
+            aria-hidden="true"
+          >
+            <GaugeArc score={assessment.score} />
+            <div style={{ flex: 1, minWidth: "200px" }}>
+              <p
+                style={{
+                  margin: "0 0 8px",
+                  fontSize: "0.9375rem",
+                  color: "var(--muted)",
+                  lineHeight: "1.6",
+                }}
+              >
+                {assessment.notes}
+              </p>
+              <p
+                style={{
+                  margin: "8px 0 0",
+                  fontSize: "0.75rem",
+                  color: "var(--muted)",
+                  opacity: 0.7,
+                }}
+              >
+                Evidence collected{" "}
+                {new Date(assessment.evidenceTimestamp).toLocaleString()}
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Implements #998: Mark risk scores stale when their evidence expires.

## Summary
- Added evidenceTimestamp and staleAfterMs to RiskAssessment
- Scheduled stale check after assessment completes
- Shows explicit stale warning UI with Re-assess action
- Added loading, error, retry, and race-condition handling
- 15 focused regression tests covering all states

Closes #998